### PR TITLE
[codex] Fix markdown list roundtrips

### DIFF
--- a/.changenotes/fix-markdown-list-roundtrip.md
+++ b/.changenotes/fix-markdown-list-roundtrip.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed Markdown list roundtripping for bullets and checklists.
+
+FlashType now preserves single-item bullet lists, manually typed checklist markers, and content below mid-document edits when saving Markdown files.

--- a/src/widgets/markdown/components/formatting-toolbar.test.tsx
+++ b/src/widgets/markdown/components/formatting-toolbar.test.tsx
@@ -2,10 +2,14 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useEffect } from "react";
 import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import { Editor, type JSONContent } from "@tiptap/core";
-import { MarkdownWc } from "@/widgets/markdown/editor/tiptap-markdown-bridge";
+import {
+	MarkdownWc,
+	astToTiptapDoc,
+} from "@/widgets/markdown/editor/tiptap-markdown-bridge";
 import { FormattingToolbar } from "./formatting-toolbar";
 import { EditorProvider, useEditorCtx } from "../editor/editor-context";
 import { buildMarkdownFromEditor } from "../editor/build-markdown-from-editor";
+import { parseMarkdown } from "../editor/markdown-rust";
 
 type EditorSetup = {
 	editor: Editor;
@@ -52,6 +56,27 @@ function renderToolbar(editor: Editor) {
 	);
 }
 
+function textSelection(editor: Editor, text: string) {
+	let from: number | null = null;
+	let to: number | null = null;
+	editor.state.doc.descendants((node, pos) => {
+		if (from != null) return false;
+		if (!node.isText) return true;
+		const value = node.text ?? "";
+		const index = value.indexOf(text);
+		if (index >= 0) {
+			from = pos + index;
+			to = from + text.length;
+			return false;
+		}
+		return true;
+	});
+	if (from == null || to == null) {
+		throw new Error(`Could not find text selection: ${text}`);
+	}
+	return { from, to };
+}
+
 const paragraphDoc: JSONContent = {
 	type: "doc",
 	content: [
@@ -81,6 +106,10 @@ const bulletListDoc: JSONContent = {
 		},
 	],
 };
