### PR TITLE
Improve markdown review diffs

### DIFF
--- a/src/extension-runtime/external-write-review.ts
+++ b/src/extension-runtime/external-write-review.ts
@@ -4,6 +4,8 @@ export type ExternalWriteReview = {
 	readonly reviewId: string;
 	readonly beforeData: Uint8Array;
 	readonly afterData: Uint8Array;
+	readonly beforeCommitId?: string;
+	readonly afterCommitId?: string;
 	readonly beforeDepth?: number;
 	readonly afterDepth?: number;
 };

--- a/src/extensions/markdown/diff-fixtures/block-media-link.after.md
+++ b/src/extensions/markdown/diff-fixtures/block-media-link.after.md
@@ -1,0 +1,23 @@
+## Metrics renamed
+
+The docs live at <https://example.com/guides> and <help@example.com>.
+
+![New dashboard](https://example.com/dashboard-new.png "New title")
+
+---
+
+# Launch notes
+
+```ts
+export const enabled = true;
+```
+
+> Keep **strong signal** and [support link](https://example.com/help).
+> Nested _quote detail_ stays focused.
+> Add `owner` callout.
+
+Use <kbd>Ctrl</kbd> + `K` for search and <span data-kind="badge">stable</span>.
+
+<section data-panel="new">
+Raw block content plus owner
+</section>

--- a/src/extensions/markdown/diff-fixtures/block-media-link.before.md
+++ b/src/extensions/markdown/diff-fixtures/block-media-link.before.md
@@ -1,0 +1,22 @@
+# Launch notes
+
+![Old dashboard](https://example.com/dashboard-old.png "Old title")
+
+---
+
+## Metrics
+
+```js
+export const enabled = false;
+```
+
+> Keep **bold signal** and [support link](https://example.com/support).
+> Nested _quote detail_ stays calm.
+
+The docs live at <https://example.com/docs> and <team@example.com>.
+
+Use <kbd>Cmd</kbd> + `K` for search and <span data-kind="badge">beta</span>.
+
+<section data-panel="old">
+Raw block content
+</section>

--- a/src/extensions/markdown/diff-fixtures/block-structure-moves.after.md
+++ b/src/extensions/markdown/diff-fixtures/block-structure-moves.after.md
@@ -1,0 +1,43 @@
+## Overview
+
+Shared paragraph.
+
+Repeated heading
+
+Keep the same repeated paragraph.
+
+### Details
+
+Paragraph before list.
+
+- Keep list item
+- Move list with paragraph boundary
+- Add list item between paragraphs
+
+Move this paragraph below the checklist.
+
+Paragraph after list.
+
+> Parent quote stays.
+>
+> > Nested quote detail stays focused.
+> >
+> > Nested quote owner added.
+
+```ts
+console.log("keep");
+```
+
+---
+
+<section>
+Add this HTML block.
+</section>
+
+Repeated heading
+
+Keep the same repeated paragraph.
+
+```sh
+echo "new fence"
+```

--- a/src/extensions/markdown/diff-fixtures/block-structure-moves.before.md
+++ b/src/extensions/markdown/diff-fixtures/block-structure-moves.before.md
@@ -1,0 +1,40 @@
+# Overview
+
+Shared paragraph.
+
+Move this paragraph below the checklist.
+
+## Details
+
+Repeated heading
+
+Keep the same repeated paragraph.
+
+> Parent quote stays.
+>
+> > Nested quote detail stays calm.
+
+```js
+console.log("keep");
+```
+
+```ts
+console.log("remove me");
+```
+
+---
+
+Paragraph before list.
+
+- Keep list item
+- Move list with paragraph boundary
+
+Paragraph after list.
+
+<aside>
+Remove this HTML block.
+</aside>
+
+Repeated heading
+
+Keep the same repeated paragraph.

--- a/src/extensions/markdown/diff-fixtures/duplicate-task-list.after.md
+++ b/src/extensions/markdown/diff-fixtures/duplicate-task-list.after.md
@@ -1,0 +1,13 @@
+# Duplicate task list
+
+- [ ] Prep
+  - [ ] Confirm venue
+  - [x] Invite reviewers
+  - [ ] Confirm venue
+- [ ] Prep
+  - [x] Confirm venue
+  - [ ] Pack demo kit
+  - [ ] Book rehearsal room
+- [x] Publish
+  - [ ] Send announcement
+  - [ ] Update docs

--- a/src/extensions/markdown/diff-fixtures/duplicate-task-list.before.md
+++ b/src/extensions/markdown/diff-fixtures/duplicate-task-list.before.md
@@ -1,0 +1,12 @@
+# Duplicate task list
+
+- [ ] Prep
+  - [ ] Confirm venue
+  - [x] Confirm venue
+  - [ ] Pack demo kit
+- [x] Publish
+  - [x] Send announcement
+  - [ ] Update docs
+- [ ] Prep
+  - [ ] Confirm venue
+  - [ ] Invite reviewers

--- a/src/extensions/markdown/diff-fixtures/gfm-edge-blocks.after.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-edge-blocks.after.md
@@ -1,0 +1,16 @@
+```ts
+const route = "/launch";
+return fetch(route, { cache: "no-store" });
+```
+
+> Keep the customer quote.
+> Ship the revised onboarding checklist.
+> Add a rollout owner.
+
+<aside data-kind="tip">
+Keep a short migration note and link to support.
+</aside>
+
+~~Deprecated: private beta~~
+
+See <https://example.com/guides>.

--- a/src/extensions/markdown/diff-fixtures/gfm-edge-blocks.before.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-edge-blocks.before.md
@@ -1,0 +1,15 @@
+```ts
+const route = "/draft";
+return fetch(route);
+```
+
+> Keep the customer quote.
+> Ship the current onboarding checklist.
+
+<aside data-kind="tip">
+Keep a short migration note.
+</aside>
+
+~~Deprecated: invite-only beta~~
+
+See <https://example.com/docs>.

--- a/src/extensions/markdown/diff-fixtures/gfm-table-inline.after.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-table-inline.after.md
@@ -1,0 +1,6 @@
+| Segment |   Status    |                              Owner Link | Validation                |
+| :------ | :---------: | --------------------------------------: | ------------------------- |
+| North   |  **Ready**  | [Ada Lovelace](https://example.com/ada) | Run `full` pass           |
+| South   |  _Blocked_  |          [Ben](https://example.com/ben) | Needs `api` and `db` key  |
+| West    | **Shipped** |            [Cy](https://example.com/cy) | Watch latency             |
+| East    | ~~Paused~~  |           [Dee](https://example.com/v2) | Keep `cache` and _parser_ |

--- a/src/extensions/markdown/diff-fixtures/gfm-table-inline.before.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-table-inline.before.md
@@ -1,0 +1,6 @@
+| Segment |   Status    |                     Owner Link | Validation                |
+| :------ | :---------: | -----------------------------: | ------------------------- |
+| North   |  **Draft**  | [Ada](https://example.com/ada) | Run `smoke` pass          |
+| South   |  _Blocked_  | [Ben](https://example.com/ben) | Needs `api` key           |
+| West    | **Shipped** |   [Cy](https://example.com/cy) | Watch latency             |
+| East    | ~~Paused~~  |  [Dee](https://example.com/v1) | Keep `cache` and _parser_ |

--- a/src/extensions/markdown/diff-fixtures/gfm-table-rows.after.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-table-rows.after.md
@@ -1,0 +1,7 @@
+| Area    | Owner | State       | Notes                   |
+| ------- | ----- | ----------- | ----------------------- |
+| Beta    | Noe   | In progress | Move this row unchanged |
+| Alpha   | Mia   | Planned     | Keep copy stable        |
+| Epsilon | Val   | New         | Insert this row         |
+| Alpha   | Rae   | At risk     | Duplicate label remains |
+| Delta   | Uma   | Queued      | Keep second stable cell |

--- a/src/extensions/markdown/diff-fixtures/gfm-table-rows.before.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-table-rows.before.md
@@ -1,0 +1,7 @@
+| Area  | Owner | State       | Notes                   |
+| ----- | ----- | ----------- | ----------------------- |
+| Alpha | Mia   | Planned     | Keep copy stable        |
+| Beta  | Noe   | In progress | Move this row unchanged |
+| Alpha | Rae   | At risk     | Duplicate label remains |
+| Gamma | Sol   | Done        | Remove this row         |
+| Delta | Uma   | Queued      | Keep second stable cell |

--- a/src/extensions/markdown/diff-fixtures/gfm-table-structure.after.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-table-structure.after.md
@@ -1,0 +1,8 @@
+| Item       | Priority | Owner | Notes                                   | Status |
+| ---------- | -------- | ----- | --------------------------------------- | ------ |
+| Duplicate  | medium   | Rae   | First duplicate keeps same note         | green  |
+| Pipe demo  | medium   | Noe   | Escaped \| pipe and `a \| c` code       | yellow |
+| Alpha      | high     | Mia   | Filled empty cell                       | green  |
+| Duplicate  | low      | Sol   | Second duplicate gets a modified note   | red    |
+| Remove col | medium   | Uma   | Column removal keeps row identity       | green  |
+| New row    | high     | Val   | Inserted row with changed-ready content | blue   |

--- a/src/extensions/markdown/diff-fixtures/gfm-table-structure.before.md
+++ b/src/extensions/markdown/diff-fixtures/gfm-table-structure.before.md
@@ -1,0 +1,7 @@
+| Item       | Owner | Notes                             | Legacy |
+| ---------- | ----- | --------------------------------- | ------ |
+| Alpha      | Mia   |                                   | keep   |
+| Pipe demo  | Noe   | Escaped \| pipe and `a \| b` code | drop   |
+| Duplicate  | Rae   | First duplicate keeps same note   | stay   |
+| Duplicate  | Sol   | Second duplicate will be edited   | stay   |
+| Remove col | Uma   | Column removal keeps row identity | old    |

--- a/src/extensions/markdown/diff-fixtures/index.ts
+++ b/src/extensions/markdown/diff-fixtures/index.ts
@@ -1,0 +1,820 @@
+import quickFactsBefore from "./quick-facts-list.before.md?raw";
+import quickFactsAfter from "./quick-facts-list.after.md?raw";
+import planTableBefore from "./plan-table.before.md?raw";
+import planTableAfter from "./plan-table.after.md?raw";
+import gfmTableInlineBefore from "./gfm-table-inline.before.md?raw";
+import gfmTableInlineAfter from "./gfm-table-inline.after.md?raw";
+import gfmTableRowsBefore from "./gfm-table-rows.before.md?raw";
+import gfmTableRowsAfter from "./gfm-table-rows.after.md?raw";
+import gfmTableStructureBefore from "./gfm-table-structure.before.md?raw";
+import gfmTableStructureAfter from "./gfm-table-structure.after.md?raw";
+import releaseChecklistBefore from "./release-checklist.before.md?raw";
+import releaseChecklistAfter from "./release-checklist.after.md?raw";
+import duplicateTaskListBefore from "./duplicate-task-list.before.md?raw";
+import duplicateTaskListAfter from "./duplicate-task-list.after.md?raw";
+import gfmEdgeBlocksBefore from "./gfm-edge-blocks.before.md?raw";
+import gfmEdgeBlocksAfter from "./gfm-edge-blocks.after.md?raw";
+import blockMediaLinkBefore from "./block-media-link.before.md?raw";
+import blockMediaLinkAfter from "./block-media-link.after.md?raw";
+import blockStructureMovesBefore from "./block-structure-moves.before.md?raw";
+import blockStructureMovesAfter from "./block-structure-moves.after.md?raw";
+import mixedGfmDocumentBefore from "./mixed-gfm-document.before.md?raw";
+import mixedGfmDocumentAfter from "./mixed-gfm-document.after.md?raw";
+import inlineMediaLinkBefore from "./inline-media-link.before.md?raw";
+import inlineMediaLinkAfter from "./inline-media-link.after.md?raw";
+import type { MarkdownBlockSnapshot } from "../review-diff";
+
+export type MarkdownDiffFixture = {
+	readonly id: string;
+	readonly title: string;
+	readonly beforeMarkdown: string;
+	readonly afterMarkdown: string;
+	readonly beforeBlocks: readonly MarkdownBlockSnapshot[];
+	readonly afterBlocks: readonly MarkdownBlockSnapshot[];
+};
+
+export const MARKDOWN_DIFF_FIXTURES: readonly MarkdownDiffFixture[] = [
+	{
+		id: "quick-facts-list",
+		title: "Quick Facts list item edit and add",
+		beforeMarkdown: quickFactsBefore,
+		afterMarkdown: quickFactsAfter,
+		beforeBlocks: [
+			{
+				id: "quick_facts_list",
+				orderKey: "40",
+				block: quickFactsBefore.trimEnd(),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "quick_facts_list",
+				orderKey: "40",
+				block: quickFactsAfter.trimEnd(),
+			},
+		],
+	},
+	{
+		id: "plan-table",
+		title: "Plan table cell edits",
+		beforeMarkdown: planTableBefore,
+		afterMarkdown: planTableAfter,
+		beforeBlocks: [
+			{
+				id: "plan_table",
+				orderKey: "80",
+				block: planTableBefore.trimEnd(),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "plan_table",
+				orderKey: "80",
+				block: planTableAfter.trimEnd(),
+			},
+		],
+	},
+	{
+		id: "gfm-table-inline",
+		title: "GFM table inline formatting edits",
+		beforeMarkdown: gfmTableInlineBefore,
+		afterMarkdown: gfmTableInlineAfter,
+		beforeBlocks: [
+			{
+				id: "gfm_table_inline",
+				orderKey: "120",
+				block: gfmTableInlineBefore.trimEnd(),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "gfm_table_inline",
+				orderKey: "120",
+				block: gfmTableInlineAfter.trimEnd(),
+			},
+		],
+	},
+	{
+		id: "gfm-table-rows",
+		title: "GFM table row reorder, add, remove, and duplicate labels",
+		beforeMarkdown: gfmTableRowsBefore,
+		afterMarkdown: gfmTableRowsAfter,
+		beforeBlocks: [
+			{
+				id: "gfm_table_rows",
+				orderKey: "140",
+				block: gfmTableRowsBefore.trimEnd(),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "gfm_table_rows",
+				orderKey: "140",
+				block: gfmTableRowsAfter.trimEnd(),
+			},
+		],
+	},
+	{
+		id: "gfm-table-structure",
+		title: "GFM table column changes, empty cells, and pipe literals",
+		beforeMarkdown: gfmTableStructureBefore,
+		afterMarkdown: gfmTableStructureAfter,
+		beforeBlocks: [
+			{
+				id: "gfm_table_structure",
+				orderKey: "160",
+				block: gfmTableStructureBefore.trimEnd(),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "gfm_table_structure",
+				orderKey: "160",
+				block: gfmTableStructureAfter.trimEnd(),
+			},
+		],
+	},
+	{
+		id: "release-checklist",
+		title: "Task list checked state and nested item edits",
+		beforeMarkdown: releaseChecklistBefore,
+		afterMarkdown: releaseChecklistAfter,
+		beforeBlocks: [
+			{
+				id: "release_checklist_heading",
+				orderKey: "40",
+				block: "# Release checklist",
+			},
+			{
+				id: "release_checklist_tasks",
+				orderKey: "80",
+				block: releaseChecklistBefore
+					.replace(/^# Release checklist\n\n/, "")
+					.trimEnd(),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "release_checklist_heading",
+				orderKey: "40",
+				block: "# Release checklist",
+			},
+			{
+				id: "release_checklist_tasks",
+				orderKey: "80",
+				block: releaseChecklistAfter
+					.replace(/^# Release checklist\n\n/, "")
+					.trimEnd(),
+			},
+		],
+	},
+	{
+		id: "duplicate-task-list",
+		title: "Duplicate task labels, reorder, and nested task edits",
+		beforeMarkdown: duplicateTaskListBefore,
+		afterMarkdown: duplicateTaskListAfter,
+		beforeBlocks: [
+			{
+				id: "duplicate_task_list_heading",
+				orderKey: "40",
+				block: "# Duplicate task list",
+			},
+			{
+				id: "duplicate_task_list_tasks",
+				orderKey: "80",
+				block: duplicateTaskListBefore
+					.replace(/^# Duplicate task list\n\n/, "")
+					.trimEnd(),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "duplicate_task_list_heading",
+				orderKey: "40",
+				block: "# Duplicate task list",
+			},
+			{
+				id: "duplicate_task_list_tasks",
+				orderKey: "80",
+				block: duplicateTaskListAfter
+					.replace(/^# Duplicate task list\n\n/, "")
+					.trimEnd(),
+			},
+		],
+	},
+	{
+		id: "gfm-edge-blocks",
+		title: "GFM edge block edits",
+		beforeMarkdown: gfmEdgeBlocksBefore,
+		afterMarkdown: gfmEdgeBlocksAfter,
+		beforeBlocks: [
+			{
+				id: "gfm_code_fence",
+				orderKey: "40",
+				block: [
+					"```ts",
+					'const route = "/draft";',
+					"return fetch(route);",
+					"```",
+				].join("\n"),
+			},
+			{
+				id: "gfm_blockquote",
+				orderKey: "80",
+				block: [
+					"> Keep the customer quote.",
+					"> Ship the current onboarding checklist.",
+				].join("\n"),
+			},
+			{
+				id: "gfm_raw_html",
+				orderKey: "120",
+				block: [
+					'<aside data-kind="tip">',
+					"Keep a short migration note.",
+					"</aside>",
+				].join("\n"),
+			},
+			{
+				id: "gfm_strikethrough",
+				orderKey: "160",
+				block: "~~Deprecated: invite-only beta~~",
+			},
+			{
+				id: "gfm_autolink",
+				orderKey: "200",
+				block: "See <https://example.com/docs>.",
+			},
+		],
+		afterBlocks: [
+			{
+				id: "gfm_code_fence",
+				orderKey: "40",
+				block: [
+					"```ts",
+					'const route = "/launch";',
+					'return fetch(route, { cache: "no-store" });',
+					"```",
+				].join("\n"),
+			},
+			{
+				id: "gfm_blockquote",
+				orderKey: "80",
+				block: [
+					"> Keep the customer quote.",
+					"> Ship the revised onboarding checklist.",
+					"> Add a rollout owner.",
+				].join("\n"),
+			},
+			{
+				id: "gfm_raw_html",
+				orderKey: "120",
+				block: [
+					'<aside data-kind="tip">',
+					"Keep a short migration note and link to support.",
+					"</aside>",
+				].join("\n"),
+			},
+			{
+				id: "gfm_strikethrough",
+				orderKey: "160",
+				block: "~~Deprecated: private beta~~",
+			},
+			{
+				id: "gfm_autolink",
+				orderKey: "200",
+				block: "See <https://example.com/guides>.",
+			},
+		],
+	},
+	{
+		id: "block-media-link",
+		title: "Block, media, link, and HTML edits",
+		beforeMarkdown: blockMediaLinkBefore,
+		afterMarkdown: blockMediaLinkAfter,
+		beforeBlocks: [
+			{
+				id: "launch_heading",
+				orderKey: "40",
+				block: "# Launch notes",
+			},
+			{
+				id: "dashboard_image",
+				orderKey: "80",
+				block:
+					'![Old dashboard](https://example.com/dashboard-old.png "Old title")',
+			},
+			{
+				id: "theme_break",
+				orderKey: "120",
+				block: "---",
+			},
+			{
+				id: "metrics_heading",
+				orderKey: "160",
+				block: "## Metrics",
+			},
+			{
+				id: "language_fence",
+				orderKey: "200",
+				block: ["```js", "export const enabled = false;", "```"].join("\n"),
+			},
+			{
+				id: "nested_quote",
+				orderKey: "240",
+				block: [
+					"> Keep **bold signal** and [support link](https://example.com/support).",
+					"> Nested _quote detail_ stays calm.",
+				].join("\n"),
+			},
+			{
+				id: "autolinks",
+				orderKey: "280",
+				block:
+					"The docs live at <https://example.com/docs> and <team@example.com>.",
+			},
+			{
+				id: "inline_html",
+				orderKey: "320",
+				block:
+					'Use <kbd>Cmd</kbd> + `K` for search and <span data-kind="badge">beta</span>.',
+			},
+			{
+				id: "raw_html_block",
+				orderKey: "360",
+				block: [
+					'<section data-panel="old">',
+					"Raw block content",
+					"</section>",
+				].join("\n"),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "metrics_heading",
+				orderKey: "40",
+				block: "## Metrics renamed",
+			},
+			{
+				id: "autolinks",
+				orderKey: "80",
+				block:
+					"The docs live at <https://example.com/guides> and <help@example.com>.",
+			},
+			{
+				id: "dashboard_image",
+				orderKey: "120",
+				block:
+					'![New dashboard](https://example.com/dashboard-new.png "New title")',
+			},
+			{
+				id: "theme_break",
+				orderKey: "160",
+				block: "***",
+			},
+			{
+				id: "launch_heading",
+				orderKey: "200",
+				block: "# Launch notes",
+			},
+			{
+				id: "language_fence",
+				orderKey: "240",
+				block: ["```ts", "export const enabled = true;", "```"].join("\n"),
+			},
+			{
+				id: "nested_quote",
+				orderKey: "280",
+				block: [
+					"> Keep **strong signal** and [support link](https://example.com/help).",
+					"> Nested _quote detail_ stays focused.",
+					"> Add `owner` callout.",
+				].join("\n"),
+			},
+			{
+				id: "inline_html",
+				orderKey: "320",
+				block:
+					'Use <kbd>Ctrl</kbd> + `K` for search and <span data-kind="badge">stable</span>.',
+			},
+			{
+				id: "raw_html_block",
+				orderKey: "360",
+				block: [
+					'<section data-panel="new">',
+					"Raw block content plus owner",
+					"</section>",
+				].join("\n"),
+			},
+		],
+	},
+	{
+		id: "block-structure-moves",
+		title: "Block moves, repeated text, and structural add/remove cases",
+		beforeMarkdown: blockStructureMovesBefore,
+		afterMarkdown: blockStructureMovesAfter,
+		beforeBlocks: [
+			{
+				id: "overview_heading",
+				orderKey: "40",
+				block: "# Overview",
+			},
+			{
+				id: "shared_paragraph",
+				orderKey: "80",
+				block: "Shared paragraph.",
+			},
+			{
+				id: "moved_paragraph",
+				orderKey: "120",
+				block: "Move this paragraph below the checklist.",
+			},
+			{
+				id: "details_heading",
+				orderKey: "160",
+				block: "## Details",
+			},
+			{
+				id: "repeated_heading_first",
+				orderKey: "200",
+				block: "Repeated heading",
+			},
+			{
+				id: "repeated_paragraph_first",
+				orderKey: "240",
+				block: "Keep the same repeated paragraph.",
+			},
+			{
+				id: "nested_blockquote",
+				orderKey: "280",
+				block: [
+					"> Parent quote stays.",
+					">",
+					"> > Nested quote detail stays calm.",
+				].join("\n"),
+			},
+			{
+				id: "changed_language_fence",
+				orderKey: "320",
+				block: ["```js", 'console.log("keep");', "```"].join("\n"),
+			},
+			{
+				id: "removed_code_fence",
+				orderKey: "360",
+				block: ["```ts", 'console.log("remove me");', "```"].join("\n"),
+			},
+			{
+				id: "changed_theme_break",
+				orderKey: "400",
+				block: "---",
+			},
+			{
+				id: "paragraph_before_list",
+				orderKey: "440",
+				block: "Paragraph before list.",
+			},
+			{
+				id: "list_between_paragraphs",
+				orderKey: "480",
+				block: ["- Keep list item", "- Move list with paragraph boundary"].join(
+					"\n",
+				),
+			},
+			{
+				id: "paragraph_after_list",
+				orderKey: "520",
+				block: "Paragraph after list.",
+			},
+			{
+				id: "removed_html_block",
+				orderKey: "560",
+				block: ["<aside>", "Remove this HTML block.", "</aside>"].join("\n"),
+			},
+			{
+				id: "repeated_heading_second",
+				orderKey: "600",
+				block: "Repeated heading",
+			},
+			{
+				id: "repeated_paragraph_second",
+				orderKey: "640",
+				block: "Keep the same repeated paragraph.",
+			},
+		],
+		afterBlocks: [
+			{
+				id: "overview_heading",
+				orderKey: "40",
+				block: "## Overview",
+			},
+			{
+				id: "shared_paragraph",
+				orderKey: "80",
+				block: "Shared paragraph.",
+			},
+			{
+				id: "repeated_heading_first",
+				orderKey: "120",
+				block: "Repeated heading",
+			},
+			{
+				id: "repeated_paragraph_first",
+				orderKey: "160",
+				block: "Keep the same repeated paragraph.",
+			},
+			{
+				id: "details_heading",
+				orderKey: "200",
+				block: "### Details",
+			},
+			{
+				id: "paragraph_before_list",
+				orderKey: "240",
+				block: "Paragraph before list.",
+			},
+			{
+				id: "list_between_paragraphs",
+				orderKey: "280",
+				block: [
+					"- Keep list item",
+					"- Move list with paragraph boundary",
+					"- Add list item between paragraphs",
+				].join("\n"),
+			},
+			{
+				id: "moved_paragraph",
+				orderKey: "320",
+				block: "Move this paragraph below the checklist.",
+			},
+			{
+				id: "paragraph_after_list",
+				orderKey: "360",
+				block: "Paragraph after list.",
+			},
+			{
+				id: "nested_blockquote",
+				orderKey: "400",
+				block: [
+					"> Parent quote stays.",
+					">",
+					"> > Nested quote detail stays focused.",
+					"> >",
+					"> > Nested quote owner added.",
+				].join("\n"),
+			},
+			{
+				id: "changed_language_fence",
+				orderKey: "440",
+				block: ["```ts", 'console.log("keep");', "```"].join("\n"),
+			},
+			{
+				id: "changed_theme_break",
+				orderKey: "480",
+				block: "***",
+			},
+			{
+				id: "added_html_block",
+				orderKey: "520",
+				block: ["<section>", "Add this HTML block.", "</section>"].join("\n"),
+			},
+			{
+				id: "repeated_heading_second",
+				orderKey: "560",
+				block: "Repeated heading",
+			},
+			{
+				id: "repeated_paragraph_second",
+				orderKey: "600",
+				block: "Keep the same repeated paragraph.",
+			},
+			{
+				id: "added_code_fence",
+				orderKey: "640",
+				block: ["```sh", 'echo "new fence"', "```"].join("\n"),
+			},
+		],
+	},
+	{
+		id: "mixed-gfm-document",
+		title: "Mixed GFM document table, list, code, and links",
+		beforeMarkdown: mixedGfmDocumentBefore,
+		afterMarkdown: mixedGfmDocumentAfter,
+		beforeBlocks: [
+			{
+				id: "mixed_launch_heading",
+				orderKey: "40",
+				block: "# Launch review",
+			},
+			{
+				id: "mixed_link_paragraph",
+				orderKey: "80",
+				block:
+					"Read the [runbook](https://example.com/runbook) and ping <ops@example.com>.",
+			},
+			{
+				id: "mixed_table",
+				orderKey: "120",
+				block: [
+					"| Area | Owner | Status |",
+					"| --- | --- | --- |",
+					"| API | Dee | Ready |",
+					"| Web | Mo | Draft |",
+				].join("\n"),
+			},
+			{
+				id: "mixed_task_list",
+				orderKey: "160",
+				block: [
+					"- [x] Confirm launch owner",
+					"- [ ] Update docs",
+					"  - Keep migration note",
+					"  - Verify search index",
+				].join("\n"),
+			},
+			{
+				id: "mixed_code_fence",
+				orderKey: "200",
+				block: [
+					"```ts",
+					'export const rollout = "staged";',
+					'notify("ops");',
+					"```",
+				].join("\n"),
+			},
+		],
+		afterBlocks: [
+			{
+				id: "mixed_launch_heading",
+				orderKey: "40",
+				block: "# Launch review",
+			},
+			{
+				id: "mixed_link_paragraph",
+				orderKey: "80",
+				block:
+					"Read the [runbook](https://example.com/runbook-v2) and ping <ops@example.com>.",
+			},
+			{
+				id: "mixed_table",
+				orderKey: "120",
+				block: [
+					"| Area | Owner | Status |",
+					"| --- | --- | --- |",
+					"| API | Dee | Ready |",
+					"| Web | Mo | Approved |",
+					"| Billing | Ada | Watching |",
+				].join("\n"),
+			},
+			{
+				id: "mixed_task_list",
+				orderKey: "160",
+				block: [
+					"- [x] Confirm launch owner",
+					"- [x] Update docs",
+					"  - Keep migration note",
+					"  - Verify search index",
+					"  - Add rollback note",
+				].join("\n"),
+			},
+			{
+				id: "mixed_code_fence",
+				orderKey: "200",
+				block: [
+					"```ts",
+					'export const rollout = "global";',
+					'notify("ops");',
+					'notify("support");',
+					"```",
+				].join("\n"),
+			},
+		],
+	},
+	{
+		id: "inline-media-link",
+		title: "Inline media, reference links, autolinks, escapes, and breaks",
+		beforeMarkdown: inlineMediaLinkBefore,
+		afterMarkdown: inlineMediaLinkAfter,
+		beforeBlocks: [
+			{
+				id: "inline_media_link_heading",
+				orderKey: "40",
+				block: "# Inline media and links",
+			},
+			{
+				id: "inline_punctuation",
+				orderKey: "80",
+				block:
+					"Opening line keeps emoji :) around **bold**, `code`, ~~strike~~, and punctuation!",
+			},
+			{
+				id: "inline_links",
+				orderKey: "120",
+				block:
+					"Change [Docs](https://example.com/docs) text, but keep [API](https://example.com/api-v1) text with a URL-only edit.",
+			},
+			{
+				id: "reference_links",
+				orderKey: "160",
+				block: [
+					"Reference [Guide][guide-v1] and logo ![Reference logo][logo-v1].",
+					"",
+					"[guide-v1]: https://example.com/guide-v1",
+					'[logo-v1]: https://example.com/logo-v1.png "Logo v1"',
+				].join("\n"),
+			},
+			{
+				id: "bare_autolinks",
+				orderKey: "200",
+				block:
+					"Bare links: https://example.com/bare-v1 and ops-v1@example.com.",
+			},
+			{
+				id: "escaped_markdown",
+				orderKey: "240",
+				block: String.raw`Escaped markdown: \*literal stars\* and \[literal link\].`,
+			},
+			{
+				id: "breaks",
+				orderKey: "280",
+				block: [
+					"Soft break stays here",
+					"with the next line, and hard break stays here  ",
+					"with the forced line.",
+				].join("\n"),
+			},
+			{
+				id: "removed_image",
+				orderKey: "320",
+				block:
+					'![Removed chart](https://example.com/chart-old.png "Removed title")',
+			},
+			{
+				id: "changed_image",
+				orderKey: "360",
+				block:
+					'![Screenshot old alt](https://example.com/screenshot.png "Old screenshot title")',
+			},
+		],
+		afterBlocks: [
+			{
+				id: "inline_media_link_heading",
+				orderKey: "40",
+				block: "# Inline media and links",
+			},
+			{
+				id: "inline_punctuation",
+				orderKey: "80",
+				block:
+					"Opening line keeps emoji :) around **strong**, `snippet`, ~~retired~~, and punctuation?",
+			},
+			{
+				id: "inline_links",
+				orderKey: "120",
+				block:
+					"Change [Guides](https://example.com/docs) text, but keep [API](https://example.com/api-v2) text with a URL-only edit.",
+			},
+			{
+				id: "reference_links",
+				orderKey: "160",
+				block: [
+					"Reference [Guidebook][guide-v2] and logo ![Reference logo new][logo-v2].",
+					"",
+					"[guide-v2]: https://example.com/guide-v2",
+					'[logo-v2]: https://example.com/logo-v2.png "Logo v2"',
+				].join("\n"),
+			},
+			{
+				id: "bare_autolinks",
+				orderKey: "200",
+				block:
+					"Bare links: https://example.com/bare-v2 and ops-v2@example.com.",
+			},
+			{
+				id: "escaped_markdown",
+				orderKey: "240",
+				block: String.raw`Escaped markdown: \*literal asterisks\* and \[literal reference\].`,
+			},
+			{
+				id: "breaks",
+				orderKey: "280",
+				block: [
+					"Soft break stays here",
+					"with the next line updated, and hard break stays here  ",
+					"with the forced line updated.",
+				].join("\n"),
+			},
+			{
+				id: "added_image",
+				orderKey: "320",
+				block:
+					'![Added chart](https://example.com/chart-new.png "Added title")',
+			},
+			{
+				id: "changed_image",
+				orderKey: "360",
+				block:
+					'![Screenshot new alt](https://example.com/screenshot.png "New screenshot title")',
+			},
+		],
+	},
+];

--- a/src/extensions/markdown/diff-fixtures/inline-media-link.after.md
+++ b/src/extensions/markdown/diff-fixtures/inline-media-link.after.md
@@ -1,0 +1,22 @@
+# Inline media and links
+
+Opening line keeps emoji :) around **strong**, `snippet`, ~~retired~~, and punctuation?
+
+Change [Guides](https://example.com/docs) text, but keep [API](https://example.com/api-v2) text with a URL-only edit.
+
+Reference [Guidebook][guide-v2] and logo ![Reference logo new][logo-v2].
+
+Bare links: https://example.com/bare-v2 and ops-v2@example.com.
+
+Escaped markdown: \*literal asterisks\* and \[literal reference\].
+
+Soft break stays here
+with the next line updated, and hard break stays here  
+with the forced line updated.
+
+![Added chart](https://example.com/chart-new.png "Added title")
+
+![Screenshot new alt](https://example.com/screenshot.png "New screenshot title")
+
+[guide-v2]: https://example.com/guide-v2
+[logo-v2]: https://example.com/logo-v2.png "Logo v2"

--- a/src/extensions/markdown/diff-fixtures/inline-media-link.before.md
+++ b/src/extensions/markdown/diff-fixtures/inline-media-link.before.md
@@ -1,0 +1,22 @@
+# Inline media and links
+
+Opening line keeps emoji :) around **bold**, `code`, ~~strike~~, and punctuation!
+
+Change [Docs](https://example.com/docs) text, but keep [API](https://example.com/api-v1) text with a URL-only edit.
+
+Reference [Guide][guide-v1] and logo ![Reference logo][logo-v1].
+
+Bare links: https://example.com/bare-v1 and ops-v1@example.com.
+
+Escaped markdown: \*literal stars\* and \[literal link\].
+
+Soft break stays here
+with the next line, and hard break stays here  
+with the forced line.
+
+![Removed chart](https://example.com/chart-old.png "Removed title")
+
+![Screenshot old alt](https://example.com/screenshot.png "Old screenshot title")
+
+[guide-v1]: https://example.com/guide-v1
+[logo-v1]: https://example.com/logo-v1.png "Logo v1"

--- a/src/extensions/markdown/diff-fixtures/mixed-gfm-document.after.md
+++ b/src/extensions/markdown/diff-fixtures/mixed-gfm-document.after.md
@@ -1,0 +1,21 @@
+# Launch review
+
+Read the [runbook](https://example.com/runbook-v2) and ping <ops@example.com>.
+
+| Area    | Owner | Status   |
+| ------- | ----- | -------- |
+| API     | Dee   | Ready    |
+| Web     | Mo    | Approved |
+| Billing | Ada   | Watching |
+
+- [x] Confirm launch owner
+- [x] Update docs
+  - Keep migration note
+  - Verify search index
+  - Add rollback note
+
+```ts
+export const rollout = "global";
+notify("ops");
+notify("support");
+```

--- a/src/extensions/markdown/diff-fixtures/mixed-gfm-document.before.md
+++ b/src/extensions/markdown/diff-fixtures/mixed-gfm-document.before.md
@@ -1,0 +1,18 @@
+# Launch review
+
+Read the [runbook](https://example.com/runbook) and ping <ops@example.com>.
+
+| Area | Owner | Status |
+| ---- | ----- | ------ |
+| API  | Dee   | Ready  |
+| Web  | Mo    | Draft  |
+
+- [x] Confirm launch owner
+- [ ] Update docs
+  - Keep migration note
+  - Verify search index
+
+```ts
+export const rollout = "staged";
+notify("ops");
+```

--- a/src/extensions/markdown/diff-fixtures/plan-table.after.md
+++ b/src/extensions/markdown/diff-fixtures/plan-table.after.md
@@ -1,0 +1,5 @@
+| Day      | Base           | Main Move                                                                    | Food Stop                                     | Evening Mood                   |
+| -------- | -------------- | ---------------------------------------------------------------------------- | --------------------------------------------- | ------------------------------ |
+| Friday   | Mitte          | [Museum Island](https://www.museumsinsel-berlin.de/en/) and the Berliner Dom | Coffee near Hackescher Markt                  | Easy dinner in Prenzlauer Berg |
+| Saturday | Kreuzberg      | Landwehr Canal walk and neighborhood wandering                               | [Markthalle Neun](https://markthalleneun.de/) | Bars around Oranienstrasse     |
+| Sunday   | Charlottenburg | Palace gardens and Savignyplatz                                              | Savignyplatz cafes                            | Soft exit before departure     |

--- a/src/extensions/markdown/diff-fixtures/plan-table.before.md
+++ b/src/extensions/markdown/diff-fixtures/plan-table.before.md
@@ -1,0 +1,5 @@
+| Day      | Base           | Main Move                                               | Food Stop                                     | Evening Mood                   |
+| -------- | -------------- | ------------------------------------------------------- | --------------------------------------------- | ------------------------------ |
+| Friday   | Mitte          | [Museum Island](https://www.museumsinsel-berlin.de/en/) | Coffee near Hackescher Markt                  | Easy dinner in Prenzlauer Berg |
+| Saturday | Kreuzberg      | Landwehr Canal walk                                     | [Markthalle Neun](https://markthalleneun.de/) | Bars around Oranienstrasse     |
+| Sunday   | Charlottenburg | Palace gardens                                          | Savignyplatz cafes                            | Soft exit before departure     |

--- a/src/extensions/markdown/diff-fixtures/quick-facts-list.after.md
+++ b/src/extensions/markdown/diff-fixtures/quick-facts-list.after.md
@@ -1,0 +1,5 @@
+- **Best for:** first-time visitors who want museums, food markets, canals, and relaxed neighborhood wandering.
+- **Trip length:** three days and two nights.
+- **Transit:** U-Bahn, S-Bahn, tram, regional trains, and plenty of walking.
+- **Pace:** one main plan per day, with open space around it.
+- **Budget:** moderate, with inexpensive lunches and a few paid attractions.

--- a/src/extensions/markdown/diff-fixtures/quick-facts-list.before.md
+++ b/src/extensions/markdown/diff-fixtures/quick-facts-list.before.md
@@ -1,0 +1,4 @@
+- **Best for:** first-time visitors who want museums, food markets, canals, and relaxed neighborhood wandering.
+- **Trip length:** three days and two nights.
+- **Transit:** U-Bahn, S-Bahn, tram, and plenty of walking.
+- **Pace:** one main plan per day, with open space around it.

--- a/src/extensions/markdown/diff-fixtures/release-checklist.after.md
+++ b/src/extensions/markdown/diff-fixtures/release-checklist.after.md
@@ -1,0 +1,11 @@
+# Release checklist
+
+- [x] Confirm launch owner
+  - [x] Draft release notes for beta customers
+  - [ ] Schedule support handoff
+- [ ] Verify analytics
+  - [ ] Check conversion dashboard
+  - [x] Confirm event names
+- [ ] Archive notes
+  - [ ] Leave changelog draft untouched
+- [ ] Announce internally

--- a/src/extensions/markdown/diff-fixtures/release-checklist.before.md
+++ b/src/extensions/markdown/diff-fixtures/release-checklist.before.md
@@ -1,0 +1,10 @@
+# Release checklist
+
+- [ ] Confirm launch owner
+  - [ ] Draft release notes
+  - [ ] Schedule support handoff
+- [ ] Verify analytics
+  - [ ] Check conversion dashboard
+- [ ] Archive notes
+  - [ ] Leave changelog draft untouched
+- [ ] Announce internally

--- a/src/extensions/markdown/diff-fixtures/visual.html
+++ b/src/extensions/markdown/diff-fixtures/visual.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Markdown Diff Fixtures</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./visual.ts"></script>
+	</body>
+</html>

--- a/src/extensions/markdown/diff-fixtures/visual.ts
+++ b/src/extensions/markdown/diff-fixtures/visual.ts
@@ -1,0 +1,57 @@
+import "@/index.css";
+import "../style.css";
+import { renderMarkdownReviewDiffHtml } from "../render-review-diff-html";
+import { MARKDOWN_DIFF_FIXTURES } from ".";
+
+const root = document.getElementById("root");
+
+if (!root) {
+	throw new Error("Missing #root");
+}
+
+root.innerHTML = `
+	<main class="min-h-dvh bg-background px-8 py-8 text-foreground">
+		<div class="mx-auto max-w-5xl space-y-6">
+			<header class="flex items-center justify-between gap-4">
+				<h1 class="text-xl font-semibold tracking-normal">Markdown Diff Fixtures</h1>
+				<nav class="flex flex-wrap gap-2 text-sm">
+					${MARKDOWN_DIFF_FIXTURES.map(
+						(fixture) =>
+							`<a class="rounded-md border border-border px-3 py-1.5 text-muted-foreground hover:bg-muted" href="#${fixture.id}">${fixture.title}</a>`,
+					).join("")}
+				</nav>
+			</header>
+			${MARKDOWN_DIFF_FIXTURES.map(
+				(fixture) => `
+					<section id="${fixture.id}" class="space-y-3">
+						<h2 class="text-sm font-medium text-muted-foreground">${fixture.title}</h2>
+						<div class="grid gap-3 lg:grid-cols-2">
+							<div class="space-y-2">
+								<h3 class="text-xs font-medium uppercase tracking-normal text-muted-foreground">Before</h3>
+								<pre class="max-h-80 overflow-auto rounded-lg border border-border bg-muted/30 p-4 text-sm leading-relaxed text-foreground"><code>${escapeHtml(fixture.beforeMarkdown.trimEnd())}</code></pre>
+							</div>
+							<div class="space-y-2">
+								<h3 class="text-xs font-medium uppercase tracking-normal text-muted-foreground">After</h3>
+								<pre class="max-h-80 overflow-auto rounded-lg border border-border bg-muted/30 p-4 text-sm leading-relaxed text-foreground"><code>${escapeHtml(fixture.afterMarkdown.trimEnd())}</code></pre>
+							</div>
+						</div>
+						<div class="markdown-view markdown-review rounded-lg border border-border bg-background">
+							<div class="tiptap-container bg-background p-6">
+								<div class="ProseMirror tiptap mx-auto w-full">
+									${renderMarkdownReviewDiffHtml(fixture)}
+								</div>
+							</div>
+						</div>
+					</section>
+				`,
+			).join("")}
+		</div>
+	</main>
+`;
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/nodes.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/nodes.ts
@@ -13,9 +13,14 @@ declare module "@tiptap/core" {
 function diffAttrs(node: any, mode: "words" | "element" = "words"): any {
 	const id = node?.attrs?.data?.id;
 	if (typeof id !== "string" || id.length === 0) return {};
+	const diffMode =
+		node?.attrs?.data?.diffMode === "words" ||
+		node?.attrs?.data?.diffMode === "element"
+			? node.attrs.data.diffMode
+			: mode;
 	return {
 		"data-diff-key": id,
-		"data-diff-mode": mode,
+		"data-diff-mode": diffMode,
 		"data-diff-show-when-removed": "true",
 	};
 }
@@ -119,8 +124,27 @@ export function markdownWcNodes(): Extensions {
 				return { checked: { default: null }, data: { default: null } };
 			},
 			renderHTML({ node }) {
-				// Match serializeToHtml default: plain <li>
-				return ["li", diffAttrs(node, "element"), 0];
+				const isTask =
+					node.attrs.checked === true || node.attrs.checked === false;
+				const attrs = diffAttrs(node, "element");
+				if (!isTask) return ["li", attrs, ["div", 0]];
+				return [
+					"li",
+					{
+						...attrs,
+						"data-task": node.attrs.checked ? "x" : " ",
+					},
+					[
+						"input",
+						{
+							type: "checkbox",
+							checked: node.attrs.checked ? "checked" : undefined,
+							disabled: "true",
+							style: "margin-right: 6px;",
+						},
+					],
+					["div", 0],
+				];
 			},
 			addNodeView() {
 				return ({ node, editor, getPos }) => {

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -2,7 +2,12 @@ import { Suspense, useEffect } from "react";
 import { useMemo } from "react";
 import type { ReactNode } from "react";
 import { ExternalLink, FileText, Github, Loader2 } from "lucide-react";
-import { LixProvider, useLix, useQueryTakeFirst } from "@/lib/lix-react";
+import {
+	LixProvider,
+	useLix,
+	useQuery,
+	useQueryTakeFirst,
+} from "@/lib/lix-react";
 import { qb } from "@/lib/lix-kysely";
 import { isMarkdownFilePath } from "@/extension-runtime/file-handlers";
 import { EditorProvider } from "@/extensions/markdown/editor/editor-context";
@@ -13,7 +18,7 @@ import { createReactExtensionDefinition } from "../../extension-runtime/react-ex
 import { FILE_EXTENSION_KIND } from "../../extension-runtime/extension-instance-helpers";
 import { FormattingToolbar } from "./components/formatting-toolbar";
 import { SlashCommandMenu } from "./components/slash-command-menu";
-import type { MarkdownReviewDiff } from "./review-diff";
+import type { MarkdownBlockSnapshot, MarkdownReviewDiff } from "./review-diff";
 import { decodeFileDataToText } from "@/lib/decode-file-data";
 import { ExternalWriteReviewControls } from "@/extension-runtime/external-write-review-controls";
 import {
@@ -37,6 +42,10 @@ type MarkdownViewProps = {
 		readonly fileId: string;
 		readonly reviewId: string;
 	}) => Promise<void>;
+};
+
+type HistoricalMarkdownBlockRow = {
+	readonly snapshot_content: unknown;
 };
 
 /**
@@ -133,14 +142,18 @@ function MarkdownViewContent({
 							focusOnLoad={focusOnLoad}
 						/>
 						{reviewDiff && externalWriteReview ? (
-							<MarkdownReviewOverlay
-								fileId={fileRow.id}
-								reviewDiff={reviewDiff}
-								reviewId={externalWriteReview.reviewId}
-								isActive={isActiveView && isPanelFocused}
-								onAccept={onAcceptReviewDiff}
-								onReject={onRejectReviewDiff}
-							/>
+							<Suspense fallback={<MarkdownReviewOverlayFallback />}>
+								<MarkdownReviewOverlay
+									fileId={fileRow.id}
+									reviewDiff={reviewDiff}
+									reviewId={externalWriteReview.reviewId}
+									beforeCommitId={externalWriteReview.beforeCommitId}
+									afterCommitId={externalWriteReview.afterCommitId}
+									isActive={isActiveView && isPanelFocused}
+									onAccept={onAcceptReviewDiff}
+									onReject={onRejectReviewDiff}
+								/>
+							</Suspense>
 						) : null}
 					</div>
 					{reviewDiff ? null : <SlashCommandMenu />}
@@ -163,6 +176,8 @@ function MarkdownReviewOverlay({
 	fileId,
 	reviewDiff,
 	reviewId,
+	beforeCommitId,
+	afterCommitId,
 	isActive,
 	onAccept,
 	onReject,
@@ -170,6 +185,8 @@ function MarkdownReviewOverlay({
 	readonly fileId: string;
 	readonly reviewDiff: MarkdownReviewDiff;
 	readonly reviewId: string;
+	readonly beforeCommitId?: string;
+	readonly afterCommitId?: string;
 	readonly isActive: boolean;
 	readonly onAccept?: (args: {
 		readonly fileId: string;
@@ -180,9 +197,30 @@ function MarkdownReviewOverlay({
 		readonly reviewId: string;
 	}) => Promise<void>;
 }) {
+	const beforeBlocks = useMarkdownBlocksAtCommit(fileId, beforeCommitId);
+	const afterBlocks = useMarkdownBlocksAtCommit(fileId, afterCommitId);
+	const enrichedReviewDiff = useMemo<MarkdownReviewDiff>(
+		() => {
+			const beforeSnapshotsAvailable =
+				beforeBlocks !== undefined &&
+				(beforeBlocks.length > 0 || reviewDiff.beforeMarkdown.trim().length === 0);
+			const afterSnapshotsAvailable =
+				afterBlocks !== undefined &&
+				(afterBlocks.length > 0 || reviewDiff.afterMarkdown.trim().length === 0);
+			if (!beforeSnapshotsAvailable || !afterSnapshotsAvailable) {
+				return reviewDiff;
+			}
+			return {
+				...reviewDiff,
+				beforeBlocks: beforeBlocks ?? [],
+				afterBlocks: afterBlocks ?? [],
+			};
+		},
+		[afterBlocks, beforeBlocks, reviewDiff],
+	);
 	const diffHtml = useMemo(() => {
-		return renderMarkdownReviewDiffHtml(reviewDiff);
-	}, [reviewDiff]);
+		return renderMarkdownReviewDiffHtml(enrichedReviewDiff);
+	}, [enrichedReviewDiff]);
 	const rejectReview = () => void onReject?.({ fileId, reviewId });
 
 	return (
@@ -202,6 +240,112 @@ function MarkdownReviewOverlay({
 			/>
 		</div>
 	);
+}
+
+function MarkdownReviewOverlayFallback() {
+	return (
+		<div className="markdown-review-overlay">
+			<div className="markdown-review-surface">
+				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+					<Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+					<span>Loading review…</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function useMarkdownBlocksAtCommit(
+	fileId: string,
+	commitId: string | undefined,
+): MarkdownBlockSnapshot[] | undefined {
+	const rows = useQuery<HistoricalMarkdownBlockRow>(
+		(lix) =>
+			commitId
+				? historicalMarkdownBlocksQuery(lix, commitId, fileId)
+				: emptyMarkdownBlocksQuery(),
+		{ subscribe: false },
+	);
+	return useMemo(() => {
+		if (!commitId) return undefined;
+		return rows
+			.map((row) => parseHistoricalMarkdownBlock(row.snapshot_content))
+			.filter((block): block is MarkdownBlockSnapshot => block !== null)
+			.sort(
+				(left, right) =>
+					left.orderKey.localeCompare(right.orderKey) ||
+					left.id.localeCompare(right.id),
+			);
+	}, [commitId, rows]);
+}
+
+function historicalMarkdownBlocksQuery(
+	lix: ReturnType<typeof useLix>,
+	commitId: string,
+	fileId: string,
+) {
+	const sql = `
+		WITH ranked AS (
+			SELECT
+				entity_pk,
+				snapshot_content,
+				depth,
+				ROW_NUMBER() OVER (
+					PARTITION BY entity_pk
+					ORDER BY depth ASC
+				) AS rn
+			FROM lix_state_history
+			WHERE start_commit_id = ?
+				AND file_id = ?
+				AND schema_key = 'markdown_block'
+		)
+		SELECT snapshot_content
+		FROM ranked
+		WHERE rn = 1
+			AND snapshot_content IS NOT NULL
+	`;
+	const parameters = [commitId, fileId] as const;
+	return {
+		compile: () => ({ sql, parameters }),
+		execute: async () => {
+			const result = await lix.execute(sql, parameters);
+			return result.rows.map(
+				(row) => row.toObject() as HistoricalMarkdownBlockRow,
+			);
+		},
+	};
+}
+
+function emptyMarkdownBlocksQuery() {
+	return {
+		compile: () => ({ sql: "SELECT 1 WHERE 0", parameters: [] }),
+		execute: async () => [] as HistoricalMarkdownBlockRow[],
+	};
+}
+
+function parseHistoricalMarkdownBlock(
+	value: unknown,
+): MarkdownBlockSnapshot | null {
+	const snapshot = typeof value === "string" ? safeJsonParse(value) : value;
+	if (!snapshot || typeof snapshot !== "object") return null;
+	const record = snapshot as Record<string, unknown>;
+	const { id, order_key: orderKey, block } = record;
+	if (
+		typeof id !== "string" ||
+		typeof orderKey !== "string" ||
+		typeof block !== "string"
+	) {
+		return null;
+	}
+	return { id, orderKey, block };
+}
+
+function safeJsonParse(value: string): unknown {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return null;
+	}
 }
 
 function UnsupportedFilePlaceholder({

--- a/src/extensions/markdown/render-review-diff-html.test.ts
+++ b/src/extensions/markdown/render-review-diff-html.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "vitest";
+import {
+	bundledPluginArchives,
+	openLix,
+	type Lix,
+} from "@/test-utils/node-lix-sdk";
+import {
+	MARKDOWN_DIFF_FIXTURES,
+	type MarkdownDiffFixture,
+} from "./diff-fixtures";
 import { renderMarkdownReviewDiffHtml } from "./render-review-diff-html";
+import type { MarkdownBlockSnapshot } from "./review-diff";
 
 describe("renderMarkdownReviewDiffHtml", () => {
 	test("marks added headings and blocks", () => {
@@ -12,6 +22,8 @@ describe("renderMarkdownReviewDiffHtml", () => {
 		expect(html).toContain('data-diff-status="added"');
 		expect(html).toContain(">Poem</h2>");
 		expect(html).toContain(">Fresh line</p>");
+		expect(html.trim().startsWith("<h1")).toBe(true);
+		expect(html).not.toContain("</h1>\n");
 	});
 
 	test("marks removed blocks", () => {
@@ -35,4 +47,821 @@ describe("renderMarkdownReviewDiffHtml", () => {
 		expect(html).toContain("general audience");
 		expect(html).toContain("writers already using Claude");
 	});
+
+	test("uses markdown block ids when snapshots are available", () => {
+		const html = renderMarkdownReviewDiffHtml({
+			beforeMarkdown: "# Strategy\n\nTarget a general audience.\n",
+			afterMarkdown: "# Strategy\n\nTarget writers already using Claude.\n",
+			beforeBlocks: [
+				{ id: "heading_block", orderKey: "40", block: "# Strategy" },
+				{
+					id: "paragraph_block",
+					orderKey: "80",
+					block: "Target a general audience.",
+				},
+			],
+			afterBlocks: [
+				{ id: "heading_block", orderKey: "40", block: "# Strategy" },
+				{
+					id: "paragraph_block",
+					orderKey: "80",
+					block: "Target writers already using Claude.",
+				},
+			],
+		});
+
+		expect(html).toContain('data-diff-key="paragraph_block"');
+		expect(html).toContain("general audience");
+		expect(html).toContain("writers already using Claude");
+	});
+
+	test("uses markdown block snapshots when one side is empty", () => {
+		const html = renderMarkdownReviewDiffHtml({
+			beforeMarkdown: "",
+			afterMarkdown: "# New document\n",
+			beforeBlocks: [],
+			afterBlocks: [
+				{ id: "new_document_heading", orderKey: "40", block: "# New document" },
+			],
+		});
+
+		expect(html).toContain('data-diff-key="new_document_heading"');
+		expect(statusesForText(html, "New document")).toContain("added");
+	});
+
+	test("keeps unchanged list items stable inside a changed list block", () => {
+		const fixture = fixtureById("quick-facts-list");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+
+		expect(statusesForText(html, "Best for")).toEqual([]);
+		expect(statusesForText(html, "Trip length")).toEqual([]);
+		expect(statusesForText(html, "Pace")).toEqual([]);
+		expect(statusesForText(html, "regional trains")).toContain("added");
+		expect(statusesForText(html, "Budget")).toContain("added");
+	});
+
+	test("keeps unchanged table cells stable inside a changed table block", () => {
+		const fixture = fixtureById("plan-table");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+
+		expect(statusesForText(html, "Friday")).toEqual([]);
+		expect(statusesForText(html, "Mitte")).toEqual([]);
+		expect(statusesForText(html, "Coffee near Hackescher Markt")).toEqual([]);
+		expect(statusesForText(html, "and the Berliner Dom")).toContain("added");
+		expect(statusesForText(html, "neighborhood wandering")).toContain("added");
+	});
+
+	test("marks inline formatting and link edits inside aligned GFM table cells", () => {
+		const fixture = fixtureById("gfm-table-inline");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+
+		expect(html).toContain("<table");
+		expect(statusesForText(html, "South")).toEqual([]);
+		expect(statusesForText(html, "Blocked")).toEqual([]);
+		expect(statusesForText(html, "Shipped")).toEqual([]);
+		expect(statusesForText(html, "Draft")).toContain("removed");
+		expect(statusesForText(html, "Ready")).toContain("added");
+		expect(statusesForText(html, "Lovelace")).toContain("added");
+		expect(statusesForText(html, "smoke")).toContain("removed");
+		expect(statusesForText(html, "full")).toContain("added");
+		expect(statusesForText(html, "db")).toContain("added");
+		expect(statusesForText(html, "East")).toEqual([]);
+		expect(statusesForText(html, "Paused")).toEqual([]);
+		expect(statusesForText(html, "cache")).toEqual([]);
+		expect(statusesForText(html, "parser")).toEqual([]);
+		expect(hrefsForText(html, "Dee")).toEqual(["https://example.com/v2"]);
+		expect(html).toContain("https://example.com/v2");
+	});
+
+	test("handles GFM table row reorder, insertions, removals, and duplicate labels", () => {
+		const fixture = fixtureById("gfm-table-rows");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+
+		expect(duplicateDiffKeys(html)).toEqual([]);
+		expect(html).toContain("<table");
+		expect(statusesForText(html, "Beta")).toEqual([]);
+		expect(statusesForText(html, "Move this row unchanged")).toEqual([]);
+		expect(statusesForText(html, "Keep copy stable")).toEqual([]);
+		expect(statusesForText(html, "Duplicate label remains")).toEqual([]);
+		expect(statusesForText(html, "Keep second stable cell")).toEqual([]);
+		expect(html).toContain('data-diff-key="gfm_table_rows:tr:gamma:td:notes"');
+		expect(html).toContain('data-diff-status="removed"');
+		expect(html).toContain("Remove this row");
+		expect(statusesForText(html, "Epsilon")).toContain("added");
+		expect(statusesForText(html, "Insert this row")).toContain("added");
+		expect(statusesForText(html, "Alpha")).toEqual([]);
+	});
+
+	test("handles GFM table column changes, empty cells, and pipe literals", () => {
+		const fixture = fixtureById("gfm-table-structure");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+		const root = htmlRoot(html);
+
+		expect(root.querySelectorAll("tr")).toHaveLength(7);
+		expect(root.querySelectorAll("tr")[2]?.querySelectorAll("td")).toHaveLength(
+			5,
+		);
+		expect(statusesForText(html, "Item")).toEqual([]);
+		expect(statusesForText(html, "Owner")).toEqual([]);
+		expect(statusesForText(html, "Notes")).toEqual([]);
+		expect(statusesForText(html, "Priority")).toContain("added");
+		expect(statusesForText(html, "Legacy")).toEqual([]);
+		expect(statusesForText(html, "Status")).toContain("added");
+		expect(html).toContain(
+			'data-diff-key="gfm_table_structure:tr:alpha:td:owner"',
+		);
+		expect(html).toContain(
+			'data-diff-key="gfm_table_structure:tr:alpha:td:notes"',
+		);
+
+		expect(statusesForText(html, "Alpha")).toEqual([]);
+		expect(statusesForText(html, "Mia")).toEqual([]);
+		expect(statusesForText(html, "high")).toContain("added");
+		expect(statusesForText(html, "Filled empty cell")).toContain("added");
+		expect(statusesForText(html, "Pipe demo")).toEqual([]);
+		expect(statusesForText(html, "Escaped")).toEqual([]);
+		expect(statusesForText(html, "pipe and")).toEqual([]);
+		expect(statusesForText(html, "b")).toContain("removed");
+		expect(statusesForText(html, "c")).toContain("added");
+
+		expect(statusesForText(html, "First duplicate keeps same note")).toEqual(
+			[],
+		);
+		expect(statusesForText(html, "Second duplicate")).toEqual([]);
+		expect(statusesForText(html, "will be edited")).toContain("removed");
+		expect(statusesForText(html, "gets a modified note")).toContain("added");
+		expect(statusesForText(html, "Column removal keeps row identity")).toEqual(
+			[],
+		);
+		expect(statusesForText(html, "old")).toEqual([]);
+		expect(statusesForText(html, "New row")).toContain("added");
+		expect(
+			statusesForText(html, "Inserted row with changed-ready content"),
+		).toContain("added");
+		expect(statusesForText(html, "blue")).toContain("added");
+	});
+
+	test("tracks task list checked-state and nested list edits", () => {
+		const fixture = fixtureById("release-checklist");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+		const root = htmlRoot(html);
+
+		expect(root.querySelector("li ul")).not.toBeNull();
+		expect(root.querySelector('li[data-task] input[type="checkbox"]')).not.toBe(
+			null,
+		);
+		expect(taskCheckedStatesForText(html, "Confirm launch owner")).toEqual([
+			true,
+		]);
+		expect(taskCheckedStatesForText(html, "Draft release notes")).toContain(
+			true,
+		);
+		expect(taskCheckedStatesForText(html, "Confirm event names")).toContain(
+			true,
+		);
+		expect(statusesForText(html, "Confirm launch owner")).toEqual([]);
+		expect(statusesForText(html, "Draft release notes")).toEqual([]);
+		expect(statusesForText(html, "for beta customers")).toContain("added");
+		expect(statusesForText(html, "Schedule support handoff")).toEqual([]);
+		expect(statusesForText(html, "Check conversion dashboard")).toEqual([]);
+		expect(statusesForText(html, "Confirm event names")).toContain("added");
+		expect(statusesForText(html, "Archive notes")).toEqual([]);
+		expect(statusesForText(html, "Leave changelog draft untouched")).toEqual(
+			[],
+		);
+		expect(statusesForText(html, "Announce internally")).toEqual([]);
+	});
+
+	test("keeps reordered duplicate task labels nested with checkbox DOM", () => {
+		const fixture = fixtureById("duplicate-task-list");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+		const root = htmlRoot(html);
+
+		expect(duplicateDiffKeys(html)).toEqual([]);
+		expect(root.querySelectorAll("li ul").length).toBeGreaterThanOrEqual(3);
+		expect(
+			root.querySelectorAll('li[data-task] input[type="checkbox"]').length,
+		).toBeGreaterThanOrEqual(10);
+		expect(taskCheckedStatesForText(html, "Prep")).toEqual([false, false]);
+		expect(taskCheckedStatesForText(html, "Confirm venue")).toContain(false);
+		expect(taskCheckedStatesForText(html, "Confirm venue")).toContain(true);
+		expect(taskCheckedStatesForText(html, "Invite reviewers")).toContain(true);
+		expect(taskCheckedStatesForText(html, "Send announcement")).toContain(true);
+		expect(taskCheckedStatesForText(html, "Send announcement")).toContain(
+			false,
+		);
+
+		expect(statusesForText(html, "Prep")).toEqual(["added", "removed"]);
+		expect(statusesForText(html, "Update docs")).toEqual([]);
+		expect(statusesForText(html, "Invite reviewers")).toEqual([]);
+		expect(statusesForText(html, "Book rehearsal room")).toContain("added");
+		expect(statusesForText(html, "Pack demo kit")).toEqual([
+			"added",
+			"removed",
+		]);
+	});
+
+	test("handles GFM fenced code, blockquotes, raw HTML, strikethrough, and autolinks", () => {
+		const fixture = fixtureById("gfm-edge-blocks");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+
+		expect(html).toContain('data-diff-key="gfm_code_fence"');
+		expect(html).toContain('data-diff-key="gfm_blockquote"');
+		expect(html).toContain('data-diff-key="gfm_raw_html"');
+		expect(html).toContain('data-diff-key="gfm_strikethrough"');
+		expect(html).toContain('data-diff-key="gfm_autolink"');
+
+		expect(statusesForText(html, "const route")).toEqual([]);
+		expect(statusesForText(html, "draft")).toContain("removed");
+		expect(statusesForText(html, "launch")).toContain("added");
+		expect(statusesForText(html, 'cache: "no-store"')).toContain("added");
+
+		expect(statusesForText(html, "Keep the customer quote")).toEqual([]);
+		expect(statusesForText(html, "current")).toContain("removed");
+		expect(statusesForText(html, "revised")).toContain("added");
+		expect(statusesForText(html, "Add a rollout owner")).toContain("added");
+
+		expect(statusesForText(html, "HTML block (read only)")).toEqual([
+			"added",
+			"removed",
+		]);
+		expect(statusesForText(html, "Keep a short migration note")).toEqual([
+			"added",
+			"removed",
+		]);
+		expect(statusesForText(html, "and link to support")).toContain("added");
+		expect(statusesForText(html, "invite-only")).toContain("removed");
+		expect(statusesForText(html, "private")).toContain("added");
+		expect(statusesForText(html, "docs")).toContain("removed");
+		expect(statusesForText(html, "guides")).toContain("added");
+	});
+
+	test("handles moved headings, media, breaks, HTML, code language, quotes, and autolinks", () => {
+		const fixture = fixtureById("block-media-link");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+		const root = htmlRoot(html);
+
+		expect(root.querySelectorAll("img")).toHaveLength(2);
+		expect(root.querySelector('img[alt="Old dashboard"]')).not.toBeNull();
+		expect(root.querySelector('img[alt="New dashboard"]')).not.toBeNull();
+		expect(root.querySelectorAll("hr")).toHaveLength(1);
+		expect(
+			root.querySelector('hr[data-diff-key="theme_break"]'),
+		).not.toBeNull();
+		expect(root.querySelector("code.language-ts")).not.toBeNull();
+		expect(html).toContain("&lt;kbd&gt;");
+		expect(html).toContain('&lt;span data-kind="badge"&gt;');
+
+		expect(statusesForText(html, "Launch notes")).toEqual([]);
+		expect(statusesForText(html, "Metrics")).toEqual([]);
+		expect(statusesForText(html, "renamed")).toContain("added");
+
+		expect(statusesForSelector(html, 'img[alt="Old dashboard"]')).toEqual([
+			"removed",
+		]);
+		expect(statusesForSelector(html, 'img[alt="New dashboard"]')).toEqual([
+			"added",
+		]);
+
+		expect(statusesForText(html, "export const enabled")).toEqual([]);
+		expect(statusesForText(html, "false")).toContain("removed");
+		expect(statusesForText(html, "true")).toContain("added");
+
+		expect(statusesForText(html, "Keep")).toEqual([]);
+		expect(statusesForText(html, "bold")).toContain("removed");
+		expect(statusesForText(html, "strong")).toContain("added");
+		expect(statusesForText(html, "calm")).toContain("removed");
+		expect(statusesForText(html, "focused")).toContain("added");
+		expect(statusesForText(html, "owner")).toContain("added");
+
+		expect(statusesForText(html, "docs")).toContain("removed");
+		expect(statusesForText(html, "guides")).toContain("added");
+		expect(statusesForText(html, "team")).toContain("removed");
+		expect(statusesForText(html, "help")).toContain("added");
+
+		expect(statusesForText(html, "Cmd")).toContain("removed");
+		expect(statusesForText(html, "Ctrl")).toContain("added");
+		expect(statusesForText(html, "beta")).toContain("removed");
+		expect(statusesForText(html, "stable")).toContain("added");
+		expect(statusesForText(html, "Raw block content")).toEqual([
+			"added",
+			"removed",
+		]);
+		expect(statusesForText(html, "plus owner")).toContain("added");
+	});
+
+	test("covers inline media, reference links, autolinks, escaped markdown, and breaks", () => {
+		const fixture = fixtureById("inline-media-link");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+		const root = htmlRoot(html);
+
+		expect(statusesForText(html, "Inline media and links")).toEqual([]);
+		expect(statusesForText(html, "emoji :) around")).toEqual([]);
+		expect(statusesForText(html, "bold")).toContain("removed");
+		expect(statusesForText(html, "strong")).toContain("added");
+		expect(statusesForText(html, "code")).toContain("removed");
+		expect(statusesForText(html, "snippet")).toContain("added");
+		expect(statusesForText(html, "strike")).toContain("removed");
+		expect(statusesForText(html, "retired")).toContain("added");
+		expect(statusesForText(html, "punctuation")).toEqual([]);
+		expect(statusesForText(html, "!")).toContain("removed");
+		expect(statusesForText(html, "?")).toContain("added");
+
+		expect(statusesForText(html, "Docs")).toContain("removed");
+		expect(statusesForText(html, "Guides")).toContain("added");
+		expect(hrefsForText(html, "Guides")).toEqual([]);
+		expect(statusesForText(html, "API")).toEqual([]);
+		expect(hrefsForText(html, "API")).toEqual([]);
+
+		expect(statusesForText(html, "Reference")).toEqual([]);
+		expect(hrefsForText(html, "Guidebook")).toEqual([]);
+		expect(statusesForSelector(html, 'img[alt="Reference logo"]')).toEqual([]);
+		expect(statusesForSelector(html, 'img[alt="Reference logo new"]')).toEqual(
+			[],
+		);
+
+		expect(hrefsForText(html, "https://example.com/bare-v2")).toEqual([]);
+		expect(hrefsForText(html, "ops-v2@example.com")).toEqual([]);
+		expect(statusesForText(html, "v1")).toContain("removed");
+		expect(statusesForText(html, "v2")).toContain("added");
+
+		expect(statusesForText(html, "stars")).toContain("removed");
+		expect(statusesForText(html, "asterisks")).toContain("added");
+		expect(statusesForText(html, "link")).toContain("removed");
+		expect(statusesForText(html, "reference")).toContain("added");
+
+		expect(root.querySelectorAll("br")).toHaveLength(0);
+		expect(statusesForText(html, "Soft break stays here")).toEqual([]);
+		expect(statusesForText(html, "with the next line")).toEqual([]);
+		expect(statusesForText(html, "updated")).toContain("added");
+		expect(statusesForText(html, "hard break stays here")).toEqual([]);
+		expect(statusesForText(html, "with the forced line")).toEqual([]);
+
+		expect(statusesForSelector(html, 'img[alt="Removed chart"]')).toContain(
+			"removed",
+		);
+		expect(statusesForSelector(html, 'img[alt="Added chart"]')).toEqual([
+			"added",
+		]);
+		expect(imageTitlesForAlt(html, "Added chart")).toEqual(["Added title"]);
+		expect(statusesForSelector(html, 'img[alt="Screenshot old alt"]')).toEqual(
+			[],
+		);
+		expect(statusesForSelector(html, 'img[alt="Screenshot new alt"]')).toEqual(
+			[],
+		);
+		expect(imageTitlesForAlt(html, "Screenshot new alt")).toEqual([
+			"New screenshot title",
+		]);
+	});
+
+	test("handles block moves, heading levels, lifecycle blocks, and repeated text", () => {
+		const fixture = fixtureById("block-structure-moves");
+		const html = renderMarkdownReviewDiffHtml(fixture);
+		const root = htmlRoot(html);
+
+		expect(html).toContain('data-diff-key="moved_paragraph"');
+		expect(statusesForText(html, "Shared paragraph")).toEqual([]);
+		expect(
+			statusesForText(html, "Move this paragraph below the checklist"),
+		).toEqual([]);
+		expect(statusesForText(html, "Repeated heading")).toEqual([]);
+		expect(statusesForText(html, "Keep the same repeated paragraph")).toEqual(
+			[],
+		);
+
+		expect(root.querySelector("h2")?.textContent).toContain("Overview");
+		expect(root.querySelector("h3")?.textContent).toContain("Details");
+		expect(statusesForText(html, "Overview")).toEqual([]);
+		expect(statusesForText(html, "Details")).toEqual([]);
+
+		expect(statusesForText(html, "Parent quote stays")).toEqual([]);
+		expect(statusesForText(html, "calm").length).toBeGreaterThan(0);
+		expect(statusesForText(html, "focused")).toContain("added");
+		expect(statusesForText(html, "Nested quote owner added")).toContain(
+			"added",
+		);
+
+		expect(root.querySelector("code.language-ts")).not.toBeNull();
+		expect(root.querySelector("code.language-sh")).not.toBeNull();
+		expect(statusesForText(html, 'console.log("keep");')).toEqual([]);
+		expect(statusesForText(html, 'console.log("remove me");')).toContain(
+			"removed",
+		);
+		expect(statusesForText(html, 'echo "new fence"')).toContain("added");
+
+		expect(root.querySelectorAll("hr")).toHaveLength(1);
+		expect(
+			root.querySelector('hr[data-diff-key="changed_theme_break"]'),
+		).not.toBeNull();
+
+		expect(statusesForText(html, "Paragraph before list")).toEqual([]);
+		expect(statusesForText(html, "Keep list item")).toEqual([]);
+		expect(statusesForText(html, "Move list with paragraph boundary")).toEqual(
+			[],
+		);
+		expect(statusesForText(html, "Add list item between paragraphs")).toContain(
+			"added",
+		);
+		expect(statusesForText(html, "Paragraph after list")).toEqual([]);
+
+		expect(statusesForText(html, "Remove this HTML block")).toContain(
+			"removed",
+		);
+		expect(statusesForText(html, "Add this HTML block")).toContain("added");
+	});
+
+	test.each([
+		{
+			id: "quick-facts-list",
+			assertions: assertQuickFactsListDiff,
+		},
+		{
+			id: "plan-table",
+			assertions: assertPlanTableDiff,
+		},
+		{
+			id: "release-checklist",
+			assertions: assertReleaseChecklistDiff,
+		},
+		{
+			id: "mixed-gfm-document",
+			assertions: assertMixedGfmDocumentDiff,
+		},
+	])(
+		"renders $id fixture diff from real lix markdown_block state and history",
+		async ({ id, assertions }) => {
+			const fixture = fixtureById(id);
+			const { html, beforeBlocks, afterBlocks } =
+				await renderFixtureDiffFromRealLix(fixture);
+
+			expect(beforeBlocks.length).toBeGreaterThan(0);
+			expect(afterBlocks.length).toBeGreaterThan(0);
+			expect(beforeBlocks.map((block) => block.block).join("\n\n")).toContain(
+				fixture.beforeMarkdown.trim().split("\n")[0],
+			);
+			expect(afterBlocks.map((block) => block.block).join("\n\n")).toContain(
+				fixture.afterMarkdown.trim().split("\n")[0],
+			);
+
+			if (id === "mixed-gfm-document") {
+				expectStableRealLixBlockKeys(html, beforeBlocks, afterBlocks);
+			}
+
+			assertions(html);
+		},
+	);
 });
+
+async function renderFixtureDiffFromRealLix(
+	fixture: MarkdownDiffFixture,
+): Promise<{
+	html: string;
+	beforeBlocks: MarkdownBlockSnapshot[];
+	afterBlocks: MarkdownBlockSnapshot[];
+}> {
+	const lix = await openLix();
+	try {
+		await installBundledPlugins(lix);
+		const filePath = `/fixtures/${fixture.id}.md`;
+		await writeMarkdownFile(lix, filePath, fixture.beforeMarkdown);
+		const fileId = await fileIdByPath(lix, filePath);
+		const beforeCommitId = await activeCommitId(lix);
+
+		await writeMarkdownFile(lix, filePath, fixture.afterMarkdown);
+		const afterCommitId = await activeCommitId(lix);
+		const beforeBlocks = await historicalMarkdownBlocks(
+			lix,
+			beforeCommitId,
+			fileId,
+		);
+		const afterBlocks = await historicalMarkdownBlocks(
+			lix,
+			afterCommitId,
+			fileId,
+		);
+
+		const html = renderMarkdownReviewDiffHtml({
+			beforeMarkdown: fixture.beforeMarkdown,
+			afterMarkdown: fixture.afterMarkdown,
+			beforeBlocks,
+			afterBlocks,
+		});
+
+		return { html, beforeBlocks, afterBlocks };
+	} finally {
+		await lix.close();
+	}
+}
+
+function assertQuickFactsListDiff(html: string): void {
+	expect(statusesForText(html, "Best for")).toEqual([]);
+	expect(statusesForText(html, "Trip length")).toEqual([]);
+	expect(statusesForText(html, "Pace")).toEqual([]);
+	expect(statusesForText(html, "regional trains")).toContain("added");
+	expect(statusesForText(html, "Budget")).toContain("added");
+}
+
+function assertPlanTableDiff(html: string): void {
+	expect(html).toContain("<table");
+	expect(statusesForText(html, "Friday")).toEqual([]);
+	expect(statusesForText(html, "Mitte")).toEqual([]);
+	expect(statusesForText(html, "Coffee near Hackescher Markt")).toEqual([]);
+	expect(statusesForText(html, "and the Berliner Dom")).toContain("added");
+	expect(statusesForText(html, "neighborhood wandering")).toContain("added");
+}
+
+function assertReleaseChecklistDiff(html: string): void {
+	const root = htmlRoot(html);
+
+	expect(root.querySelector("li ul")).not.toBeNull();
+	expect(root.querySelector('li[data-task] input[type="checkbox"]')).not.toBe(
+		null,
+	);
+	expect(statusesForText(html, "Confirm launch owner")).toEqual([]);
+	expect(statusesForText(html, "Draft release notes")).toEqual([]);
+	expect(statusesForText(html, "for beta customers")).toContain("added");
+	expect(statusesForText(html, "Confirm event names")).toContain("added");
+	expect(statusesForText(html, "Announce internally")).toEqual([]);
+}
+
+function assertMixedGfmDocumentDiff(html: string): void {
+	const root = htmlRoot(html);
+
+	expect(root.querySelector("table")).not.toBeNull();
+	expect(root.querySelector("code.language-ts")).not.toBeNull();
+	expect(root.querySelector('li[data-task] input[type="checkbox"]')).not.toBe(
+		null,
+	);
+
+	expect(statusesForText(html, "Launch review")).toEqual([]);
+	expect(statusesForText(html, "Read the")).toEqual([]);
+	expect(statusesForText(html, "ops@example.com")).toEqual([]);
+	expect(hrefsForText(html, "runbook")).toEqual([
+		"https://example.com/runbook-v2",
+	]);
+
+	expect(statusesForText(html, "API")).toEqual([]);
+	expect(statusesForText(html, "Dee")).toEqual([]);
+	expect(statusesForText(html, "Ready")).toEqual([]);
+	expect(statusesForText(html, "Draft")).toContain("removed");
+	expect(statusesForText(html, "Approved")).toContain("added");
+	expect(statusesForText(html, "Billing")).toContain("added");
+	expect(statusesForText(html, "Watching")).toContain("added");
+
+	expect(taskCheckedStatesForText(html, "Confirm launch owner")).toEqual([
+		true,
+	]);
+	expect(taskCheckedStatesForText(html, "Update docs")).toEqual([true]);
+	expect(statusesForText(html, "Confirm launch owner")).toEqual([]);
+	expect(statusesForText(html, "Keep migration note")).toEqual([]);
+	expect(statusesForText(html, "Verify search index")).toEqual([]);
+	expect(statusesForText(html, "Add rollback note")).toContain("added");
+
+	expect(statusesForText(html, 'notify("ops")')).toEqual([]);
+	expect(statusesForText(html, "staged")).toContain("removed");
+	expect(statusesForText(html, "global")).toContain("added");
+	expect(statusesForText(html, 'notify("support")')).toContain("added");
+}
+
+function expectStableRealLixBlockKeys(
+	html: string,
+	beforeBlocks: MarkdownBlockSnapshot[],
+	afterBlocks: MarkdownBlockSnapshot[],
+): void {
+	const stableAnchors = [
+		"Launch review",
+		"ops@example.com",
+		"Area",
+		"Confirm launch owner",
+		'notify("ops")',
+	];
+
+	for (const anchor of stableAnchors) {
+		const beforeId = blockIdContaining(beforeBlocks, anchor);
+		const afterId = blockIdContaining(afterBlocks, anchor);
+		expect(beforeId, `before block id for ${anchor}`).toBeTruthy();
+		expect(afterId, `after block id for ${anchor}`).toBe(beforeId);
+		expect(hasDiffKeyForBlock(html, afterId!)).toBe(true);
+	}
+}
+
+function hasDiffKeyForBlock(html: string, blockId: string): boolean {
+	return (
+		html.includes(`data-diff-key="${blockId}"`) ||
+		html.includes(`data-diff-key="${blockId}:`)
+	);
+}
+
+function blockIdContaining(
+	blocks: MarkdownBlockSnapshot[],
+	text: string,
+): string | undefined {
+	return blocks.find((block) => block.block.includes(text))?.id;
+}
+
+function fixtureById(id: string) {
+	const fixture = MARKDOWN_DIFF_FIXTURES.find((entry) => entry.id === id);
+	if (!fixture) throw new Error(`Missing markdown diff fixture '${id}'`);
+	return fixture;
+}
+
+function statusesForText(html: string, text: string): string[] {
+	const root = htmlRoot(html);
+	const statuses = new Set<string>();
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+	let node = walker.nextNode();
+	while (node) {
+		if (node.textContent?.includes(text)) {
+			const status = nearestDiffStatus(parentElementForNode(node));
+			if (status) statuses.add(status);
+		}
+		node = walker.nextNode();
+	}
+	return [...statuses].sort();
+}
+
+function statusesForSelector(html: string, selector: string): string[] {
+	const root = htmlRoot(html);
+	return [...root.querySelectorAll(selector)]
+		.map((element) => nearestDiffStatus(element))
+		.filter((status): status is string => status !== null)
+		.sort();
+}
+
+function hrefsForText(html: string, text: string): string[] {
+	const root = htmlRoot(html);
+	return [...root.querySelectorAll("a")]
+		.filter((link) => link.textContent?.includes(text))
+		.map((link) => link.getAttribute("href"))
+		.filter((href): href is string => href !== null)
+		.sort();
+}
+
+function imageTitlesForAlt(html: string, alt: string): string[] {
+	const root = htmlRoot(html);
+	return [...root.querySelectorAll("img")]
+		.filter((image) => image.getAttribute("alt") === alt)
+		.map((image) => image.getAttribute("title"))
+		.filter((title): title is string => title !== null)
+		.sort();
+}
+
+function htmlRoot(html: string): HTMLDivElement {
+	const root = document.createElement("div");
+	root.innerHTML = html;
+	return root;
+}
+
+function duplicateDiffKeys(html: string): string[] {
+	const root = htmlRoot(html);
+	const seen = new Set<string>();
+	const duplicates = new Set<string>();
+	for (const element of root.querySelectorAll("[data-diff-key]")) {
+		const key = element.getAttribute("data-diff-key");
+		if (!key) continue;
+		if (seen.has(key)) duplicates.add(key);
+		seen.add(key);
+	}
+	return [...duplicates].sort();
+}
+
+function taskCheckedStatesForText(html: string, text: string): boolean[] {
+	const root = htmlRoot(html);
+	return [...root.querySelectorAll("li[data-task]")]
+		.filter((item) => listItemOwnText(item).includes(text))
+		.map((item) => {
+			const checkbox = item.querySelector<HTMLInputElement>(
+				'input[type="checkbox"]',
+			);
+			if (!checkbox) throw new Error(`Missing checkbox for task '${text}'`);
+			return checkbox.checked;
+		});
+}
+
+function listItemOwnText(item: Element): string {
+	let text = "";
+	for (const child of item.childNodes) {
+		if (
+			child.nodeType === Node.ELEMENT_NODE &&
+			(child as Element).tagName === "UL"
+		) {
+			continue;
+		}
+		text += child.textContent ?? "";
+	}
+	return text.replace(/\s+/g, " ").trim();
+}
+
+function parentElementForNode(node: Node): Element | null {
+	const parent = node.parentNode;
+	return parent?.nodeType === Node.ELEMENT_NODE ? (parent as Element) : null;
+}
+
+function nearestDiffStatus(element: Element | null): string | null {
+	let current: Element | null = element;
+	while (current) {
+		const status = current.getAttribute("data-diff-status");
+		if (status) return status;
+		current = current.parentElement;
+	}
+	return null;
+}
+
+async function writeMarkdownFile(
+	lix: Lix,
+	path: string,
+	markdown: string,
+): Promise<void> {
+	await lix.execute(
+		"INSERT INTO lix_file (path, data) VALUES (?, ?) \
+		 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+		[path, new TextEncoder().encode(markdown)],
+	);
+}
+
+async function installBundledPlugins(lix: Lix): Promise<void> {
+	for (const plugin of await bundledPluginArchives()) {
+		await lix.execute(
+			"INSERT INTO lix_file (path, data) VALUES (?, ?) \
+			 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+			[`/.lix_system/plugins/${plugin.key}.lixplugin`, plugin.archiveBytes],
+		);
+	}
+}
+
+async function fileIdByPath(lix: Lix, path: string): Promise<string> {
+	const result = await lix.execute("SELECT id FROM lix_file WHERE path = ?", [
+		path,
+	]);
+	const id = result.rows[0]?.get("id");
+	if (typeof id !== "string") throw new Error(`Missing file id for ${path}`);
+	return id;
+}
+
+async function activeCommitId(lix: Lix): Promise<string> {
+	const result = await lix.execute("SELECT lix_active_branch_commit_id()");
+	const commitId = result.rows[0]?.get("lix_active_branch_commit_id()");
+	if (typeof commitId !== "string") {
+		throw new Error("Missing active branch commit id");
+	}
+	return commitId;
+}
+
+async function historicalMarkdownBlocks(
+	lix: Lix,
+	commitId: string,
+	fileId: string,
+): Promise<MarkdownBlockSnapshot[]> {
+	const result = await lix.execute(
+		`
+			WITH ranked AS (
+				SELECT
+					snapshot_content,
+					ROW_NUMBER() OVER (
+						PARTITION BY entity_pk
+						ORDER BY depth ASC
+					) AS rn
+				FROM lix_state_history
+				WHERE start_commit_id = ?
+					AND file_id = ?
+					AND schema_key = 'markdown_block'
+			)
+			SELECT snapshot_content
+			FROM ranked
+			WHERE rn = 1
+				AND snapshot_content IS NOT NULL
+		`,
+		[commitId, fileId],
+	);
+	return result.rows
+		.map((row) => parseMarkdownBlockSnapshot(row.get("snapshot_content")))
+		.filter((block): block is MarkdownBlockSnapshot => block !== null)
+		.sort(
+			(left, right) =>
+				left.orderKey.localeCompare(right.orderKey) ||
+				left.id.localeCompare(right.id),
+		);
+}
+
+function parseMarkdownBlockSnapshot(
+	value: unknown,
+): MarkdownBlockSnapshot | null {
+	const content =
+		typeof value === "string"
+			? JSON.parse(value)
+			: (value as Record<string, any>);
+	if (
+		!content ||
+		typeof content.id !== "string" ||
+		typeof content.order_key !== "string" ||
+		typeof content.block !== "string"
+	) {
+		return null;
+	}
+	return {
+		id: content.id,
+		orderKey: content.order_key,
+		block: content.block,
+	};
+}

--- a/src/extensions/markdown/render-review-diff-html.ts
+++ b/src/extensions/markdown/render-review-diff-html.ts
@@ -10,16 +10,191 @@ import type { MarkdownReviewDiff } from "./review-diff";
 export function renderMarkdownReviewDiffHtml(
 	reviewDiff: MarkdownReviewDiff,
 ): string {
+	if (reviewDiff.beforeBlocks !== undefined && reviewDiff.afterBlocks !== undefined) {
+		return normalizeHtmlDiffFragment(
+			renderHtmlDiff({
+				beforeHtml: renderMarkdownBlocksHtml(reviewDiff.beforeBlocks),
+				afterHtml: renderMarkdownBlocksHtml(reviewDiff.afterBlocks),
+				diffAttribute: "data-diff-key",
+			}),
+		);
+	}
+
 	const beforeAst = parseMarkdown(reviewDiff.beforeMarkdown) as any;
 	const afterAst = parseMarkdown(reviewDiff.afterMarkdown) as any;
 	ensurePairedDiffIds(beforeAst, afterAst);
 	const beforeHtml = renderMarkdownAstEditorHtml(beforeAst);
 	const afterHtml = renderMarkdownAstEditorHtml(afterAst);
-	return renderHtmlDiff({
-		beforeHtml,
-		afterHtml,
-		diffAttribute: "data-diff-key",
+	return normalizeHtmlDiffFragment(
+		renderHtmlDiff({
+			beforeHtml,
+			afterHtml,
+			diffAttribute: "data-diff-key",
+		}),
+	);
+}
+
+function normalizeHtmlDiffFragment(html: string): string {
+	// html-diff wraps multi-root fragments in a plain div. The markdown view
+	// needs TipTap blocks as direct ProseMirror children, and ProseMirror's
+	// break-spaces styling makes top-level whitespace text nodes visible.
+	const template = document.createElement("template");
+	template.innerHTML = html.trim();
+	const childElements = Array.from(template.content.children);
+	if (childElements.length !== 1) {
+		return serializeHtmlFragmentWithoutWhitespaceText(template.content);
+	}
+	const wrapper = childElements[0];
+	if (wrapper?.tagName !== "DIV" || wrapper.attributes.length > 0) {
+		return html;
+	}
+	if (wrapper.children.length <= 1) {
+		return html;
+	}
+	return serializeHtmlFragmentWithoutWhitespaceText(wrapper);
+}
+
+function serializeHtmlFragmentWithoutWhitespaceText(
+	root: DocumentFragment | Element,
+): string {
+	return Array.from(root.childNodes)
+		.filter((node) => node.nodeType !== Node.TEXT_NODE || node.textContent?.trim())
+		.map((node) => {
+			if (node instanceof Element) return node.outerHTML;
+			return node.textContent ?? "";
+		})
+		.join("");
+}
+
+function renderMarkdownBlocksHtml(
+	blocks: NonNullable<MarkdownReviewDiff["beforeBlocks"]>,
+): string {
+	return blocks.map(renderMarkdownBlockHtml).join("\n");
+}
+
+function renderMarkdownBlockHtml(
+	block: NonNullable<MarkdownReviewDiff["beforeBlocks"]>[number],
+): string {
+	const ast = parseMarkdown(block.block) as any;
+	ensureDiffIds(ast);
+	ensureNestedDiffIds(ast, block.id);
+	const children = Array.isArray(ast.children) ? ast.children : [];
+	for (const child of children) {
+		if (supportsDiffId(child)) {
+			if (child?.type === "list" || child?.type === "table") {
+				clearDataId(child);
+			} else {
+				writeDataId(child, block.id);
+				if (child?.type === "blockquote") {
+					writeDataDiffMode(child, "words");
+				}
+			}
+			break;
+		}
+	}
+	return renderMarkdownAstEditorHtml(ast);
+}
+
+function ensureNestedDiffIds(ast: any, blockId: string): void {
+	const children = Array.isArray(ast?.children) ? ast.children : [];
+	for (const child of children) {
+		if (child?.type === "list") {
+			ensureListItemDiffIds(child, blockId);
+		} else if (child?.type === "table") {
+			ensureTableDiffIds(child, blockId);
+		}
+	}
+}
+
+function ensureListItemDiffIds(
+	listNode: any,
+	blockId: string,
+	parentKey = "",
+): void {
+	clearDataId(listNode);
+	const items = Array.isArray(listNode.children) ? listNode.children : [];
+	const itemKeys = items.map((item: any, index: number) =>
+		item?.type === "listItem" ? stableListItemKey(item, index) : "",
+	);
+	const itemKeyCounts = new Map<string, number>();
+	for (const itemKey of itemKeys) {
+		if (!itemKey) continue;
+		itemKeyCounts.set(itemKey, (itemKeyCounts.get(itemKey) ?? 0) + 1);
+	}
+	const resolvedKeys = items.map((item: any, index: number) => {
+		const stableKey = itemKeys[index] || `index-${index}`;
+		if (itemKeyCounts.get(stableKey) === 1) return stableKey;
+		return `${stableKey}:${listItemChildSignature(item, index)}`;
 	});
+	const resolvedKeyCounts = new Map<string, number>();
+	for (const key of resolvedKeys) {
+		if (!key) continue;
+		resolvedKeyCounts.set(key, (resolvedKeyCounts.get(key) ?? 0) + 1);
+	}
+	items.forEach((item: any, index: number) => {
+		if (item?.type !== "listItem") return;
+		const resolvedKey = resolvedKeys[index] || `index-${index}`;
+		const itemKey =
+			resolvedKeyCounts.get(resolvedKey) === 1
+				? `${parentKey}${resolvedKey}`
+				: `${parentKey}${resolvedKey}:${index}`;
+		clearDataId(item);
+		writeListItemOwnDiffId(item, `${blockId}:li:${itemKey}`);
+		for (const child of Array.isArray(item.children) ? item.children : []) {
+			if (child?.type === "list") {
+				ensureListItemDiffIds(child, blockId, `${itemKey}:`);
+			}
+		}
+	});
+}
+
+function ensureTableDiffIds(tableNode: any, blockId: string): void {
+	clearDataId(tableNode);
+	const rows = Array.isArray(tableNode.children) ? tableNode.children : [];
+	const columnKeys = tableColumnKeys(rows);
+	const firstCellCounts = new Map<string, number>();
+	for (const row of rows) {
+		if (row?.type !== "tableRow") continue;
+		const firstCellKey = tableRowFirstCellKey(row);
+		firstCellCounts.set(
+			firstCellKey,
+			(firstCellCounts.get(firstCellKey) ?? 0) + 1,
+		);
+	}
+	rows.forEach((row: any, rowIndex: number) => {
+		if (row?.type !== "tableRow") return;
+			const rowKey = `${blockId}:tr:${tableRowKey(
+				row,
+				rowIndex,
+				firstCellCounts,
+			)}`;
+		clearDataId(row);
+		const cells = Array.isArray(row.children) ? row.children : [];
+		cells.forEach((cell: any, cellIndex: number) => {
+			if (cell?.type === "tableCell") {
+				writeDataId(
+					cell,
+					`${rowKey}:td:${columnKeys[cellIndex] ?? `index-${cellIndex}`}`,
+				);
+			}
+		});
+	});
+}
+
+function tableColumnKeys(rows: any[]): string[] {
+	const headerCells: any[] = Array.isArray(rows[0]?.children)
+		? rows[0].children
+		: [];
+	const baseKeys = headerCells.map((cell: any, index: number) =>
+		stableTextKey(cell, index),
+	);
+	const counts = new Map<string, number>();
+	for (const key of baseKeys) {
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+	return baseKeys.map((key, index) =>
+		counts.get(key) === 1 ? key : `${key}:${index}`,
+	);
 }
 
 function ensurePairedDiffIds(beforeAst: any, afterAst: any): void {
@@ -90,8 +265,122 @@ function writeDataId(node: any, id: string): void {
 	node.data.id = id;
 }
 
+function clearDataId(node: any): void {
+	if (!node || typeof node !== "object") return;
+	if (!node.data || typeof node.data !== "object") return;
+	delete node.data.id;
+}
+
+function writeDataDiffMode(node: any, mode: "words" | "element"): void {
+	node.data = node.data && typeof node.data === "object" ? node.data : {};
+	node.data.diffMode = mode;
+}
+
 function blockSignature(node: any): string {
 	return `${node.type}:${textContent(node).replace(/\s+/g, " ").trim()}`;
+}
+
+function tableRowKey(
+	row: any,
+	rowIndex: number,
+	firstCellCounts: ReadonlyMap<string, number>,
+): string {
+	const cells = Array.isArray(row?.children) ? row.children : [];
+	const firstCellText = cells.length > 0 ? textContent(cells[0]) : "";
+	let identityText = firstCellText;
+	if (firstCellCounts.get(tableRowFirstCellKey(row)) !== 1) {
+		const disambiguator = duplicateRowDisambiguator(cells.slice(1));
+		identityText = `${firstCellText} ${disambiguator ?? ""}`;
+	}
+	return stableTextKey({ value: identityText }, rowIndex);
+}
+
+function duplicateRowDisambiguator(cells: any[]): string | undefined {
+	const candidates = cells
+		.map(textContent)
+		.map((text: string) => text.replace(/\s+/g, " ").trim())
+		.filter(Boolean);
+	const labelLike = candidates
+		.filter((text: string) => /^[A-Z][\p{L}\p{N}\s.'-]{0,39}$/u.test(text))
+		.sort((a: string, b: string) => a.length - b.length)[0];
+	return labelLike ?? candidates.sort((a: string, b: string) => b.length - a.length)[0];
+}
+
+function tableRowFirstCellKey(row: any): string {
+	const cells = Array.isArray(row?.children) ? row.children : [];
+	return textContent(cells[0]).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function stableTextKey(node: any, index: number): string {
+	const text = textContent(node).replace(/\s+/g, " ").trim();
+	const label = text.match(/^([^:]{1,80}):/)?.[1] ?? text;
+	const normalized = label
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return normalized || `index-${index}`;
+}
+
+function stableListItemKey(item: any, index: number): string {
+	const text = listItemOwnText(item).replace(/\s+/g, " ").trim();
+	const label = text.match(/^([^:]{1,80}):/)?.[1];
+	const identityText = label ?? text.split(/\s+/).slice(0, 3).join(" ");
+	const normalized = identityText
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return normalized || `index-${index}`;
+}
+
+function listItemOwnText(item: any): string {
+	const children = Array.isArray(item?.children) ? item.children : [];
+	return children
+		.filter((child: any) => child?.type !== "list")
+		.map(textContent)
+		.join("");
+}
+
+function listItemChildSignature(item: any, index: number): string {
+	const childKeys = nestedListItems(item)
+		.map((child, childIndex) => stableListItemKey(child, childIndex))
+		.filter(Boolean)
+		.sort();
+	const uniqueChildKeys = [...new Set(childKeys)];
+	return uniqueChildKeys.length > 0
+		? uniqueChildKeys.join("-")
+		: `index-${index}`;
+}
+
+function nestedListItems(item: any): any[] {
+	const out: any[] = [];
+	const visit = (node: any) => {
+		const children = Array.isArray(node?.children) ? node.children : [];
+		for (const child of children) {
+			if (child?.type === "list") {
+				for (const listItem of Array.isArray(child.children)
+					? child.children
+					: []) {
+					if (listItem?.type === "listItem") {
+						out.push(listItem);
+						visit(listItem);
+					}
+				}
+			}
+		}
+	};
+	visit(item);
+	return out;
+}
+
+function writeListItemOwnDiffId(item: any, id: string): void {
+	const children = Array.isArray(item?.children) ? item.children : [];
+	const ownBlock = children.find(
+		(child: any) => child?.type !== "list" && supportsDiffId(child),
+	);
+	if (ownBlock) {
+		writeDataId(ownBlock, id);
+		writeDataDiffMode(ownBlock, "words");
+	}
 }
 
 function textContent(node: any): string {

--- a/src/extensions/markdown/review-diff.ts
+++ b/src/extensions/markdown/review-diff.ts
@@ -1,6 +1,14 @@
 export type MarkdownReviewDiff = {
 	readonly beforeMarkdown: string;
 	readonly afterMarkdown: string;
+	readonly beforeBlocks?: readonly MarkdownBlockSnapshot[];
+	readonly afterBlocks?: readonly MarkdownBlockSnapshot[];
 	readonly beforeDepth?: number;
 	readonly afterDepth?: number;
+};
+
+export type MarkdownBlockSnapshot = {
+	readonly id: string;
+	readonly orderKey: string;
+	readonly block: string;
 };

--- a/src/shell/external-write-review-history.ts
+++ b/src/shell/external-write-review-history.ts
@@ -7,6 +7,7 @@ import type { ExternalWriteReview } from "@/extension-runtime/external-write-rev
 type FileHistoryRow = {
 	readonly data: unknown;
 	readonly lixcol_depth: number | null;
+	readonly lixcol_observed_commit_id: string | null;
 };
 
 export async function getExternalWriteReview(
@@ -15,22 +16,25 @@ export async function getExternalWriteReview(
 	path: string,
 ): Promise<ExternalWriteReview | null> {
 	const rows = await getHistoryRows(lix, fileId);
-	if (rows.length < 2) return null;
-	const afterData = decodeFileDataToBytes(rows[0]?.data);
-	const beforeData = decodeFileDataToBytes(rows[1]?.data);
+	if (!rows || rows.history.length < 2) return null;
+	const afterData = decodeFileDataToBytes(rows.history[0]?.data);
+	const beforeData = decodeFileDataToBytes(rows.history[1]?.data);
 	return {
 		fileId,
 		path,
 		reviewId: `${fileId}:${hashFileData(beforeData)}:${hashFileData(afterData)}`,
 		afterData,
 		beforeData,
+		afterCommitId:
+			rows.history[0]?.lixcol_observed_commit_id ?? rows.startCommitId,
+		beforeCommitId: rows.history[1]?.lixcol_observed_commit_id ?? undefined,
 		afterDepth:
-			typeof rows[0]?.lixcol_depth === "number"
-				? rows[0].lixcol_depth
+			typeof rows.history[0]?.lixcol_depth === "number"
+				? rows.history[0].lixcol_depth
 				: undefined,
 		beforeDepth:
-			typeof rows[1]?.lixcol_depth === "number"
-				? rows[1].lixcol_depth
+			typeof rows.history[1]?.lixcol_depth === "number"
+				? rows.history[1].lixcol_depth
 				: undefined,
 	};
 }
@@ -38,7 +42,7 @@ export async function getExternalWriteReview(
 async function getHistoryRows(
 	lix: Lix,
 	fileId: string,
-): Promise<FileHistoryRow[]> {
+): Promise<{ startCommitId: string; history: FileHistoryRow[] } | null> {
 	const activeBranchId = await lix.activeBranchId();
 	const branch = await qb(lix)
 		.selectFrom("lix_branch")
@@ -49,15 +53,16 @@ async function getHistoryRows(
 
 	const startCommitId = branch?.commit_id;
 	if (typeof startCommitId !== "string" || startCommitId.length === 0) {
-		return [];
+		return null;
 	}
 
-	return (await qb(lix)
+	const history = (await qb(lix)
 		.selectFrom("lix_file_history")
-		.select(["data", "lixcol_depth"])
+		.select(["data", "lixcol_depth", "lixcol_observed_commit_id"])
 		.where("lixcol_start_commit_id", "=", startCommitId)
 		.where("id", "=", fileId)
 		.orderBy("lixcol_depth", "asc")
 		.limit(2)
 		.execute()) as FileHistoryRow[];
+	return { startCommitId, history };
 }

--- a/src/test-utils/node-lix-sdk.ts
+++ b/src/test-utils/node-lix-sdk.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import type {
+	BundledPluginArchive,
 	ExecuteResult,
 	Lix as SdkLix,
 	OpenLixOptions as SdkOpenLixOptions,
@@ -15,6 +16,7 @@ import type {
 } from "@/lib/lix-types";
 
 export type { Lix, SqlTransaction } from "@/lib/lix-types";
+export type { BundledPluginArchive };
 
 type OpenTestLixOptions = SdkOpenLixOptions & {
 	keyValues?: ReadonlyArray<OpenLixKeyValueEntry>;
@@ -35,6 +37,11 @@ export async function openLix(options: OpenTestLixOptions = {}): Promise<Lix> {
 		await seedKeyValues(lix, keyValues);
 	}
 	return lix;
+}
+
+export async function bundledPluginArchives(): Promise<BundledPluginArchive[]> {
+	const sdk = await loadSdk();
+	return await sdk.bundledPluginArchives();
 }
 
 async function loadSdk(): Promise<SdkModule> {


### PR DESCRIPTION
## Summary

- render markdown review diffs from Lix markdown block snapshots when available
- add stable nested diff keys for markdown lists and tables
- normalize html-diff output so it matches TipTap/ProseMirror DOM expectations
- add visual and automated GFM markdown diff fixtures

## Validation

- pnpm vitest run src/extensions/markdown/render-review-diff-html.test.ts
- pnpm run typecheck
- pnpm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large change to review diff rendering and alignment logic; mistakes could mislabel adds/removes or break the review overlay, but scope is editor UX with strong fixture and Lix integration tests.
> 
> **Overview**
> External-write markdown review now prefers **Lix `markdown_block` snapshots** at the before/after commit IDs (new on `ExternalWriteReview` from file history) instead of diffing whole-file markdown only. The overlay loads those blocks from `lix_state_history`, shows a loading state while they resolve, and passes enriched `beforeBlocks` / `afterBlocks` into the renderer.
> 
> **`renderMarkdownReviewDiffHtml`** takes a snapshot path when both block arrays are present: each block is rendered with stable `data-diff-key` values from Lix block ids, plus nested keys for list items and table rows/cells (including duplicate labels and reorders). Output is **normalized** so html-diff wrappers and whitespace do not break TipTap/ProseMirror layout. TipTap list HTML now renders **task checkboxes** and honors per-node **`data-diff-mode`**.
> 
> Coverage adds a large **GFM fixture suite** (tables, task lists, moves, inline media) with Vitest assertions and optional **visual.html** preview, plus integration tests that build real Lix history via bundled plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3136bb830316269576ae951b592f89cabe9dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->