### PR TITLE
[codex] Add GitHub external link icons

### DIFF
--- a/src/widgets/files/index.tsx
+++ b/src/widgets/files/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Files, FileUp, FilePlus } from "lucide-react";
+import { ExternalLink, Files, FileUp, FilePlus, Github } from "lucide-react";
 import { LixProvider, useLix, useQuery } from "@/lib/lix-react";
 import { isMarkdownFilePath } from "@/widget-runtime/file-handlers";
 import { selectFilesystemEntries } from "@/queries";
@@ -479,9 +479,11 @@ export function FilesView({ context }: FilesViewProps) {
 							href="https://github.com/opral/flashtype/issues"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="underline hover:text-foreground pointer-events-auto"
+							className="inline-flex items-center gap-1 underline hover:text-foreground pointer-events-auto"
 						>
+							<Github className="size-3" aria-hidden="true" />
 							an issue on GitHub
+							<ExternalLink className="size-3" aria-hidden="true" />
 						</a>{" "}
 						for support for CSV, PDF, etc
 					</p>

--- a/src/widgets/markdown/index.tsx
+++ b/src/widgets/markdown/index.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect } from "react";
 import { useMemo } from "react";
 import type { ReactNode } from "react";
-import { FileText, Loader2 } from "lucide-react";
+import { ExternalLink, FileText, Github, Loader2 } from "lucide-react";
 import { LixProvider, useLix, useQueryTakeFirst } from "@/lib/lix-react";
 import { qb } from "@/lib/lix-kysely";
 import { isMarkdownFilePath } from "@/widget-runtime/file-handlers";
@@ -225,9 +225,11 @@ function UnsupportedFilePlaceholder({
 						href="https://github.com/opral/flashtype/issues"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="font-medium text-brand-600 underline underline-offset-2 hover:text-brand-700"
+						className="inline-flex items-center gap-1 font-medium text-brand-600 underline underline-offset-2 hover:text-brand-700"
 					>
+						<Github className="size-3.5" aria-hidden="true" />
 						Open an issue on GitHub
+						<ExternalLink className="size-3" aria-hidden="true" />
 					</a>{" "}
 					for support for more file types.
 				</p>

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -129,8 +129,15 @@ function Nav() {
 				<span>Flashtype</span>
 			</a>
 			<nav className="flex items-center gap-[22px] max-sm:gap-[14px]" aria-label="Primary navigation">
-				<a href={GITHUB_URL} className="text-[15px] font-semibold text-[#44403C] no-underline max-sm:text-[14px]">
-					GitHub ↗
+				<a
+					href={GITHUB_URL}
+					target="_blank"
+					rel="noreferrer"
+					className="inline-flex items-center gap-[6px] text-[15px] font-semibold text-[#44403C] no-underline hover:text-ink max-sm:text-[14px]"
+				>
+					<GitHubIcon className="h-[17px] w-[17px]" />
+					GitHub
+					<span aria-hidden="true">↗</span>
 				</a>
 				<DownloadLink
 					className={`${primaryButton} rounded-[10px] px-[20px] py-[10px] text-[15px] shadow-[0_4px_14px_rgba(232,89,12,0.35),inset_0_1px_0_rgba(255,255,255,0.25)] max-sm:hidden`}
@@ -815,6 +822,18 @@ function DownloadIcon() {
 				strokeWidth="2.2"
 				strokeLinecap="round"
 				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}
+
+function GitHubIcon({ className = "" }: { className?: string }) {
+	return (
+		<svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M12 2C6.48 2 2 6.58 2 12.23c0 4.52 2.86 8.35 6.84 9.7.5.1.68-.22.68-.5 0-.24-.01-1.05-.01-1.9-2.78.62-3.37-1.22-3.37-1.22-.46-1.19-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.05 1.53 1.05.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.64-1.36-2.22-.26-4.56-1.14-4.56-5.05 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.3.1-2.71 0 0 .84-.28 2.75 1.05A9.4 9.4 0 0 1 12 6.92c.85 0 1.71.12 2.51.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.71 1.03 1.62 1.03 2.74 0 3.92-2.34 4.79-4.57 5.04.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.81 0 .28.18.6.69.5A10.1 10.1 0 0 0 22 12.23C22 6.58 17.52 2 12 2Z"
 			/>
 		</svg>
 	);


### PR DESCRIPTION
Closes https://github.com/opral/flashtype/issues/136

## Summary
- Add GitHub and external-link icons to in-app GitHub issue links.
- Add a GitHub icon to the website header GitHub link while preserving the original ↗ arrow.
- Make the website header GitHub link open externally in a new tab.

## Validation
- pnpm exec vitest run src/widgets/markdown/index.test.tsx src/widgets/files/index.test.tsx
- pnpm typecheck
- pnpm -C website typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only link and icon changes with no logic, auth, or data handling impact.
> 
> **Overview**
> **In-app GitHub issue links** in the files drag-and-drop overlay and the unsupported-file markdown placeholder now use `inline-flex` layout with **lucide** `Github` and `ExternalLink` icons (decorative, `aria-hidden`) flanking the link text.
> 
> On the **landing page**, the nav **GitHub** link opens in a new tab (`target="_blank"`, `rel="noreferrer"`), gets a hover style, and shows a new inline **`GitHubIcon`** SVG before the label while keeping the existing **↗** external indicator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47981292beaab626857f15a0095a32856bab6d89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->