### PR TITLE
[codex] Fix file navigator scrolling

### DIFF
--- a/.changenotes/fix-file-view-scrolling.md
+++ b/.changenotes/fix-file-view-scrolling.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed scrolling in the file navigator when a workspace contains many files.
+
+The file list now scrolls inside the navigator panel instead of overflowing past the visible area.

--- a/src/widgets/files/index.test.tsx
+++ b/src/widgets/files/index.test.tsx
@@ -336,6 +336,44 @@ describe("FilesView", () => {
 		await lix.close();
 	});
 
+	test("renders the file tree inside a vertical scroll region", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values(
+				Array.from({ length: 20 }, (_, index) => ({
+					id: `file_${index}`,
+					path: `/file-${String(index + 1).padStart(2, "0")}.md`,
+					data: new Uint8Array(),
+				})),
+			)
+			.execute();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView />
+					</Suspense>
+				</LixProvider>,
+			);
+		});
+
+		await waitFor(() => {
+			expect(utils!.getByText("file-01.md")).toBeInTheDocument();
+		});
+
+		const scrollRegion = utils!.getByTestId("files-view-tree-scroll");
+		expect(scrollRegion).toHaveClass("min-h-0");
+		expect(scrollRegion).toHaveClass("flex-1");
+		expect(scrollRegion).toHaveClass("overflow-y-auto");
+		expect(scrollRegion).toHaveClass("overflow-x-hidden");
+
+		utils!.unmount();
+		await lix.close();
+	});
+
 	test("replaces whitespace with dashes when creating files", async () => {
 		const lix = await openLix();
 		const openWidget = vi.fn();

--- a/src/widgets/files/index.tsx
+++ b/src/widgets/files/index.tsx
@@ -487,25 +487,30 @@ export function FilesView({ context }: FilesViewProps) {
 					</p>
 				</div>
 			)}
-			<FileTree
-				nodes={nodes}
-				openFileView={handleOpenFile}
-				onSelectItem={handleSelectItem}
-				selectedPath={selectedPath ?? undefined}
-				isPanelFocused={isPanelFocused}
-				draft={
-					draft
-						? {
-								kind: draft.kind,
-								directoryPath: draft.directoryPath,
-								value: draft.value,
-								onChange: handleDraftChange,
-								onCommit: handleDraftCommit,
-								onCancel: handleDraftCancel,
-							}
-						: null
-				}
-			/>
+			<div
+				data-testid="files-view-tree-scroll"
+				className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pr-1"
+			>
+				<FileTree
+					nodes={nodes}
+					openFileView={handleOpenFile}
+					onSelectItem={handleSelectItem}
+					selectedPath={selectedPath ?? undefined}
+					isPanelFocused={isPanelFocused}
+					draft={
+						draft
+							? {
+									kind: draft.kind,
+									directoryPath: draft.directoryPath,
+									value: draft.value,
+									onChange: handleDraftChange,
+									onCommit: handleDraftCommit,
+									onCancel: handleDraftCancel,
+								}
+							: null
+					}
+				/>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Fix file navigator scrolling when a workspace contains more files than fit in the left panel.

- wraps the file tree in a dedicated vertical scroll region
- keeps the new-file action outside the scrolling list
- adds a regression test for the scroll container contract
- adds a patch changenote

## Root Cause

The file tree could grow taller than the navigator panel, but no element inside the panel owned vertical scrolling. The parent panel clips overflow, so large workspaces could render files beyond the visible area with no working scroll target.

## Validation

- Reproduced in Electron with a temporary 200-file workspace before the fix: file panel content height exceeded the visible panel, but wheel scrolling did not move any scroll target.
- Verified in Electron after the fix: the file tree scroll region moved to `scrollTop: 3000` after a wheel scroll.
- `pnpm vitest run src/widgets/files/index.test.tsx src/widgets/files/file-tree.test.tsx`
- `pnpm oxlint --tsconfig ./tsconfig.json --ignore-path .gitignore src/widgets/files/index.tsx src/widgets/files/index.test.tsx`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change in the files widget with no auth, data, or API impact; risk is limited to panel layout/scroll behavior.
> 
> **Overview**
> Fixes **file navigator scrolling** when a workspace has more files than fit in the left panel. The tree had no element that owned vertical overflow, so wheel input did not scroll past clipped content.
> 
> **`FileTree`** is now inside a dedicated scroll wrapper (`min-h-0 flex-1 overflow-y-auto`) with `data-testid="files-view-tree-scroll"`, so the list scrolls inside the panel while the **New file** row and drag overlay stay fixed above it.
> 
> Adds a **regression test** that asserts the scroll container’s layout classes, plus a **patch changenote** for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50eebecc66c40d8da0228c402c69f6acfbacb6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->