### PR TITLE
[codex] Fix Markdown default app registration

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -50,7 +50,7 @@ mac:
       - CFBundleTypeName: Markdown Document
         CFBundleTypeRole: Editor
         CFBundleTypeIconFile: markdown.icns
-        LSHandlerRank: Owner
+        LSHandlerRank: Alternate
         LSItemContentTypes:
           - public.markdown
           - net.daringfireball.markdown

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -13,16 +13,14 @@ import {
 	setWorkspaceFromPath,
 } from "./workspace.mjs";
 import { captureAppOpened } from "./telemetry.mjs";
+import {
+	APP_NAME,
+	registerMarkdownDefaultHandler,
+} from "./markdown-default-handler.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const execFileAsync = promisify(execFile);
-const APP_NAME = "Flashtype";
-const APP_BUNDLE_ID = "com.flashtype.app";
 const AUTO_UPDATE_CHECK_DELAY_MS = 10_000;
-const MARKDOWN_CONTENT_TYPES = [
-	"public.markdown",
-	"net.daringfireball.markdown",
-];
 const DEV_SERVER_URL =
 	process.env.VITE_DEV_SERVER_URL ?? "http://127.0.0.1:4173";
 let mainWindow = null;
@@ -152,7 +150,14 @@ app.whenReady().then(async () => {
 	registerAppIpc();
 	registerWorkspaceIpc((event) => BrowserWindow.fromWebContents(event.sender));
 	installApplicationMenu();
-	void registerMarkdownDefaultHandler();
+	void registerMarkdownDefaultHandler({
+		execFileAsync,
+		executablePath: process.execPath,
+		isPackaged: app.isPackaged,
+		platform: process.platform,
+	}).catch((error) => {
+		console.warn("Failed to register Flashtype as the Markdown editor", error);
+	});
 	void captureAppOpened();
 	const workspaceArgument = getWorkspacePathArgument(process.argv);
 	if (workspaceArgument !== undefined && !getWorkspace()) {
@@ -759,38 +764,4 @@ function installApplicationMenu() {
 			},
 		]),
 	);
-}
-
-async function registerMarkdownDefaultHandler() {
-	if (process.platform !== "darwin" || !app.isPackaged) {
-		return;
-	}
-
-	const script = `
-ObjC.import("CoreServices");
-const bundleId = ${JSON.stringify(APP_BUNDLE_ID)};
-const contentTypes = ${JSON.stringify(MARKDOWN_CONTENT_TYPES)};
-for (const contentType of contentTypes) {
-	const status = $.LSSetDefaultRoleHandlerForContentType(
-		$(contentType),
-		$.kLSRolesEditor,
-		$(bundleId)
-	);
-	if (status !== 0) {
-		throw new Error("LSSetDefaultRoleHandlerForContentType failed for " + contentType + ": " + status);
-	}
-}
-`;
-
-	try {
-		await execFileAsync(
-			"/usr/bin/osascript",
-			["-l", "JavaScript", "-e", script],
-			{
-				timeout: 5000,
-			},
-		);
-	} catch (error) {
-		console.warn("Failed to register Flashtype as the Markdown editor", error);
-	}
 }

