### PR TITLE
[codex] Fix workspace switch crash

### DIFF
--- a/.changenotes/fix-workspace-switch-crash.md
+++ b/.changenotes/fix-workspace-switch-crash.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed a crash when switching workspaces to an empty folder.
+
+FlashType now closes the previous workspace cleanly before opening the next one, so switching folders no longer leaves stale files or app state behind.

--- a/e2e/workspace-switch.spec.ts
+++ b/e2e/workspace-switch.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import type { ElectronApplication } from "playwright";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+	closeElectronApp,
+	expectInstalledPluginArchives,
+	launchDevElectronApp,
+	registerRendererConsoleLogging,
+} from "./electron-test-utils";
+
+test("switching to an empty workspace closes the previous lix session", async (
+	{ browserName: _browserName },
+	testInfo,
+) => {
+	const firstWorkspaceDir = testInfo.outputPath("first-workspace");
+	const secondWorkspaceDir = testInfo.outputPath("second-workspace");
+
+	let electronApp: ElectronApplication | undefined;
+	try {
+		await mkdir(firstWorkspaceDir, { recursive: true });
+		await mkdir(secondWorkspaceDir, { recursive: true });
+		await writeFile(
+			path.join(firstWorkspaceDir, "old-workspace-marker.md"),
+			"# Old workspace marker\n",
+		);
+
+		electronApp = await launchDevElectronApp(firstWorkspaceDir);
+		const page = await electronApp.firstWindow();
+		registerRendererConsoleLogging(page);
+
+		await expect(page.getByText("old-workspace-marker.md")).toBeVisible();
+		await expectInstalledPluginArchives(firstWorkspaceDir);
+
+		await page.evaluate(async (workspacePath) => {
+			await window.flashtypeDesktop?.workspace.open({ path: workspacePath });
+			await window.flashtypeDesktop?.lix.close();
+		}, secondWorkspaceDir);
+		await page.reload({ waitUntil: "domcontentloaded" });
+
+		await expect(page).toHaveTitle(path.basename(secondWorkspaceDir));
+		await expect(page.getByText("old-workspace-marker.md")).toHaveCount(0);
+		await expect(page.getByText("Start writing")).toBeVisible();
+		await expectInstalledPluginArchives(secondWorkspaceDir);
+	} finally {
+		await closeElectronApp(electronApp);
+	}
+});

