### PR TITLE
[codex] Close deleted open files

### DIFF
--- a/.changenotes/fix-close-deleted-open-file.md
+++ b/.changenotes/fix-close-deleted-open-file.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed deleted files staying open in the main editor.
+
+When a file is deleted from the file navigator, any open editor view for that file now closes instead of showing stale content.

--- a/e2e/electron-test-utils.ts
+++ b/e2e/electron-test-utils.ts
@@ -5,7 +5,8 @@ import path from "node:path";
 
 export const repoRoot = path.resolve(import.meta.dirname, "..");
 
-const rendererUrl = "http://127.0.0.1:4173";
+const rendererPort = process.env.FLASHTYPE_E2E_RENDERER_PORT ?? "4173";
+const rendererUrl = `http://127.0.0.1:${rendererPort}`;
 const electronCloseTimeoutMs = 5_000;
 
 export async function launchDevElectronApp(

--- a/e2e/files-click-tour.spec.ts
+++ b/e2e/files-click-tour.spec.ts
@@ -11,6 +11,8 @@ import {
 } from "./electron-test-utils";
 
 const clickCount = 100;
+const deleteShortcut =
+	process.platform === "darwin" ? "Meta+Backspace" : "Control+Backspace";
 
 test("left files panel survives a seeded random file click tour", async ({
 	browserName: _browserName,
@@ -70,6 +72,44 @@ test("left files panel survives a seeded random file click tour", async ({
 				await page.waitForTimeout(delayMs);
 			});
 		}
+	} finally {
+		await closeElectronApp(electronApp);
+	}
+});
+
+test("deleting the active file closes the central file view", async ({
+	browserName: _browserName,
+}, testInfo) => {
+	const workspaceDir = testInfo.outputPath("workspace-delete-active-file");
+
+	let electronApp: ElectronApplication | undefined;
+	try {
+		await writeStarterFiles(workspaceDir);
+		electronApp = await launchDevElectronApp(workspaceDir);
+
+		const page = await electronApp.firstWindow();
+		registerRendererConsoleLogging(page);
+
+		await expect(page.getByTestId("central-panel-empty-state")).toBeVisible();
+		await expectInstalledPluginArchives(workspaceDir);
+		await ensureFilesViewOpenInLeftPanel(page);
+
+		const file = page.getByTestId("file-tree-item-welcome-md");
+		await expect(file).toBeVisible();
+		await file.click();
+		await expect(file).toHaveAttribute("data-selected", "true");
+		await expect(
+			page.locator('[data-active="true"][data-view-key="flashtype_file"]'),
+		).toBeVisible();
+
+		await file.click();
+		await page.keyboard.press(deleteShortcut);
+
+		await expect(file).toHaveCount(0);
+		await expect(
+			page.locator('[data-active="true"][data-view-key="flashtype_file"]'),
+		).toHaveCount(0);
+		await expect(page.getByTestId("central-panel-empty-state")).toBeVisible();
 	} finally {
 		await closeElectronApp(electronApp);
 	}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
+const rendererPort = process.env.FLASHTYPE_E2E_RENDERER_PORT ?? "4173";
+const rendererUrl = `http://127.0.0.1:${rendererPort}`;
+
 export default defineConfig({
 	testDir: "./e2e",
 	testIgnore: ["**/packaged-macos.spec.ts"],
@@ -15,9 +18,8 @@ export default defineConfig({
 		video: "retain-on-failure",
 	},
 	webServer: {
-		command:
-			"node ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port 4173 --strictPort",
-		url: "http://127.0.0.1:4173",
+		command: `node ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port ${rendererPort} --strictPort`,
+		url: rendererUrl,
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,
 	},

--- a/src/extension-runtime/types.ts
+++ b/src/extension-runtime/types.ts
@@ -137,6 +137,10 @@ export interface ExtensionContext {
 		readonly instance?: string;
 		readonly kind?: ExtensionKind;
 	}) => void;
+	readonly closeFileViews?: (args: {
+		readonly panel?: PanelSide;
+		readonly fileId: string;
+	}) => void;
 	readonly isPanelFocused?: boolean;
 	readonly setTabBadgeCount: (count: number | null | undefined) => void;
 	readonly moveExtensionToPanel?: (

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -109,6 +109,7 @@ describe("FilesView", () => {
 
 	test("Cmd+Backspace deletes the selected file", async () => {
 		const lix = await openLix();
+		const closeFileViews = vi.fn();
 		await qb(lix)
 			.insertInto("lix_file")
 			.values({
@@ -123,7 +124,7 @@ describe("FilesView", () => {
 			utils = render(
 				<LixProvider lix={lix}>
 					<Suspense fallback={null}>
-						<FilesView />
+						<FilesView context={createViewContext(lix, { closeFileViews })} />
 					</Suspense>
 				</LixProvider>,
 			);
@@ -152,6 +153,61 @@ describe("FilesView", () => {
 		await waitFor(() => {
 			expect(utils!.queryByText("hello.md")).toBeNull();
 		});
+		expect(closeFileViews).toHaveBeenCalledWith({ fileId: "file_1" });
+
+		utils!.unmount();
+		await lix.close();
+	});
+
+	test("Cmd+Backspace closes a newly created selected file view", async () => {
+		const lix = await openLix();
+		const openFile = vi.fn();
+		const closeFileViews = vi.fn();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView
+							context={createViewContext(lix, { closeFileViews, openFile })}
+						/>
+					</Suspense>
+				</LixProvider>,
+			);
+		});
+
+		await act(async () => {
+			fireEvent.keyDown(document, { key: ".", metaKey: true });
+		});
+		const input = (await utils!.findByTestId(
+			"files-view-draft-input",
+		)) as HTMLInputElement;
+		await act(async () => {
+			fireEvent.change(input, { target: { value: "fresh" } });
+		});
+		await act(async () => {
+			fireEvent.keyDown(input, { key: "Enter" });
+		});
+
+		await waitFor(() => {
+			expect(openFile).toHaveBeenCalled();
+		});
+		const createdFileId = openFile.mock.calls[0]?.[0]?.fileId;
+		expect(typeof createdFileId).toBe("string");
+
+		await act(async () => {
+			fireEvent.keyDown(document, { key: "Backspace", metaKey: true });
+		});
+
+		await waitFor(async () => {
+			const rows = await qb(lix)
+				.selectFrom("lix_file")
+				.select(["path"])
+				.execute();
+			expect(rows.filter((row) => isUserPath(row.path))).toHaveLength(0);
+		});
+		expect(closeFileViews).toHaveBeenCalledWith({ fileId: createdFileId });
 
 		utils!.unmount();
 		await lix.close();

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -41,6 +41,7 @@ export function FilesView({ context }: FilesViewProps) {
 	);
 	const [draft, setDraft] = useState<DraftState>(null);
 	const [selectedPath, setSelectedPath] = useState<string | null>(null);
+	const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
 	const [selectedKind, setSelectedKind] = useState<"file" | "directory" | null>(
 		null,
 	);
@@ -74,7 +75,6 @@ export function FilesView({ context }: FilesViewProps) {
 		}
 		return combined;
 	}, [entryDirectorySet, pendingDirectoryPaths]);
-
 	useEffect(() => {
 		if (pendingPaths.length === 0) return;
 		setPendingPaths((prev) => prev.filter((path) => !entryPathSet.has(path)));
@@ -110,6 +110,7 @@ export function FilesView({ context }: FilesViewProps) {
 		setDraft((prev) => {
 			if (prev) return prev;
 			setSelectedPath(null);
+			setSelectedFileId(null);
 			setSelectedKind(null);
 			return {
 				kind: "file",
@@ -153,6 +154,7 @@ export function FilesView({ context }: FilesViewProps) {
 				}
 				setPendingPaths((prev) => [...prev, path]);
 				setSelectedPath(path);
+				setSelectedFileId(id);
 				setSelectedKind("file");
 				context?.openFile?.({
 					panel: "central",
@@ -205,6 +207,7 @@ export function FilesView({ context }: FilesViewProps) {
 	const handleOpenFile = useCallback(
 		async (fileId: string, path: string) => {
 			setSelectedPath(path);
+			setSelectedFileId(fileId);
 			setSelectedKind("file");
 			context?.openFile?.({
 				panel: "central",
@@ -219,6 +222,9 @@ export function FilesView({ context }: FilesViewProps) {
 	const handleSelectItem = useCallback(
 		(path: string, kind: "file" | "directory") => {
 			setSelectedPath(path);
+			if (kind === "directory") {
+				setSelectedFileId(null);
+			}
 			setSelectedKind(kind);
 		},
 		[],
@@ -239,6 +245,9 @@ export function FilesView({ context }: FilesViewProps) {
 				setPendingPaths((prev) =>
 					prev.filter((path) => path !== normalizedPath),
 				);
+				if (selectedFileId) {
+					context?.closeFileViews?.({ fileId: selectedFileId });
+				}
 			} else {
 				await qb(lix)
 					.deleteFrom("lix_directory")
@@ -252,9 +261,10 @@ export function FilesView({ context }: FilesViewProps) {
 			console.error("Failed to delete entry", error);
 		} finally {
 			setSelectedPath(null);
+			setSelectedFileId(null);
 			setSelectedKind(null);
 		}
-	}, [lix, selectedKind, selectedPath]);
+	}, [context, lix, selectedFileId, selectedKind, selectedPath]);
 
 	useEffect(() => {
 		const listener = (event: KeyboardEvent) => {

--- a/src/extensions/markdown/editor/create-editor.test.ts
+++ b/src/extensions/markdown/editor/create-editor.test.ts
@@ -680,6 +680,74 @@ test("delete removes the middle paragraph from persisted markdown", async () => 
 	editor.destroy();
 });
 
+test("destroy flushes pending autosave for an existing file", async () => {
+	const lix = await openLix();
+	const fileId = "destroy_flush_pending_autosave";
+
+	await qb(lix)
+		.insertInto("lix_file")
+		.values({
+			id: fileId,
+			path: "/destroy-flush-pending-autosave.md",
+			data: new TextEncoder().encode("Start"),
+		})
+		.execute();
+
+	const editor: Editor = await createEditorFromFile({
+		lix,
+		fileId,
+		persistDebounceMs: 50,
+	});
+
+	editor.commands.setTextSelection(editor.state.doc.content.size);
+	editor.commands.insertContent(" Changed");
+	editor.destroy();
+
+	const markdown = await waitForMarkdown(
+		lix,
+		fileId,
+		(value) => value === ensureTrailingNewline("Start Changed"),
+	);
+	expect(markdown).toBe(ensureTrailingNewline("Start Changed"));
+
+	await lix.close();
+});
+
+test("destroy flushes pending autosave without recreating a deleted file", async () => {
+	const lix = await openLix();
+	const fileId = "destroy_cancel_pending_autosave";
+
+	await qb(lix)
+		.insertInto("lix_file")
+		.values({
+			id: fileId,
+			path: "/destroy-cancel-pending-autosave.md",
+			data: new TextEncoder().encode("Start"),
+		})
+		.execute();
+
+	const editor: Editor = await createEditorFromFile({
+		lix,
+		fileId,
+		persistDebounceMs: 50,
+	});
+
+	editor.commands.setTextSelection(editor.state.doc.content.size);
+	editor.commands.insertContent(" Changed");
+	await qb(lix).deleteFrom("lix_file").where("id", "=", fileId).execute();
+	editor.destroy();
+
+	await new Promise((resolve) => setTimeout(resolve, 80));
+	const row = await qb(lix)
+		.selectFrom("lix_file")
+		.select(["id", "path"])
+		.where("id", "=", fileId)
+		.executeTakeFirst();
+	expect(row).toBeUndefined();
+
+	await lix.close();
+});
+
 test("editing a long markdown document does not truncate content below the edit point", async () => {
 	const lix = await openLix();
 	const fileId = "long_markdown_mid_edit";

--- a/src/extensions/markdown/editor/create-editor.ts
+++ b/src/extensions/markdown/editor/create-editor.ts
@@ -84,11 +84,45 @@ export function createEditor(args: CreateEditorArgs): Editor {
 	let persistStateTimer: any = null;
 	let persistRunning = false;
 	let persistQueued = false;
+	let persistPromise: Promise<void> | null = null;
+	let destroyed = false;
+	let editorInstance: Editor | null = null;
 	let currentEditor: Editor | null = null;
 	let lastPersistedMarkdown = normalizePersistedMarkdown(
 		initialMarkdown ?? serializeAst(ast as any),
 	);
 	const persistDebounceMsResolved = persistDebounceMs ?? 0;
+	const persistOnce = async (editor: Editor) => {
+		const markdown = normalizePersistedMarkdown(markdownFromEditorAst(editor));
+		if (markdown === lastPersistedMarkdown) return;
+		await upsertMarkdownFile({
+			lix,
+			fileId: fileId!,
+			markdown,
+			createIfMissing: false,
+		});
+		lastPersistedMarkdown = markdown;
+	};
+	const runPersist = (editor: Editor): Promise<void> => {
+		if (!fileId || !persistState) return Promise.resolve();
+		if (persistRunning) {
+			persistQueued = true;
+			return persistPromise ?? Promise.resolve();
+		}
+		persistRunning = true;
+		persistPromise = (async () => {
+			try {
+				do {
+					persistQueued = false;
+					await persistOnce(editor);
+				} while (persistQueued && !destroyed);
+			} finally {
+				persistRunning = false;
+				persistPromise = null;
+			}
+		})();
+		return persistPromise;
+	};
 
 	const placeholderConfig: any = {
 		placeholder: ({ node }: { node: any }) =>
@@ -105,7 +139,7 @@ export function createEditor(args: CreateEditorArgs): Editor {
 
 	const markdownExtensions = MarkdownWc({}) as any[];
 
-	return new Editor({
+	editorInstance = new Editor({
 		extensions: [
 			...markdownExtensions,
 			History.configure({
@@ -128,45 +162,43 @@ export function createEditor(args: CreateEditorArgs): Editor {
 			onCreate?.({ editor });
 		},
 		onUpdate: ({ editor }) => {
+			if (destroyed) return;
 			if (onUpdate?.({ editor }) === false) return;
 			if (!fileId || !persistState) return;
 			const scheduleRun = () => {
+				if (destroyed) return;
 				if (persistDebounceMsResolved <= 0) {
-					void run();
+					void runPersist(editor);
 					return;
 				}
 				if (persistStateTimer) clearTimeout(persistStateTimer);
 				persistStateTimer = setTimeout(() => {
 					persistStateTimer = null;
-					void run();
+					if (destroyed) return;
+					void runPersist(editor);
 				}, persistDebounceMsResolved);
 			};
-			const run = async () => {
+			scheduleRun();
+		},
+		onDestroy: () => {
+			persistQueued = false;
+			if (persistStateTimer) {
+				clearTimeout(persistStateTimer);
+				persistStateTimer = null;
+			}
+			const editorToPersist = currentEditor ?? editorInstance;
+			if (editorToPersist && fileId && persistState) {
 				if (persistRunning) {
 					persistQueued = true;
-					return;
 				}
-				persistRunning = true;
-				try {
-					const markdown = normalizePersistedMarkdown(
-						markdownFromEditorAst(editor),
-					);
-					if (markdown === lastPersistedMarkdown) return;
-					await upsertMarkdownFile({
-						lix,
-						fileId,
-						markdown,
-					});
-					lastPersistedMarkdown = markdown;
-				} finally {
-					persistRunning = false;
-					if (persistQueued) {
-						persistQueued = false;
-						scheduleRun();
-					}
-				}
-			};
-			scheduleRun();
+				void runPersist(editorToPersist).finally(() => {
+					destroyed = true;
+					currentEditor = null;
+				});
+			} else {
+				destroyed = true;
+				currentEditor = null;
+			}
 		},
 		editorProps: {
 			handlePaste: async (_view: any, event: ClipboardEvent) => {
@@ -179,6 +211,8 @@ export function createEditor(args: CreateEditorArgs): Editor {
 			...editorProps,
 		},
 	});
+	currentEditor = editorInstance;
+	return editorInstance;
 }
 
 // React useEditor config builder. TipTapEditor should use this to keep a single source.

--- a/src/extensions/markdown/editor/upsert-markdown-file.ts
+++ b/src/extensions/markdown/editor/upsert-markdown-file.ts
@@ -8,11 +8,18 @@ export async function upsertMarkdownFile(args: {
 	markdown: string;
 	path?: string;
 	metadata?: any;
+	createIfMissing?: boolean;
 }): Promise<void> {
-	const { lix, fileId, markdown, path, metadata } = args;
+	const {
+		lix,
+		fileId,
+		markdown,
+		path,
+		metadata,
+		createIfMissing = true,
+	} = args;
 	const data = new TextEncoder().encode(markdown);
 	const db = qb(lix);
-	markFlashtypeMarkdownWrite(fileId, markdown);
 
 	const existing = await db
 		.selectFrom("lix_file")
@@ -21,6 +28,7 @@ export async function upsertMarkdownFile(args: {
 		.executeTakeFirst();
 
 	if (existing) {
+		markFlashtypeMarkdownWrite(fileId, markdown);
 		const resolvedPath = path ?? existing.path ?? `/${fileId}.md`;
 		const resolvedMetadata = metadata ?? existing.lixcol_metadata ?? null;
 		await db
@@ -33,6 +41,8 @@ export async function upsertMarkdownFile(args: {
 			.where("id", "=", fileId)
 			.execute();
 	} else {
+		if (!createIfMissing) return;
+		markFlashtypeMarkdownWrite(fileId, markdown);
 		// Insert requires a path; use provided or fallback to /<fileId>.md
 		await db
 			.insertInto("lix_file")

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -1063,6 +1063,38 @@ function LayoutShellContent({
 		[setPanelState],
 	);
 
+	const handleCloseFileViews = useCallback(
+		({ panel, fileId }: { panel?: PanelSide; fileId: string }) => {
+			const targetPanels: PanelSide[] = panel
+				? [panel]
+				: (["central", "left", "right"] as PanelSide[]);
+			const matchesFileView = (entry: ExtensionInstance) => {
+				if (entry.state?.fileId !== fileId) return false;
+				if (typeof entry.state.filePath !== "string") return false;
+				return (
+					entry.instance === fileExtensionInstanceForKind(entry.kind, fileId)
+				);
+			};
+			for (const side of targetPanels) {
+				setPanelState(side, (current) => {
+					const views = current.views.filter(
+						(entry) => !matchesFileView(entry),
+					);
+					if (views.length === current.views.length) {
+						return current;
+					}
+					const activeInstance = views.some(
+						(entry) => entry.instance === current.activeInstance,
+					)
+						? current.activeInstance
+						: (views[views.length - 1]?.instance ?? null);
+					return { views, activeInstance };
+				});
+			}
+		},
+		[setPanelState],
+	);
+
 	const handleAddView = useCallback(
 		(side: PanelSide, kind: ExtensionKind, state?: ExtensionState) => {
 			// Multi-instance kinds (agent terminals) get a fresh instance per
@@ -1452,6 +1484,7 @@ function LayoutShellContent({
 			openExtension: handleOpenView,
 			openFile: handleOpenFile,
 			closeExtension: handleCloseView,
+			closeFileViews: handleCloseFileViews,
 			setTabBadgeCount: () => {},
 			moveExtensionToPanel: handleMoveViewToPanel,
 			resizePanel: handleResizePanel,
@@ -1464,6 +1497,7 @@ function LayoutShellContent({
 			handleOpenView,
 			handleOpenFile,
 			handleCloseView,
+			handleCloseFileViews,
 			handleMoveViewToPanel,
 			handleResizePanel,
 			handleAcceptExternalWriteReview,


### PR DESCRIPTION
## Summary

- Close any open file-view instances when the corresponding file is deleted from the file navigator.
- Track the selected file id directly in the Files view so newly created files can be deleted without leaving stale editor views.
- Cancel pending markdown autosaves on editor destroy and prevent autosave from recreating deleted files.
- Add a patch changenote and regression coverage for the file-delete cleanup path.

## Validation

- `pnpm vitest run src/extensions/files/index.test.tsx src/extensions/markdown/editor/create-editor.test.ts`
- `pnpm oxlint --tsconfig ./tsconfig.json --ignore-path .gitignore src/extensions/files/index.tsx src/extensions/files/index.test.tsx src/extension-runtime/types.ts src/shell/layout-shell.tsx e2e/files-click-tour.spec.ts e2e/electron-test-utils.ts playwright.config.ts src/extensions/markdown/editor/create-editor.ts src/extensions/markdown/editor/upsert-markdown-file.ts src/extensions/markdown/editor/create-editor.test.ts`
- `pnpm typecheck`
- `FLASHTYPE_E2E_RENDERER_PORT=5177 pnpm exec playwright test e2e/files-click-tour.spec.ts -g "deleting the active file closes the central file view"`
- Manual Electron replay on port `5177`: deleting open `stale.md` removed the file tree item, closed the active file view, showed the central empty state, and removed stale content from the DOM.

## Notes

The e2e renderer port is now configurable through `FLASHTYPE_E2E_RENDERER_PORT` so local Playwright runs do not accidentally reuse another Flashtype checkout already running on `4173`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches file deletion, panel view lifecycle, and markdown autosave on editor destroy—user-visible editor state and lix file rows, with regression tests but not security-critical paths.
> 
> **Overview**
> Deleting a file from the **Files** navigator now closes any open editor tab for that file and returns the central panel to the empty state, instead of leaving stale content visible.
> 
> The Files view tracks **`selectedFileId`** (not just path) so deletes right after creating a file still invoke **`closeFileViews`**. The layout shell implements that hook by removing matching file-view instances across panels. Markdown persistence was tightened so **destroy** flushes debounced saves for existing rows but **`upsertMarkdownFile`** no longer re-inserts a file that was already deleted.
> 
> E2E Playwright can use **`FLASHTYPE_E2E_RENDERER_PORT`** to avoid port clashes; a regression test covers delete-with-active-file. A patch changenote documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be732daf11b17346eb4da3a66055b3e066abc3fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->