+
+const newFileMarkdown =
+	"# Launching\n\n- open source launch (reddit)\n- hello\n\n# Campaigns\n\n- github stars\n";
+const mixedTaskListMarkdown = "- plain bullet\n- [ ] todo\n";
 
 describe("FormattingToolbar", () => {
 	const originalClipboard = navigator.clipboard;
@@ -120,14 +149,16 @@ describe("FormattingToolbar", () => {
 		destroyEditor(setup);
 	});
 
-	test("wraps and unwraps the current block in a bullet list", async () => {
+	test("wraps the current block in a bullet list without unwrapping a collapsed list selection", async () => {
 		const setup = createEditor(paragraphDoc);
 		const utils = renderToolbar(setup.editor);
 
 		const bulletButton = await screen.findByLabelText("Bullet list");
 
 		await act(async () => {
-			setup.editor.commands.selectAll();
+			setup.editor.commands.setTextSelection(
+				textSelection(setup.editor, "Hello world"),
+			);
 			fireEvent.click(bulletButton);
 		});
 
@@ -140,9 +171,52 @@ describe("FormattingToolbar", () => {
 			fireEvent.click(bulletButton);
 		});
 
-		expect(setup.editor.isActive("bulletList")).toBe(false);
+		expect(setup.editor.isActive("bulletList")).toBe(true);
 		doc = setup.editor.getJSON() as any;
+		expect(doc.content?.[0]?.type).toBe("bulletList");
+
+		await act(async () => {
+			utils.unmount();
+		});
+		destroyEditor(setup);
+	});
+
+	test("unwraps an explicitly selected bullet-list item", async () => {
+		const setup = createEditor(bulletListDoc);
+		const utils = renderToolbar(setup.editor);
+
+		const bulletButton = await screen.findByLabelText("Bullet list");
+
+		await act(async () => {
+			setup.editor.commands.setTextSelection(textSelection(setup.editor, "First"));
+			fireEvent.click(bulletButton);
+		});
+
+		expect(setup.editor.isActive("bulletList")).toBe(false);
+		const doc = setup.editor.getJSON() as any;
 		expect(doc.content?.[0]?.type).toBe("paragraph");
+		expect(buildMarkdownFromEditor(setup.editor)).toBe("First\n");
+
+		await act(async () => {
+			utils.unmount();
+		});
+		destroyEditor(setup);
+	});
+
+	test("keeps the final single-item bullet list serialized after choosing the bullet-list control", async () => {
+		const setup = createEditor(
+			astToTiptapDoc(parseMarkdown(newFileMarkdown)) as JSONContent,
+		);
+		const utils = renderToolbar(setup.editor);
+
+		const bulletButton = await screen.findByLabelText("Bullet list");
+
+		await act(async () => {
+			setup.editor.commands.setTextSelection(setup.editor.state.doc.content.size);
+			fireEvent.click(bulletButton);
+		});
+
+		expect(buildMarkdownFromEditor(setup.editor)).toBe(newFileMarkdown);
 
 		await act(async () => {
 			utils.unmount();
@@ -169,6 +243,8 @@ describe("FormattingToolbar", () => {
 
 		let listItem = (setup.editor.getJSON() as any).content?.[0]?.content?.[0];
 		expect(listItem?.attrs?.checked).toBe(false);
+		expect(bulletButton).toHaveAttribute("aria-pressed", "false");
+		expect(checklistButton).toHaveAttribute("aria-pressed", "true");
 
 		await act(async () => {
 			fireEvent.click(checklistButton);
@@ -176,6 +252,39 @@ describe("FormattingToolbar", () => {
 
 		listItem = (setup.editor.getJSON() as any).content?.[0]?.content?.[0];
 		expect(listItem?.attrs?.checked ?? null).toBeNull();
+		expect(bulletButton).toHaveAttribute("aria-pressed", "true");
+		expect(checklistButton).toHaveAttribute("aria-pressed", "false");
+
+		await act(async () => {
+			utils.unmount();
+		});
+		destroyEditor(setup);
+	});
+
+	test("shows plain bullets and checklist items separately in a mixed list", async () => {
+		const setup = createEditor(
+			astToTiptapDoc(parseMarkdown(mixedTaskListMarkdown)) as JSONContent,
+		);
+		const utils = renderToolbar(setup.editor);
+
+		const bulletButton = await screen.findByLabelText("Bullet list");
+		const checklistButton = await screen.findByLabelText("Checklist");
+
+		await act(async () => {
+			setup.editor.commands.setTextSelection(
+				textSelection(setup.editor, "plain bullet"),
+			);
+		});
+
+		expect(bulletButton).toHaveAttribute("aria-pressed", "true");
+		expect(checklistButton).toHaveAttribute("aria-pressed", "false");
+
+		await act(async () => {
+			setup.editor.commands.setTextSelection(textSelection(setup.editor, "todo"));
+		});
+
+		expect(bulletButton).toHaveAttribute("aria-pressed", "false");
+		expect(checklistButton).toHaveAttribute("aria-pressed", "true");
 
 		await act(async () => {
 			utils.unmount();

--- a/src/widgets/markdown/components/formatting-toolbar.tsx
+++ b/src/widgets/markdown/components/formatting-toolbar.tsx
@@ -102,14 +102,15 @@ export function FormattingToolbar({ className }: { className?: string }) {
 	useEffect(() => {
 		if (!editor) return;
 		const update = () => {
+			const isTaskList = computeTaskListActive(editor, hasTaskListCommand);
 			setFormatState({
 				block: getActiveBlock(editor),
 				isBold: editor.isActive("bold"),
 				isItalic: editor.isActive("italic"),
 				isCode: editor.isActive("code"),
-				isBulletList: editor.isActive("bulletList"),
+				isBulletList: editor.isActive("bulletList") && !isTaskList,
 				isOrderedList: editor.isActive("orderedList"),
-				isTaskList: computeTaskListActive(editor, hasTaskListCommand),
+				isTaskList,
 			});
 		};
 
@@ -162,6 +163,9 @@ export function FormattingToolbar({ className }: { className?: string }) {
 
 	const handleToggleBulletList = useCallback(() => {
 		if (!editor) return;
+		if (editor.isActive("bulletList") && editor.state.selection.empty) {
+			return;
+		}
 		const chain = editor.chain().focus() as any;
 		let success = editor.isActive("bulletList")
 			? (chain.liftListItem?.("listItem")?.run?.() ?? false)
@@ -177,6 +181,9 @@ export function FormattingToolbar({ className }: { className?: string }) {
 
 	const handleToggleOrderedList = useCallback(() => {
 		if (!editor) return;
+		if (editor.isActive("orderedList") && editor.state.selection.empty) {
+			return;
+		}
 		const chain = editor.chain().focus() as any;
 		let success = editor.isActive("orderedList")
 			? (chain.liftListItem?.("listItem")?.run?.() ?? false)
@@ -472,10 +479,13 @@ function getActiveBlock(editor: Editor): ToolbarBlockType {
 
 function computeTaskListActive(editor: Editor, hasTaskListCommand: boolean) {
 	if (hasTaskListCommand && editor.isActive("taskList")) return true;
+	const itemAttrs = editor.getAttributes("listItem");
+	if (itemAttrs && "checked" in itemAttrs) {
+		return typeof itemAttrs.checked === "boolean";
+	}
 	const listAttrs = editor.getAttributes("bulletList");
 	if (listAttrs?.isTaskList) return true;
-	const itemAttrs = editor.getAttributes("listItem");
-	return typeof itemAttrs?.checked === "boolean";
+	return false;
 }
 
 function toggleTaskListFallback(editor: Editor) {

--- a/src/widgets/markdown/editor/create-editor.test.ts
+++ b/src/widgets/markdown/editor/create-editor.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "vitest";
 import { openLix } from "@/test-utils/node-lix-sdk";
 import { createEditor } from "./create-editor";
 import { astToTiptapDoc } from "./tiptap-markdown-bridge";
-import { parseMarkdown } from "./markdown-rust";
+import { parseMarkdown, serializeAst } from "./markdown-rust";
 import { handlePaste } from "./handle-paste";
 import { Editor } from "@tiptap/core";
 import { qb } from "@/lib/lix-kysely";
@@ -44,6 +44,80 @@ function paragraphTexts(markdown: string): string[] {
 		.split(/\n{2,}/)
 		.map((paragraph) => paragraph.trim())
 		.filter(Boolean);
+}
+
+function buildLongMarkdownRepro(): string {
+	const parts = [
+		"# Complex roundtrip document",
+		"",
+		"Opening paragraph with **bold**, _italic_, `inline code`, and [a link](https://example.com).",
+		"",
+	];
+	for (let i = 1; i <= 36; i += 1) {
+		parts.push(`## Section ${String(i).padStart(2, "0")}`);
+		parts.push("");
+		parts.push(
+			`Paragraph ${i} alpha. This text should remain after edits, including punctuation: commas, semicolons; and parentheses (like this).`,
+		);
+		parts.push("");
+		if (i % 3 === 0) {
+			parts.push(`- Bullet ${i}.1 remains`);
+			parts.push(`- Bullet ${i}.2 remains`);
+			parts.push("");
+		}
+		if (i % 4 === 0) {
+			parts.push(`- [ ] Todo ${i} remains unchecked`);
+			parts.push(`- [x] Done ${i} remains checked`);
+			parts.push("");
+		}
+		if (i % 5 === 0) {
+			parts.push(`1. Ordered ${i}.1 remains`);
+			parts.push(`2. Ordered ${i}.2 remains`);
+			parts.push("");
+		}
+		if (i % 6 === 0) {
+			parts.push(`> Quote ${i} should remain below edit points.`);
+			parts.push("");
+		}
+		if (i === 18) {
+			parts.push(
+				"TARGET paragraph. Editing inside this line should not delete anything below it.",
+			);
+			parts.push("");
+		}
+	}
+	parts.push("## Tail table");
+	parts.push("");
+	parts.push("| Name | Value |");
+	parts.push("| - | - |");
+	parts.push("| tail-a | survives |");
+	parts.push("| tail-b | survives |");
+	parts.push("");
+	parts.push("```ts");
+	parts.push('export const tail = "survives";');
+	parts.push("```");
+	parts.push("");
+	parts.push("Final paragraph at the very bottom must survive mid-document edits.");
+	return `${parts.join("\n")}\n`;
+}
+
+function positionAfterText(editor: Editor, needle: string): number {
+	let found: number | null = null;
+	editor.state.doc.descendants((node, pos) => {
+		if (found != null) return false;
+		if (!node.isText) return true;
+		const text = node.text ?? "";
+		const index = text.indexOf(needle);
+		if (index >= 0) {
+			found = pos + index + needle.length;
+			return false;
+		}
+		return true;
+	});
+	if (found == null) {
+		throw new Error(`Could not find text in editor: ${needle}`);
+	}
+	return found;
 }
 
 async function createEditorFromFile(args: {
@@ -600,6 +674,47 @@ test("delete removes the middle paragraph from persisted markdown", async () => 
 		(value) => paragraphTexts(value).length === 2,
 	);
 	expect(paragraphTexts(markdown)).toEqual(["Start", "Third"]);
+
+	editor.destroy();
+});
+
+test("editing a long markdown document does not truncate content below the edit point", async () => {
+	const lix = await openLix();
+	const fileId = "long_markdown_mid_edit";
+	const initial = buildLongMarkdownRepro();
+
+	await qb(lix)
+		.insertInto("lix_file")
+		.values({
+			id: fileId,
+			path: "/long-markdown-mid-edit.md",
+			data: new TextEncoder().encode(initial),
+		})
+		.execute();
+
+	const editor: Editor = await createEditorFromFile({
+		lix,
+		fileId,
+		persistDebounceMs: 0,
+	});
+
+	editor.commands.setTextSelection(positionAfterText(editor, "TARGET"));
+	editor.commands.insertContent(" EXACT");
+	const expected = serializeAst(parseMarkdown(initial)).replace(
+		"TARGET paragraph.",
+		"TARGET EXACT paragraph.",
+	);
+
+	const markdown = await waitForMarkdown(
+		lix,
+		fileId,
+		(value) => value === expected,
+	);
+	expect(markdown).toBe(expected);
+
+	await new Promise((resolve) => setTimeout(resolve, 50));
+	const settledMarkdown = await readMarkdown(lix, fileId);
+	expect(settledMarkdown).toBe(expected);
 
 	editor.destroy();
 });

--- a/src/widgets/markdown/editor/markdown-rust.ts
+++ b/src/widgets/markdown/editor/markdown-rust.ts
@@ -33,11 +33,54 @@ export function parseMarkdown(markdown: string): AstRoot {
 }
 
 export function serializeAst(ast: any): string {
-	const children = Array.isArray(ast?.children) ? ast.children : [];
+	const children = Array.isArray(ast?.children)
+		? ast.children.map(prepareTaskListMarkers)
+		: [];
 	return serialize_markdown({
 		blocks: children,
 		source: DEFAULT_SOURCE_META,
 	} satisfies MarkdownDocument);
+}
+
+function prepareTaskListMarkers(node: any): any {
+	if (!node || typeof node !== "object") {
+		return node;
+	}
+	if (Array.isArray(node)) {
+		return node.map(prepareTaskListMarkers);
+	}
+
+	const out: Record<string, any> = { ...node };
+	if (Array.isArray(node.children)) {
+		out.children = node.children.map(prepareTaskListMarkers);
+	}
+
+	if (
+		node.type !== "listItem" ||
+		!(node.checked === true || node.checked === false)
+	) {
+		return out;
+	}
+
+	const marker = node.checked ? "[x] " : "[ ] ";
+	const children = Array.isArray(out.children) ? [...out.children] : [];
+	const first = children[0];
+	if (first?.type === "paragraph") {
+		const paragraphChildren = Array.isArray(first.children)
+			? [...first.children]
+			: [];
+		children[0] = {
+			...first,
+			children: [{ type: "text", value: marker }, ...paragraphChildren],
+		};
+	} else {
+		children.unshift({
+			type: "paragraph",
+			children: [{ type: "text", value: marker }],
+		});
+	}
+	out.children = children;
+	return out;
 }
 
 export function normalizeAst(ast: any): AstRoot {

--- a/src/widgets/markdown/editor/tiptap-markdown-bridge/roundtrip.test.ts
+++ b/src/widgets/markdown/editor/tiptap-markdown-bridge/roundtrip.test.ts
@@ -450,6 +450,18 @@ describe("lists", () => {
 		expect(canonicalAst(output)).toEqual(canonicalAst(input));
 		// Editor roundtrip of task list is exercised in the example app; core mapping equality is asserted here.
 	});
+
+	test("task list markdown preserves checked markers through editor serialization", () => {
+		const markdown = "- [x] done\n- [ ] todo\n";
+
+		expect(roundtripMarkdownThroughEditor(markdown)).toBe(markdown);
+	});
+
+	test("mixed plain and formatted task list markdown preserves markers", () => {
+		const markdown = "- plain bullet\n- [ ] unchecked **bold**\n- [x] checked _italic_\n";
+
+		expect(roundtripMarkdownThroughEditor(markdown)).toBe(markdown);
+	});
 });
 
 describe("blocks", () => {

--- a/src/widgets/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
+++ b/src/widgets/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
@@ -2,11 +2,13 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { Editor } from "@tiptap/core";
 import { MarkdownWc } from "./markdown-wc";
+import { buildMarkdownFromEditor } from "../build-markdown-from-editor";
 
 const __editors: Editor[] = [];
-function createEditor() {
+function createEditor(content?: any) {
 	const ed = new Editor({
 		extensions: MarkdownWc(),
+		content,
 	});
 	__editors.push(ed);
 	return ed;
@@ -72,6 +74,25 @@ function sendKey(editor: Editor, key: string, opts?: { shift?: boolean }) {
 	editor.view.someProp("handleKeyDown", (f: any) => f(editor.view, event));
 }
 
+function setCursorAfterText(editor: Editor, text: string) {
+	let position: number | null = null;
+	editor.state.doc.descendants((node, pos) => {
+		if (position != null) return false;
+		if (!node.isText) return true;
+		const value = node.text ?? "";
+		const index = value.indexOf(text);
+		if (index >= 0) {
+			position = pos + index + text.length;
+			return false;
+		}
+		return true;
+	});
+	if (position == null) {
+		throw new Error(`Could not find text: ${text}`);
+	}
+	editor.commands.setTextSelection(position);
+}
+
 describe("Markdown typing shortcuts (input rules)", () => {
 	test.each([
 		["#", 1],
@@ -128,6 +149,66 @@ describe("Markdown typing shortcuts (input rules)", () => {
 		// Should not retain trigger text
 		const para = li.child(0) as any;
 		expect((para.textContent || "").trim()).toBe("");
+	});
+
+	test.each([
+		["- [] todo", "- [ ] todo\n", false],
+		["- [ ] todo", "- [ ] todo\n", false],
+		["- [x] done", "- [x] done\n", true],
+	])("%s serializes as task-list markdown", (typed, markdown, checked) => {
+		const editor = createEditor();
+		typeText(editor, typed as string);
+		const list = editor.state.doc.child(0) as any;
+		const item = list.child(0) as any;
+
+		expect(list.type.name).toBe("bulletList");
+		expect(item.attrs?.checked).toBe(checked);
+		expect(buildMarkdownFromEditor(editor)).toBe(markdown);
+	});
+
+	test("- [] serializes as a blank unchecked task item", () => {
+		const editor = createEditor();
+		typeText(editor, "- [] ");
+		const list = editor.state.doc.child(0) as any;
+		const item = list.child(0) as any;
+
+		expect(item.attrs?.checked).toBe(false);
+		expect(buildMarkdownFromEditor(editor)).toBe("- [ ] \n");
+	});
+
+	test("[ ] in a continuation paragraph does not convert the whole list item to a task", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "first paragraph" }],
+								},
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "continuation" }],
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		setCursorAfterText(editor, "continuation");
+		typeText(editor, "[ ] ");
+		const item = editor.state.doc.child(0).child(0) as any;
+
+		expect(item.attrs?.checked ?? null).toBeNull();
+		expect(buildMarkdownFromEditor(editor)).toBe(
+			"- first paragraph\n  continuation[ ] \n",
+		);
 	});
 });
 
@@ -191,6 +272,7 @@ describe("Keyboard shortcuts (keymap)", () => {
 		const li2: any = list.child(1);
 		expect(li2.type.name).toBe("listItem");
 		expect(li2.attrs?.checked).toBe(false);
+		expect(buildMarkdownFromEditor(editor)).toBe("- [ ] abc\n- [ ] \n");
 	});
 
 	test("Enter on empty bullet list item exits the list", () => {

--- a/src/widgets/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
+++ b/src/widgets/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
@@ -76,19 +76,30 @@ export const MarkdownWcShortcuts = Extension.create({
 							for (let d = $from.depth; d > 0; d--) {
 								const n = $from.node(d);
 								if (n?.type?.name === "bulletList") {
-									// Delete the typed trigger right before the cursor
-									const len =
-										match && (match as any)[0] ? (match as any)[0].length : 0;
-									if (len > 0) {
-										commands.command(({ state, tr, dispatch }: any) => {
-											const end = state.selection.from;
-											const start = Math.max(0, end - len);
-											if (dispatch) dispatch(tr.delete(start, end));
-											return true;
+									return commands.command(({ state, tr, dispatch }: any) => {
+										const selectionFrom = state.selection.$from;
+										let listItemDepth = -1;
+										for (let depth = selectionFrom.depth; depth > 0; depth--) {
+											const node = selectionFrom.node(depth);
+											if (node?.type?.name === "listItem") {
+												listItemDepth = depth;
+												break;
+											}
+										}
+										if (listItemDepth < 0) return false;
+										const listItemPos = selectionFrom.before(listItemDepth);
+										const listItem = selectionFrom.node(listItemDepth);
+										if (listItem.firstChild !== selectionFrom.parent) {
+											return false;
+										}
+										tr.delete(range.from, range.to);
+										tr.setNodeMarkup(listItemPos, undefined, {
+											...listItem.attrs,
+											checked,
 										});
-									}
-									commands.updateAttributes("listItem", { checked });
-									return null;
+										if (dispatch) dispatch(tr);
+										return true;
+									});
 								}
 							}
 


### PR DESCRIPTION
## Summary

Fixes Markdown list roundtripping in the editor:

- Prevents collapsed toolbar clicks inside active bullet/numbered lists from unwrapping the current list item and dropping bullet syntax on save.
- Preserves manually typed checklist markers such as `- []`, `- [ ]`, and `- [x]` when serializing Markdown.
- Keeps checklist toolbar state distinct from plain bullet-list state.
- Adds a long-document persistence regression for the issue #129 shape so mid-document edits do not truncate content below the edit point.
- Adds a patch changenote for the user-facing fix.

## Root Cause

TipTap represents checklists on top of bullet-list/list-item nodes, while the Markdown serializer did not emit task markers from `listItem.checked`. The toolbar also treated collapsed clicks inside active lists as unwrap commands, which could convert an existing one-item bullet list back into a paragraph before persistence.

## Validation

- `pnpm test`
- `pnpm run typecheck`
- `git diff --check`
- Manual Electron verification against `/Users/samuel/Desktop/flash_kb/new-file.md`
- Manual Electron long-document roundtrip check for the issue #129 reproduction shape

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Markdown save path and list editing UX; wrong behavior could corrupt saved file content, though changes are scoped and heavily tested.
> 
> **Overview**
> Fixes Markdown **save roundtrips** for bullet lists, checklists, and toolbar behavior so list syntax is not dropped accidentally.
> 
> **Serialization:** `serializeAst` now injects `[ ]` / `[x]` markers from `listItem.checked` before the Rust serializer runs, so checked tasks roundtrip through the editor.
> 
> **Formatting toolbar:** Collapsed clicks on bullet/numbered list buttons no longer unwrap the current item; unwrap only happens with an explicit text selection. Bullet vs checklist **aria-pressed** state is split so task items are not shown as plain bullets.
> 
> **Typing shortcuts:** Checklist triggers inside an existing list only flip `checked` on the **first paragraph** of the item, avoiding false task conversion when `[ ]` is typed in a continuation line.
> 
> Adds regression coverage (toolbar, shortcuts, editor persistence including a long-document mid-edit case) and a patch changenote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f571252d9971d70ae75d6edf1015dbb518ba6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->