--- a/electron/markdown-default-handler.mjs
+++ b/electron/markdown-default-handler.mjs
@@ -1,0 +1,175 @@
+import path from "node:path";
+
+export const APP_BUNDLE_ID = "com.flashtype.app";
+export const APP_NAME = "Flashtype";
+export const MARKDOWN_CONTENT_TYPES = [
+	"public.markdown",
+	"net.daringfireball.markdown",
+];
+
+export const REPLACEABLE_MARKDOWN_HANDLER_BUNDLE_IDS = new Set([
+	APP_BUNDLE_ID,
+	"com.apple.dt.Xcode",
+]);
+
+export const LSREGISTER_PATH =
+	"/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+
+export function getAppBundlePathFromExecutablePath(executablePath) {
+	const marker = ".app/Contents/MacOS/";
+	const markerIndex = executablePath.indexOf(marker);
+	if (markerIndex === -1) {
+		return null;
+	}
+	return executablePath.slice(0, markerIndex + ".app".length);
+}
+
+export function isCanonicalInstalledAppBundle(appBundlePath) {
+	if (!appBundlePath) {
+		return false;
+	}
+	return (
+		path.resolve(appBundlePath) === path.resolve("/Applications/Flashtype.app")
+	);
+}
+
+export function shouldReplaceMarkdownDefaultHandler(handlerBundleId) {
+	return (
+		handlerBundleId == null ||
+		REPLACEABLE_MARKDOWN_HANDLER_BUNDLE_IDS.has(handlerBundleId)
+	);
+}
+
+export function getMarkdownContentTypesToRegister(currentHandlers) {
+	return MARKDOWN_CONTENT_TYPES.filter((contentType) =>
+		shouldReplaceMarkdownDefaultHandler(currentHandlers[contentType] ?? null),
+	);
+}
+
+export function getNonCanonicalFlashtypeBundlePathsFromLsregisterDump(dump) {
+	const blocks = dump.split(/\n-{20,}\n/u);
+	return blocks.flatMap((block) => {
+		const identifierMatch = block.match(/^identifier:\s+(.+)$/mu);
+		if (!identifierMatch || identifierMatch[1] !== APP_BUNDLE_ID) {
+			return [];
+		}
+
+		const pathMatch = block.match(/^path:\s+(.+?)(?:\s+\(0x[0-9a-f]+\))?$/mu);
+		if (!pathMatch) {
+			return [];
+		}
+
+		const appBundlePath = pathMatch[1];
+		return isCanonicalInstalledAppBundle(appBundlePath) ? [] : [appBundlePath];
+	});
+}
+
+function buildMarkdownHandlerQueryScript() {
+	return `
+ObjC.import("CoreServices");
+const contentTypes = ${JSON.stringify(MARKDOWN_CONTENT_TYPES)};
+const handlers = {};
+for (const contentType of contentTypes) {
+	const handler = $.LSCopyDefaultRoleHandlerForContentType(
+		$(contentType),
+		$.kLSRolesEditor
+	);
+	handlers[contentType] = handler ? ObjC.unwrap(ObjC.castRefToObject(handler)) : null;
+}
+console.log(JSON.stringify(handlers));
+`;
+}
+
+function buildMarkdownHandlerRegistrationScript(contentTypes) {
+	return `
+ObjC.import("CoreServices");
+const bundleId = ${JSON.stringify(APP_BUNDLE_ID)};
+const contentTypes = ${JSON.stringify(contentTypes)};
+for (const contentType of contentTypes) {
+	const status = $.LSSetDefaultRoleHandlerForContentType(
+		$(contentType),
+		$.kLSRolesEditor,
+		$(bundleId)
+	);
+	if (status !== 0) {
+		throw new Error("LSSetDefaultRoleHandlerForContentType failed for " + contentType + ": " + status);
+	}
+}
+`;
+}
+
+async function getCurrentMarkdownDefaultHandlers(execFileAsync) {
+	const { stdout } = await execFileAsync(
+		"/usr/bin/osascript",
+		["-l", "JavaScript", "-e", buildMarkdownHandlerQueryScript()],
+		{ timeout: 5000 },
+	);
+	return JSON.parse(stdout);
+}
+
+async function unregisterNonCanonicalFlashtypeBundles(execFileAsync) {
+	const { stdout } = await execFileAsync(LSREGISTER_PATH, ["-dump"], {
+		timeout: 5000,
+		maxBuffer: 20 * 1024 * 1024,
+	});
+	const appBundlePaths =
+		getNonCanonicalFlashtypeBundlePathsFromLsregisterDump(stdout);
+
+	await Promise.all(
+		appBundlePaths.map(async (appBundlePath) => {
+			try {
+				await execFileAsync(LSREGISTER_PATH, ["-u", appBundlePath], {
+					timeout: 5000,
+				});
+			} catch {
+				// Stale LaunchServices entries can point at unmounted DMGs or deleted
+				// builds. Keep going so the canonical app can still be refreshed.
+			}
+		}),
+	);
+
+	return appBundlePaths;
+}
+
+export async function registerMarkdownDefaultHandler({
+	execFileAsync,
+	executablePath,
+	isPackaged,
+	platform,
+}) {
+	if (platform !== "darwin" || !isPackaged) {
+		return { status: "skipped", reason: "unsupported-runtime" };
+	}
+
+	const appBundlePath = getAppBundlePathFromExecutablePath(executablePath);
+	if (!isCanonicalInstalledAppBundle(appBundlePath)) {
+		return { status: "skipped", reason: "non-canonical-app-bundle" };
+	}
+
+	const unregisteredAppBundlePaths =
+		await unregisterNonCanonicalFlashtypeBundles(execFileAsync);
+
+	await execFileAsync(LSREGISTER_PATH, ["-f", appBundlePath], {
+		timeout: 5000,
+	});
+
+	const currentHandlers =
+		await getCurrentMarkdownDefaultHandlers(execFileAsync);
+	const contentTypes = getMarkdownContentTypesToRegister(currentHandlers);
+	if (contentTypes.length === 0) {
+		return { status: "skipped", reason: "user-handler-preserved" };
+	}
+
+	await execFileAsync(
+		"/usr/bin/osascript",
+		[
+			"-l",
+			"JavaScript",
+			"-e",
+			buildMarkdownHandlerRegistrationScript(contentTypes),
+		],
+		{ timeout: 5000 },
+	);
+
+	return { status: "registered", contentTypes, unregisteredAppBundlePaths };
+}

