### PR TITLE
[codex] Fix terminal login shell environment

### DIFF
--- a/electron/ipc-terminal.mjs
+++ b/electron/ipc-terminal.mjs
@@ -1,5 +1,10 @@
 import { ipcMain } from "electron";
 import pty from "node-pty";
+import {
+	buildTerminalEnv,
+	resolveShell,
+	resolveShellArgs,
+} from "./terminal-shell.mjs";
 
 const terminals = new Map();
 const ownerHooks = new Set();
@@ -14,19 +19,17 @@ export function registerTerminalIpc() {
 	ipcMain.handle("terminal:create", async (event, payload) => {
 		const id = `terminal:${crypto.randomUUID()}`;
 		const shell = resolveShell(payload?.shell);
+		const shellArgs = resolveShellArgs(shell);
 		const cwd = payload?.cwd;
 		const cols = clampInteger(payload?.cols, 80, 20, 500);
 		const rows = clampInteger(payload?.rows, 24, 5, 200);
 
-		const terminal = pty.spawn(shell, [], {
+		const terminal = pty.spawn(shell, shellArgs, {
 			name: "xterm-256color",
 			cwd,
 			cols,
 			rows,
-			env: {
-				...process.env,
-				TERM: "xterm-256color",
-			},
+			env: buildTerminalEnv(),
 		});
 
 		const ownerId = event.sender.id;
@@ -123,16 +126,6 @@ function getOwnedTerminal(ownerId, rawId) {
 		throw new Error(`Unknown terminal id: ${id}`);
 	}
 	return handle.terminal;
-}
-
-function resolveShell(rawShell) {
-	if (typeof rawShell === "string" && rawShell.trim().length > 0) {
-		return rawShell.trim();
-	}
-	if (process.platform === "win32") {
-		return process.env.COMSPEC ?? "powershell.exe";
-	}
-	return process.env.SHELL ?? "/bin/zsh";
 }
 
 function clampInteger(value, fallback, min, max) {

--- a/electron/terminal-shell.mjs
+++ b/electron/terminal-shell.mjs
@@ -1,0 +1,95 @@
+const LOGIN_SHELLS = new Set([
+	"bash",
+	"csh",
+	"dash",
+	"fish",
+	"ksh",
+	"sh",
+	"tcsh",
+	"zsh",
+]);
+
+const PATH_ENTRIES_BY_PLATFORM = {
+	darwin: [
+		"/opt/homebrew/bin",
+		"/opt/homebrew/sbin",
+		"/usr/local/bin",
+		"/usr/local/sbin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	],
+	default: [
+		"/usr/local/bin",
+		"/usr/local/sbin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	],
+};
+
+export function resolveShell(
+	rawShell,
+	env = process.env,
+	platform = process.platform,
+) {
+	if (typeof rawShell === "string" && rawShell.trim().length > 0) {
+		return rawShell.trim();
+	}
+	if (platform === "win32") {
+		return env.COMSPEC ?? "powershell.exe";
+	}
+	return env.SHELL ?? "/bin/zsh";
+}
+
+export function resolveShellArgs(shell, platform = process.platform) {
+	if (platform === "win32") {
+		return [];
+	}
+
+	const shellName = shell.split(/[\\/]/).pop() ?? "";
+	if (!LOGIN_SHELLS.has(shellName)) {
+		return [];
+	}
+
+	return ["-l"];
+}
+
+export function buildTerminalEnv(
+	env = process.env,
+	platform = process.platform,
+) {
+	if (platform === "win32") {
+		return {
+			...env,
+			TERM: "xterm-256color",
+		};
+	}
+
+	return {
+		...env,
+		PATH: mergePathEntries([
+			...(env.PATH ?? "").split(":"),
+			...(PATH_ENTRIES_BY_PLATFORM[platform] ?? PATH_ENTRIES_BY_PLATFORM.default),
+		]),
+		TERM: "xterm-256color",
+	};
+}
+
+function mergePathEntries(entries) {
+	const seen = new Set();
+	const merged = [];
+
+	for (const rawEntry of entries) {
+		const entry = rawEntry.trim();
+		if (!entry || seen.has(entry)) {
+			continue;
+		}
+		seen.add(entry);
+		merged.push(entry);
+	}
+
+	return merged.join(":");
+}

--- a/electron/terminal-shell.test.mjs
+++ b/electron/terminal-shell.test.mjs
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import {
+	buildTerminalEnv,
+	resolveShell,
+	resolveShellArgs,
+} from "./terminal-shell.mjs";
+
+describe("terminal shell launch", () => {
+	test("uses the user's shell on macOS", () => {
+		expect(resolveShell(undefined, { SHELL: "/bin/zsh" }, "darwin")).toBe(
+			"/bin/zsh",
+		);
+	});
+
+	test("starts common Unix shells as login shells", () => {
+		expect(resolveShellArgs("/bin/zsh", "darwin")).toEqual(["-l"]);
+		expect(resolveShellArgs("/opt/homebrew/bin/fish", "darwin")).toEqual([
+			"-l",
+		]);
+		expect(resolveShellArgs("/bin/zsh", "win32")).toEqual([]);
+	});
+
+	test("adds Homebrew paths to a minimal macOS app PATH", () => {
+		const env = buildTerminalEnv(
+			{ PATH: "/usr/bin:/bin:/usr/sbin:/sbin" },
+			"darwin",
+		);
+
+		expect(env.PATH.split(":")).toEqual([
+			"/usr/bin",
+			"/bin",
+			"/usr/sbin",
+			"/sbin",
+			"/opt/homebrew/bin",
+			"/opt/homebrew/sbin",
+			"/usr/local/bin",
+			"/usr/local/sbin",
+		]);
+		expect(env.TERM).toBe("xterm-256color");
+	});
+
+	test("deduplicates fallback PATH entries", () => {
+		const env = buildTerminalEnv(
+			{ PATH: "/usr/local/bin:/custom/bin:/usr/local/bin" },
+			"linux",
+		);
+
+		expect(env.PATH).toBe(
+			"/usr/local/bin:/custom/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fix Flashtype terminal sessions so bundled agent launches like Claude Code and Codex can resolve user-installed CLIs when the macOS app is launched from Finder or another GUI context.

## Root Cause

The embedded terminal spawned the configured shell directly with no login-shell args and inherited Electron's sparse GUI app environment. On macOS, that can leave `PATH` without Homebrew or local CLI install locations, producing errors like `zsh: command not found: claude` even though the command works in Terminal.app.

## Changes

- Launch common Unix shells as login shells from the terminal IPC path.
- Normalize terminal environment construction in a small helper.
- Preserve the existing `PATH` order while appending missing platform fallback paths such as `/opt/homebrew/bin`, `/opt/homebrew/sbin`, and `/usr/local/bin`.
- Add helper coverage for shell resolution, login-shell args, fallback PATH entries, and deduplication.

## Validation

- `node --check electron/terminal-shell.mjs`
- `node --check electron/ipc-terminal.mjs`
- `node --check electron/terminal-shell.test.mjs`
- Direct Node smoke checks for `resolveShell`, `resolveShellArgs`, and `buildTerminalEnv`

Full Vitest was not runnable in this checkout because `@lix-js/sdk@workspace:*` is missing from the empty `submodule/lix` workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every embedded PTY is spawned and which environment variables it receives; wrong PATH or login-shell behavior could break agent/CLI launches but scope is limited to the Electron terminal IPC path.
> 
> **Overview**
> Fixes embedded terminal sessions so user-installed CLIs (e.g. Homebrew tools) work when the macOS app is started from Finder by inheriting a sparse GUI `PATH`.
> 
> Terminal creation now spawns common Unix shells with **login-shell args** (`-l`) instead of a bare shell with empty argv, and builds the PTY environment through a shared **`terminal-shell.mjs`** helper. On non-Windows platforms, **`PATH`** keeps the inherited order and appends missing platform fallbacks (including `/opt/homebrew/bin` on darwin), with deduplication; Windows behavior stays env spread plus `TERM`.
> 
> **`ipc-terminal.mjs`** drops its inline `resolveShell` and wires in `resolveShellArgs` and `buildTerminalEnv`. Vitest coverage was added for shell resolution, login args, PATH augmentation, and dedup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2140b93241fd0b1e03c102fa1eb91f67ba09e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->