--- a/electron/ipc-lix.mjs
+++ b/electron/ipc-lix.mjs
@@ -257,8 +257,7 @@ export function registerLixIpc() {
 	});
 
 	ipcMain.handle("lix:close", async () => {
-		await closeAllHandles();
-		await closeLix();
+		await closeLixSession();
 	});
 
 	ipcMain.handle("workspace:resetLixRepository", async () => {
@@ -277,8 +276,12 @@ async function ensureLixOpenForEvent(_event) {
 }
 
 export async function disposeLixIpc() {
+	await closeLixSession();
+}
+
+export async function closeLixSession(options = {}) {
 	await closeAllHandles();
-	await closeLix();
+	await closeLix(options);
 }
 
 async function closeAllHandles() {

--- a/electron/lix.mjs
+++ b/electron/lix.mjs
@@ -103,9 +103,9 @@ async function fileBytesEqual(filePath, expected) {
 	}
 }
 
-export async function closeLix() {
+export async function closeLix(options = {}) {
 	await enqueue(async () => {
-		await closeCurrentLix();
+		await closeCurrentLix(options);
 	});
 }
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
-import { disposeLixIpc, registerLixIpc } from "./ipc-lix.mjs";
+import { closeLixSession, disposeLixIpc, registerLixIpc } from "./ipc-lix.mjs";
 import { disposeTerminalIpc, registerTerminalIpc } from "./ipc-terminal.mjs";
 import {
 	applyWorkspaceWindowChrome,
@@ -150,7 +150,9 @@ app.whenReady().then(async () => {
 	registerLixIpc();
 	registerTerminalIpc();
 	registerAppIpc();
-	registerWorkspaceIpc((event) => BrowserWindow.fromWebContents(event.sender));
+	registerWorkspaceIpc((event) => BrowserWindow.fromWebContents(event.sender), {
+		beforeChange: () => closeLixSession({ ignoreOpenError: true }),
+	});
 	installApplicationMenu();
 	void registerMarkdownDefaultHandler();
 	void captureAppOpened();

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -12,6 +12,7 @@ const LIX_DATABASE_FILE = path.join(".lix", "db.sqlite");
  */
 let workspace = null;
 let registered = false;
+let workspaceChangeQueue = Promise.resolve();
 
 export function getWorkspace() {
 	return workspace;
@@ -35,31 +36,39 @@ export async function resolveWorkspace(requestedPath) {
 	return { path: dir, name: path.basename(dir) };
 }
 
-export async function setWorkspaceFromPath(requestedPath, window) {
-	workspace = await resolveWorkspace(requestedPath);
-	applyWindowChrome(window);
-	return workspace;
+export async function setWorkspaceFromPath(requestedPath, window, options = {}) {
+	return await enqueueWorkspaceChange(async () => {
+		const nextWorkspace = await resolveWorkspace(requestedPath);
+		if (workspace?.path === nextWorkspace.path) {
+			applyWindowChrome(window);
+			return workspace;
+		}
+		await options.beforeChange?.(nextWorkspace);
+		workspace = nextWorkspace;
+		applyWindowChrome(window);
+		return workspace;
+	});
 }
 
 /**
  * Shows the native directory picker. Returns the new workspace, or null when
  * the user cancels (cancel keeps the current state; it is not an error).
  */
-export async function openWorkspaceDialog(window) {
-	const options = {
+export async function openWorkspaceDialog(window, options = {}) {
+	const dialogOptions = {
 		title: "Open Folder",
 		buttonLabel: "Open",
 		properties: ["openDirectory", "createDirectory"],
 	};
 	const result =
 		window && !window.isDestroyed()
-			? await dialog.showOpenDialog(window, options)
-			: await dialog.showOpenDialog(options);
+			? await dialog.showOpenDialog(window, dialogOptions)
+			: await dialog.showOpenDialog(dialogOptions);
 	const dir = result.filePaths[0];
 	if (result.canceled || dir === undefined) {
 		return null;
 	}
-	return await setWorkspaceFromPath(dir, window);
+	return await setWorkspaceFromPath(dir, window, options);
 }
 
 export async function exportWorkspaceLixFile() {
@@ -93,7 +102,13 @@ function applyWindowChrome(window) {
 	window.setRepresentedFilename(workspace.path);
 }
 
-export function registerWorkspaceIpc(getWindowForEvent) {
+function enqueueWorkspaceChange(operation) {
+	const result = workspaceChangeQueue.catch(() => {}).then(operation);
+	workspaceChangeQueue = result.catch(() => {});
+	return result;
+}
+
+export function registerWorkspaceIpc(getWindowForEvent, options = {}) {
 	if (registered) {
 		return;
 	}
@@ -107,8 +122,8 @@ export function registerWorkspaceIpc(getWindowForEvent) {
 		const window = getWindowForEvent(event);
 		const requestedPath = payload?.path;
 		if (typeof requestedPath === "string" && requestedPath.length > 0) {
-			return await setWorkspaceFromPath(requestedPath, window);
+			return await setWorkspaceFromPath(requestedPath, window, options);
 		}
-		return await openWorkspaceDialog(window);
+		return await openWorkspaceDialog(window, options);
 	});
 }


### PR DESCRIPTION
## Summary

Fixes workspace switching so Flashtype closes the current Lix session before adopting the next workspace.

The crash/stale-state path came from updating the main-process workspace descriptor before tearing down the old Lix handle. That could leave the window showing the new workspace while data was still served from the previous one, especially when switching into an empty folder.

## Changes

- Serialize main-process workspace changes so overlapping `workspace.open` calls cannot race.
- Close the current Lix session before changing workspaces, while allowing workspace switching to recover from a failed old Lix open.
- Add an Electron e2e regression for switching from a populated workspace into an empty folder.
- Add a patch changenote.

## Validation

- `pnpm exec oxlint --tsconfig ./tsconfig.json --format stylish electron/main.mjs electron/ipc-lix.mjs electron/lix.mjs electron/workspace.mjs e2e/workspace-switch.spec.ts`
- `pnpm run typecheck`
- `pnpm exec playwright test e2e/workspace-switch.spec.ts`
- `node scripts/validate-changes.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-process workspace and Lix lifecycle ordering; behavior change on every folder switch, though scoped and covered by a new e2e test.
> 
> **Overview**
> Fixes crashes and stale UI when switching workspaces (especially into an **empty folder**) by tearing down the current Lix session **before** the main process adopts the next workspace path.
> 
> Workspace opens are **serialized** via a queue so overlapping `workspace.open` calls cannot race. `registerWorkspaceIpc` now accepts a **`beforeChange`** hook; startup wires it to **`closeLixSession({ ignoreOpenError: true })`** so a failed old Lix open does not block switching. Lix teardown is centralized in **`closeLixSession`** (IPC handles, transactions/observers, then `closeLix` with optional **`ignoreOpenError`**).
> 
> Adds an Electron e2e regression (populated folder → empty folder) and a patch changenote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e849d1d11ca3d02d5eff2cf9bd7e84819100fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->