--- a/electron/markdown-default-handler.mjs
+++ b/electron/markdown-default-handler.mjs
@@ -10,6 +10,7 @@ export const MARKDOWN_CONTENT_TYPES = [
 export const REPLACEABLE_MARKDOWN_HANDLER_BUNDLE_IDS = new Set([
 	APP_BUNDLE_ID,
 	"com.apple.dt.Xcode",
+	"com.apple.TextEdit",
 ]);
 
 export const LSREGISTER_PATH =
@@ -54,7 +55,9 @@ export function getNonCanonicalFlashtypeBundlePathsFromLsregisterDump(dump) {
 			return [];
 		}
 
-		const pathMatch = block.match(/^path:\s+(.+?)(?:\s+\(0x[0-9a-f]+\))?$/mu);
+		const pathMatch = block.match(
+			/^path:\s+(.+?)(?:\s+\(0x[0-9a-fA-F]+\))?$/mu,
+		);
 		if (!pathMatch) {
 			return [];
 		}

--- a/electron/markdown-default-handler.test.ts
+++ b/electron/markdown-default-handler.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+	APP_BUNDLE_ID,
+	getAppBundlePathFromExecutablePath,
+	getMarkdownContentTypesToRegister,
+	getNonCanonicalFlashtypeBundlePathsFromLsregisterDump,
+	isCanonicalInstalledAppBundle,
+	LSREGISTER_PATH,
+	registerMarkdownDefaultHandler,
+	shouldReplaceMarkdownDefaultHandler,
+} from "./markdown-default-handler.mjs";
+
+describe("Markdown default handler registration policy", () => {
+	test("derives the .app bundle path from a packaged executable path", () => {
+		expect(
+			getAppBundlePathFromExecutablePath(
+				"/Applications/Flashtype.app/Contents/MacOS/Flashtype",
+			),
+		).toBe("/Applications/Flashtype.app");
+	});
+
+	test("only treats the /Applications app bundle as canonical", () => {
+		expect(isCanonicalInstalledAppBundle("/Applications/Flashtype.app")).toBe(
+			true,
+		);
+		expect(
+			isCanonicalInstalledAppBundle(
+				"/Volumes/Flashtype 0.1.1-arm64/Flashtype.app",
+			),
+		).toBe(false);
+		expect(
+			isCanonicalInstalledAppBundle(
+				"/tmp/flashtype/release/mac-arm64/Flashtype.app",
+			),
+		).toBe(false);
+	});
+
+	test("replaces no handler, Xcode, and Flashtype itself", () => {
+		expect(shouldReplaceMarkdownDefaultHandler(null)).toBe(true);
+		expect(shouldReplaceMarkdownDefaultHandler("com.apple.dt.Xcode")).toBe(
+			true,
+		);
+		expect(shouldReplaceMarkdownDefaultHandler(APP_BUNDLE_ID)).toBe(true);
+	});
+
+	test("preserves third-party Markdown defaults", () => {
+		expect(shouldReplaceMarkdownDefaultHandler("com.microsoft.VSCode")).toBe(
+			false,
+		);
+		expect(shouldReplaceMarkdownDefaultHandler("md.obsidian")).toBe(false);
+	});
+
+	test("chooses only replaceable Markdown content types", () => {
+		expect(
+			getMarkdownContentTypesToRegister({
+				"public.markdown": "com.apple.dt.Xcode",
+				"net.daringfireball.markdown": "com.microsoft.VSCode",
+			}),
+		).toEqual(["public.markdown"]);
+	});
+
+	test("finds registered noncanonical Flashtype app bundles", () => {
+		const dump = `
+--------------------------------------------------------------------------------
+bundle id:                  Flashtype (0x40c8)
+path:                       /Applications/Flashtype.app (0x5bcc)
+identifier:                 com.flashtype.app
+versionString:              0.2.0
+
+--------------------------------------------------------------------------------
+bundle id:                  Flashtype (0x3f44)
+path:                       /Volumes/Flashtype 0.1.1-arm64/Flashtype.app (0x59dc)
+identifier:                 com.flashtype.app
+versionString:              0.1.1
+
+--------------------------------------------------------------------------------
+bundle id:                  Flashtype Helper (0x5bdc)
+path:                       /Applications/Flashtype.app/Contents/Frameworks/Flashtype Helper.app (0x5bdc)
+identifier:                 com.flashtype.app.helper
+versionString:              0.2.0
+
+--------------------------------------------------------------------------------
+bundle id:                  Other (0x1234)
+path:                       /Applications/Other.app (0x1234)
+identifier:                 com.example.other
+versionString:              1.0.0
+`;
+
+		expect(getNonCanonicalFlashtypeBundlePathsFromLsregisterDump(dump)).toEqual(
+			["/Volumes/Flashtype 0.1.1-arm64/Flashtype.app"],
+		);
+	});
+
+	test("skips packaged apps outside /Applications", async () => {
+		const execFileAsync = vi.fn();
+
+		const result = await registerMarkdownDefaultHandler({
+			execFileAsync,
+			executablePath:
+				"/Volumes/Flashtype 0.1.1-arm64/Flashtype.app/Contents/MacOS/Flashtype",
+			isPackaged: true,
+			platform: "darwin",
+		});
+
+		expect(result).toEqual({
+			status: "skipped",
+			reason: "non-canonical-app-bundle",
+		});
+		expect(execFileAsync).not.toHaveBeenCalled();
+	});
+
+	test("registers only from the canonical installed app", async () => {
+		const execFileAsync = vi
+			.fn()
+			.mockResolvedValueOnce({
+				stdout: `
+--------------------------------------------------------------------------------
+path:                       /Applications/Flashtype.app (0x5bcc)
+identifier:                 com.flashtype.app
+
+--------------------------------------------------------------------------------
+path:                       /Volumes/Flashtype 0.1.1-arm64/Flashtype.app (0x59dc)
+identifier:                 com.flashtype.app
+`,
+			})
+			.mockResolvedValueOnce({ stdout: "" })
+			.mockResolvedValueOnce({ stdout: "" })
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({
+					"public.markdown": "com.apple.dt.Xcode",
+					"net.daringfireball.markdown": null,
+				}),
+			})
+			.mockResolvedValueOnce({ stdout: "" });
+
+		const result = await registerMarkdownDefaultHandler({
+			execFileAsync,
+			executablePath: "/Applications/Flashtype.app/Contents/MacOS/Flashtype",
+			isPackaged: true,
+			platform: "darwin",
+		});
+
+		expect(result).toEqual({
+			status: "registered",
+			contentTypes: ["public.markdown", "net.daringfireball.markdown"],
+			unregisteredAppBundlePaths: [
+				"/Volumes/Flashtype 0.1.1-arm64/Flashtype.app",
+			],
+		});
+		expect(execFileAsync).toHaveBeenNthCalledWith(
+			1,
+			LSREGISTER_PATH,
+			["-dump"],
+			{ timeout: 5000, maxBuffer: 20 * 1024 * 1024 },
+		);
+		expect(execFileAsync).toHaveBeenNthCalledWith(
+			2,
+			LSREGISTER_PATH,
+			["-u", "/Volumes/Flashtype 0.1.1-arm64/Flashtype.app"],
+			{ timeout: 5000 },
+		);
+		expect(execFileAsync).toHaveBeenNthCalledWith(
+			3,
+			LSREGISTER_PATH,
+			["-f", "/Applications/Flashtype.app"],
+			{ timeout: 5000 },
+		);
+		expect(execFileAsync).toHaveBeenNthCalledWith(
+			4,
+			"/usr/bin/osascript",
+			expect.arrayContaining(["JavaScript"]),
+			{ timeout: 5000 },
+		);
+		expect(execFileAsync).toHaveBeenNthCalledWith(
+			5,
+			"/usr/bin/osascript",
+			expect.arrayContaining(["JavaScript"]),
+			{ timeout: 5000 },
+		);
+
+		const queryScript = execFileAsync.mock.calls[3][1][3];
+		expect(queryScript).toContain("ObjC.castRefToObject(handler)");
+
+		const registrationScript = execFileAsync.mock.calls[4][1][3];
+		expect(registrationScript).toContain('"public.markdown"');
+		expect(registrationScript).toContain('"net.daringfireball.markdown"');
+		expect(registrationScript).toContain(APP_BUNDLE_ID);
+	});
+
+	test("registers only filtered content types through the full workflow", async () => {
+		const execFileAsync = vi
+			.fn()
+			.mockResolvedValueOnce({ stdout: "" })
+			.mockResolvedValueOnce({ stdout: "" })
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({
+					"public.markdown": "com.apple.dt.Xcode",
+					"net.daringfireball.markdown": "com.microsoft.VSCode",
+				}),
+			})
+			.mockResolvedValueOnce({ stdout: "" });
+
+		const result = await registerMarkdownDefaultHandler({
+			execFileAsync,
+			executablePath: "/Applications/Flashtype.app/Contents/MacOS/Flashtype",
+			isPackaged: true,
+			platform: "darwin",
+		});
+
+		expect(result).toEqual({
+			status: "registered",
+			contentTypes: ["public.markdown"],
+			unregisteredAppBundlePaths: [],
+		});
+
+		const registrationScript = execFileAsync.mock.calls[3][1][3];
+		expect(registrationScript).toContain('"public.markdown"');
+		expect(registrationScript).not.toContain('"net.daringfireball.markdown"');
+	});
+
+	test("preserves user-selected third-party handlers", async () => {
+		const execFileAsync = vi
+			.fn()
+			.mockResolvedValueOnce({ stdout: "" })
+			.mockResolvedValueOnce({ stdout: "" })
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({
+					"public.markdown": "com.microsoft.VSCode",
+					"net.daringfireball.markdown": "md.obsidian",
+				}),
+			});
+
+		const result = await registerMarkdownDefaultHandler({
+			execFileAsync,
+			executablePath: "/Applications/Flashtype.app/Contents/MacOS/Flashtype",
+			isPackaged: true,
+			platform: "darwin",
+		});
+
+		expect(result).toEqual({
+			status: "skipped",
+			reason: "user-handler-preserved",
+		});
+		expect(execFileAsync).toHaveBeenCalledTimes(3);
+	});
+});

