### PR TITLE
[codex] Guard markdown widget file handling

### DIFF
--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -39,3 +39,7 @@ export function normalizeDirectoryPath(path: string): string {
 	}
 	return normalized;
 }
+
+export function isMarkdownFilePath(path: string): boolean {
+	return /\.(md|markdown)$/i.test(path);
+}

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -57,6 +57,7 @@ import {
 	diffLabelFromPath,
 	fileWidgetInstance,
 	FILE_WIDGET_KIND,
+	activeMarkdownFileIdFromWidgetInstance,
 } from "../widget-runtime/widget-instance-helpers";
 import {
 	installWidgetFromFiles as installWidgetFromFilesInLix,
@@ -888,10 +889,7 @@ function LayoutShellContent() {
 		);
 	}, [centralPanel]);
 	const activeCentralFileId =
-		activeCentralEntry?.kind === FILE_WIDGET_KIND &&
-		typeof activeCentralEntry.state?.fileId === "string"
-			? activeCentralEntry.state.fileId
-			: null;
+		activeMarkdownFileIdFromWidgetInstance(activeCentralEntry);
 
 	useEffect(() => {
 		if (!activeCentralFileId) return;

--- a/src/widget-runtime/widget-instance-helpers.test.ts
+++ b/src/widget-runtime/widget-instance-helpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import type { WidgetInstance } from "./types";
+import {
+	FILE_WIDGET_KIND,
+	activeMarkdownFileIdFromWidgetInstance,
+} from "./widget-instance-helpers";
+
+describe("activeMarkdownFileIdFromWidgetInstance", () => {
+	test("returns the file id for markdown file widgets", () => {
+		const entry: WidgetInstance = {
+			instance: "file-widget:file_md",
+			kind: FILE_WIDGET_KIND,
+			state: {
+				fileId: "file_md",
+				filePath: "/notes/readme.md",
+			},
+		};
+
+		expect(activeMarkdownFileIdFromWidgetInstance(entry)).toBe("file_md");
+	});
+
+	test("does not return an id for non-markdown file widgets", () => {
+		const entry: WidgetInstance = {
+			instance: "file-widget:file_csv",
+			kind: FILE_WIDGET_KIND,
+			state: {
+				fileId: "file_csv",
+				filePath: "/data.csv",
+			},
+		};
+
+		expect(activeMarkdownFileIdFromWidgetInstance(entry)).toBeNull();
+	});
+
+	test("fails closed when the file path is missing", () => {
+		const entry: WidgetInstance = {
+			instance: "file-widget:file_unknown",
+			kind: FILE_WIDGET_KIND,
+			state: {
+				fileId: "file_unknown",
+			},
+		};
+
+		expect(activeMarkdownFileIdFromWidgetInstance(entry)).toBeNull();
+	});
+});

--- a/src/widget-runtime/widget-instance-helpers.ts
+++ b/src/widget-runtime/widget-instance-helpers.ts
@@ -1,4 +1,6 @@
+import { isMarkdownFilePath } from "@/lib/path";
 import type { DiffWidgetConfig, WidgetKind } from "./types";
+import type { WidgetInstance } from "./types";
 
 export const FILES_WIDGET_KIND = "flashtype_files" as WidgetKind;
 export const SEARCH_WIDGET_KIND = "flashtype_search" as WidgetKind;
@@ -65,4 +67,14 @@ export function buildDiffWidgetProps(args: {
 		flashtype: { label },
 		...(args.diffConfig ? { diff: args.diffConfig } : {}),
 	};
+}
+
+export function activeMarkdownFileIdFromWidgetInstance(
+	entry: WidgetInstance | null | undefined,
+): string | null {
+	if (entry?.kind !== FILE_WIDGET_KIND) return null;
+	if (typeof entry.state?.fileId !== "string") return null;
+	if (typeof entry.state.filePath !== "string") return null;
+	if (!isMarkdownFilePath(entry.state.filePath)) return null;
+	return entry.state.fileId;
 }

--- a/src/widgets/files/index.test.tsx
+++ b/src/widgets/files/index.test.tsx
@@ -166,6 +166,53 @@ describe("FilesView", () => {
 		await lix.close();
 	});
 
+	test("opens non-markdown files as file widget tabs", async () => {
+		const lix = await openLix();
+		const openWidget = vi.fn();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_csv",
+				path: "/data.csv",
+				data: new TextEncoder().encode("name,value\nalpha,1"),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView context={createViewContext(lix, { openWidget })} />
+					</Suspense>
+				</LixProvider>,
+			);
+		});
+
+		await waitFor(() => {
+			expect(utils!.getByText("data.csv")).toBeInTheDocument();
+		});
+
+		await act(async () => {
+			fireEvent.click(utils!.getByText("data.csv"));
+		});
+
+		expect(openWidget).toHaveBeenCalledWith({
+			panel: "central",
+			kind: FILE_WIDGET_KIND,
+			instance: fileWidgetInstance("file_csv"),
+			state: {
+				fileId: "file_csv",
+				filePath: "/data.csv",
+				flashtype: { label: "data.csv" },
+			},
+			focus: false,
+		});
+
+		utils!.unmount();
+		await lix.close();
+	});
+
 	test("Cmd+Backspace deletes the selected directory", async () => {
 		const lix = await openLix();
 		await qb(lix)

--- a/src/widgets/files/index.tsx
+++ b/src/widgets/files/index.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Files, FileUp, FilePlus } from "lucide-react";
 import { LixProvider, useLix, useQuery } from "@/lib/lix-react";
-import { normalizeDirectoryPath, normalizeFilePath } from "@/lib/path";
+import {
+	isMarkdownFilePath,
+	normalizeDirectoryPath,
+	normalizeFilePath,
+} from "@/lib/path";
 import { selectFilesystemEntries } from "@/queries";
 import { buildFilesystemTree } from "@/widgets/files/build-filesystem-tree";
 import type { WidgetContext } from "../../widget-runtime/types";
@@ -385,13 +389,13 @@ export function FilesView({ context }: FilesViewProps) {
 			if (files.length === 0) return;
 
 			// Filter for markdown files only
-			const markdownFiles = files.filter(
-				(file) => file.name.endsWith(".md") || file.name.endsWith(".markdown"),
+			const markdownFiles = files.filter((file) =>
+				isMarkdownFilePath(file.name),
 			);
 
 			if (markdownFiles.length === 0) {
 				alert(
-					"Only markdown files (.md) are supported at the moment.\n\nUpvote https://github.com/opral/flashtype/issues/81 for support for CSV, PDF, etc",
+					"Only markdown files (.md) are supported at the moment.\n\nOpen an issue on GitHub for support for CSV, PDF, etc: https://github.com/opral/flashtype/issues",
 				);
 				return;
 			}
@@ -495,14 +499,14 @@ export function FilesView({ context }: FilesViewProps) {
 						Only .md and .markdown files supported
 					</p>
 					<p className="mt-1 text-center text-xs text-muted-foreground">
-						Upvote{" "}
+						Open{" "}
 						<a
-							href="https://github.com/opral/flashtype/issues/81"
+							href="https://github.com/opral/flashtype/issues"
 							target="_blank"
 							rel="noopener noreferrer"
 							className="underline hover:text-foreground pointer-events-auto"
 						>
-							issue #81
+							an issue on GitHub
 						</a>{" "}
 						for support for CSV, PDF, etc
 					</p>

--- a/src/widgets/markdown/index.test.tsx
+++ b/src/widgets/markdown/index.test.tsx
@@ -66,6 +66,170 @@ describe("MarkdownView", () => {
 		});
 	});
 
+	test("renders the TipTap editor for .markdown files", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_markdown",
+				path: "/docs/guide.markdown",
+				data: new TextEncoder().encode("# Guide"),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render> | undefined;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
+						<Suspense fallback={null}>
+							<MarkdownView
+								fileId="file_markdown"
+								filePath="/docs/guide.markdown"
+							/>
+						</Suspense>
+					</KeyValueProvider>
+				</LixProvider>,
+			);
+		});
+
+		expect(await screen.findByTestId("tiptap-editor")).toBeInTheDocument();
+
+		await act(async () => {
+			utils?.unmount();
+		});
+	});
+
+	test("renders the TipTap editor for uppercase markdown extensions", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_uppercase",
+				path: "/docs/README.MD",
+				data: new TextEncoder().encode("# Readme"),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render> | undefined;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
+						<Suspense fallback={null}>
+							<MarkdownView
+								fileId="file_uppercase"
+								filePath="/docs/README.MD"
+							/>
+						</Suspense>
+					</KeyValueProvider>
+				</LixProvider>,
+			);
+		});
+
+		expect(await screen.findByTestId("tiptap-editor")).toBeInTheDocument();
+
+		await act(async () => {
+			utils?.unmount();
+		});
+	});
+
+	test("shows an unsupported file prompt for non-markdown files", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_csv",
+				path: "/data.csv",
+				data: new TextEncoder().encode("name,value\nalpha,1"),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render> | undefined;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
+						<Suspense fallback={null}>
+							<MarkdownView fileId="file_csv" filePath="/data.csv" />
+						</Suspense>
+					</KeyValueProvider>
+				</LixProvider>,
+			);
+		});
+
+		expect(
+			await screen.findByText(/this file type is not supported yet/i),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /open an issue/i }),
+		).toHaveAttribute("href", "https://github.com/opral/flashtype/issues");
+		expect(screen.queryByText(/alpha,1/)).not.toBeInTheDocument();
+		expect(screen.queryByTestId("tiptap-editor")).not.toBeInTheDocument();
+
+		await act(async () => {
+			utils?.unmount();
+		});
+	});
+
+	test("does not sync unsupported files as the active markdown file", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_csv",
+				path: "/data.csv",
+				data: new TextEncoder().encode("name,value\nalpha,1"),
+			})
+			.execute();
+		await qb(lix)
+			.insertInto("lix_key_value_by_branch")
+			.values({
+				key: "flashtype_active_file_id",
+				value: "existing_markdown",
+				lixcol_branch_id: "global",
+				lixcol_global: true,
+				lixcol_untracked: true,
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render> | undefined;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
+						<Suspense fallback={null}>
+							<MarkdownView
+								fileId="file_csv"
+								filePath="/data.csv"
+								isActiveView
+							/>
+						</Suspense>
+					</KeyValueProvider>
+				</LixProvider>,
+			);
+		});
+
+		expect(
+			await screen.findByText(/this file type is not supported yet/i),
+		).toBeInTheDocument();
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		const record = await qb(lix)
+			.selectFrom("lix_key_value_by_branch")
+			.select(["value"])
+			.where("key", "=", "flashtype_active_file_id")
+			.executeTakeFirst();
+		expect(record?.value).toBe("existing_markdown");
+
+		await act(async () => {
+			utils?.unmount();
+		});
+	});
+
 	test("renders the requested file even if a different active file is stored", async () => {
 		const lix = await openLix();
 		await qb(lix)

--- a/src/widgets/markdown/index.tsx
+++ b/src/widgets/markdown/index.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { FileText, Loader2 } from "lucide-react";
 import { LixProvider, useLix, useQueryTakeFirst } from "@/lib/lix-react";
 import { qb } from "@/lib/lix-kysely";
+import { isMarkdownFilePath } from "@/lib/path";
 import { EditorProvider } from "@/widgets/markdown/editor/editor-context";
 import { TipTapEditor } from "@/widgets/markdown/editor/tip-tap-editor";
 import "./style.css";
@@ -71,6 +72,8 @@ function MarkdownViewContent({
 				File not found in the workspace.
 			</div>
 		);
+	} else if (!isMarkdownFilePath(fileRow.path)) {
+		content = <UnsupportedFilePlaceholder filePath={fileRow.path} />;
 	} else {
 		content = (
 			<EditorProvider>
@@ -90,10 +93,42 @@ function MarkdownViewContent({
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col px-2 py-2">
-			{syncActiveFile ? (
+			{syncActiveFile && fileRow && isMarkdownFilePath(fileRow.path) ? (
 				<ActiveFileSync fileId={fileRow?.id} isActiveView={isActiveView} />
 			) : null}
 			{content}
+		</div>
+	);
+}
+
+function UnsupportedFilePlaceholder({
+	filePath,
+}: {
+	readonly filePath: string;
+}): ReactNode {
+	return (
+		<div className="flex h-full items-center justify-center px-6 py-8 text-center">
+			<div className="max-w-sm space-y-2 text-sm text-neutral-600">
+				<p className="font-medium text-neutral-800">
+					This file type is not supported yet.
+				</p>
+				<p>
+					Flashtype only opens markdown files in this editor, so{" "}
+					<span className="font-mono text-xs text-neutral-700">{filePath}</span>{" "}
+					was left blank to avoid damaging its formatting.
+				</p>
+				<p>
+					<a
+						href="https://github.com/opral/flashtype/issues"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="font-medium text-brand-600 underline underline-offset-2 hover:text-brand-700"
+					>
+						Open an issue on GitHub
+					</a>{" "}
+					for support for more file types.
+				</p>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- prevent non-markdown files from mounting the markdown editor
- show an unsupported-file placeholder that asks users to open an issue on GitHub
- fail closed when syncing the active markdown file id if a file widget lacks a markdown path
- add focused coverage for markdown path detection, unsupported files, and file widget opening behavior

## Validation
- pnpm vitest run src/widget-runtime/widget-instance-helpers.test.ts
- pnpm exec prettier --check src/lib/path.ts src/widget-runtime/widget-instance-helpers.ts src/widget-runtime/widget-instance-helpers.test.ts src/widgets/markdown/index.tsx src/shell/layout-shell.tsx src/widgets/files/index.tsx src/widgets/markdown/index.test.tsx src/widgets/files/index.test.tsx

## Notes
- The broader widget test suite and typecheck are blocked in this worktree by missing generated/submodule artifacts and SDK dependencies, including @markdown-wc/wasm and Lix SDK packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive UI and key-value sync changes with fail-closed behavior; low risk aside from users no longer having non-markdown files treated as the active markdown document.
> 
> **Overview**
> Adds shared **`isMarkdownFilePath`** detection and uses it so only markdown paths get the TipTap editor and **`flashtype_active_file_id`** updates.
> 
> **Non-markdown** file tabs still open in the central panel but show an **unsupported-file placeholder** (no editor mount, no raw content shown) so binary/CSV formatting is not corrupted. The shell derives the active markdown file via **`activeMarkdownFileIdFromWidgetInstance`**, which requires a markdown **`filePath`** and ignores other file widgets. Files drag-and-drop and copy now reuse the same path check; GitHub issue links point at the general issues page.
> 
> Tests cover path helpers, placeholder/sync behavior, and opening CSV as a file widget tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1dddad7cc781104d31b38efda44ee394ae3a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->