--- a/electron/markdown-default-handler.test.ts
+++ b/electron/markdown-default-handler.test.ts
@@ -35,9 +35,12 @@ describe("Markdown default handler registration policy", () => {
 		).toBe(false);
 	});
 
-	test("replaces no handler, Xcode, and Flashtype itself", () => {
+	test("replaces no handler, Xcode, TextEdit, and Flashtype itself", () => {
 		expect(shouldReplaceMarkdownDefaultHandler(null)).toBe(true);
 		expect(shouldReplaceMarkdownDefaultHandler("com.apple.dt.Xcode")).toBe(
+			true,
+		);
+		expect(shouldReplaceMarkdownDefaultHandler("com.apple.TextEdit")).toBe(
 			true,
 		);
 		expect(shouldReplaceMarkdownDefaultHandler(APP_BUNDLE_ID)).toBe(true);
@@ -53,7 +56,7 @@ describe("Markdown default handler registration policy", () => {
 	test("chooses only replaceable Markdown content types", () => {
 		expect(
 			getMarkdownContentTypesToRegister({
-				"public.markdown": "com.apple.dt.Xcode",
+				"public.markdown": "com.apple.TextEdit",
 				"net.daringfireball.markdown": "com.microsoft.VSCode",
 			}),
 		).toEqual(["public.markdown"]);
@@ -69,7 +72,7 @@ versionString:              0.2.0
 
 --------------------------------------------------------------------------------
 bundle id:                  Flashtype (0x3f44)
-path:                       /Volumes/Flashtype 0.1.1-arm64/Flashtype.app (0x59dc)
+path:                       /Volumes/Flashtype 0.1.1-arm64/Flashtype.app (0x59DC)
 identifier:                 com.flashtype.app
 versionString:              0.1.1
 
@@ -194,7 +197,7 @@ identifier:                 com.flashtype.app
 			.mockResolvedValueOnce({ stdout: "" })
 			.mockResolvedValueOnce({
 				stdout: JSON.stringify({
-					"public.markdown": "com.apple.dt.Xcode",
+					"public.markdown": "com.apple.TextEdit",
 					"net.daringfireball.markdown": "com.microsoft.VSCode",
 				}),
 			})


### PR DESCRIPTION
## Summary

Fix macOS Markdown default-app registration so Flashtype does not let old DMGs or local release builds compete with the installed app.

- only the canonical `/Applications/Flashtype.app` may register Markdown defaults
- preserve third-party Markdown handlers like VS Code or Obsidian
- replace missing handlers, Xcode, or Flashtype itself
- unregister stale noncanonical `com.flashtype.app` registrations before refreshing the installed app
- lower the passive document handler rank from `Owner` to `Alternate`

## Root Cause

LaunchServices stores default document handlers by bundle id, not by app path. Multiple Flashtype bundles used `com.flashtype.app` and claimed Markdown ownership, so macOS could resolve `.md` opens to an old mounted DMG or local release build instead of the installed 0.2.x app.

## Validation

- `pnpm vitest run electron/markdown-default-handler.test.ts`
- `pnpm oxlint --tsconfig ./tsconfig.json --ignore-path .gitignore electron/main.mjs electron/markdown-default-handler.mjs electron/markdown-default-handler.test.ts`
- `pnpm typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup code mutates system LaunchServices defaults and unregisters bundles; mistakes could affect which app opens Markdown or leave stale registrations, though scope is limited to darwin packaged installs and replaceable handlers.
> 
> **Overview**
> Fixes macOS **Markdown default-app** behavior so multiple `com.flashtype.app` bundles (DMGs, local builds) no longer steal `.md` opens from the installed app.
> 
> Markdown registration moves from inline logic in `electron/main.mjs` into **`electron/markdown-default-handler.mjs`**. On startup, only **`/Applications/Flashtype.app`** may register defaults: it unregisters stale non-canonical Flashtype bundles via `lsregister`, refreshes the canonical bundle, reads current editor handlers, and calls `LSSetDefaultRoleHandlerForContentType` only for content types whose current handler is missing, Xcode, TextEdit, or Flashtype—**third-party choices (e.g. VS Code, Obsidian) are left alone**. Packaged **`electron-builder.yml`** changes Markdown document **`LSHandlerRank`** from `Owner` to **`Alternate`**. Vitest coverage documents the policy and full workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1255c2d1153857dd9175bd3d2a4e416787f4a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->