### PR TITLE
Check for updates while app stays open

### DIFF
--- a/.changenotes/check-for-updates-while-open.md
+++ b/.changenotes/check-for-updates-while-open.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+FlashType now checks for updates periodically while the app stays open.
+
+Users who keep FlashType running for long sessions will see the Update button after a new release is downloaded, without needing to restart the app first.

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -25,6 +25,8 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const execFileAsync = promisify(execFile);
 const AUTO_UPDATE_CHECK_DELAY_MS = 10_000;
+const AUTO_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const TELEMETRY_HEARTBEAT_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const DEV_SERVER_URL =
 	process.env.VITE_DEV_SERVER_URL ?? "http://127.0.0.1:4173";
 const workspaceWindows = new Set();
@@ -39,6 +41,7 @@ let pendingManualUpdateCheck = false;
 let updateWindow = null;
 let updateWindowCloseTimer = null;
 let updateIconDataUrl = null;
+let telemetryHeartbeatInterval = null;
 
 app.setName(APP_NAME);
 app.setAboutPanelOptions({
@@ -228,6 +231,7 @@ if (hasSingleInstanceLock) {
 			);
 		});
 		void captureAppOpened();
+		setupTelemetryHeartbeat();
 		const workspacePathsToOpen = [
 			...getWorkspacePathArguments(process.argv, {
 				defaultApp: process.defaultApp === true,
@@ -277,9 +281,32 @@ async function setupAutoUpdates() {
 		setTimeout(() => {
 			void checkForUpdates(autoUpdater);
 		}, AUTO_UPDATE_CHECK_DELAY_MS);
+		setInterval(() => {
+			if (updateInstallReady) {
+				return;
+			}
+			void checkForUpdates(autoUpdater);
+		}, AUTO_UPDATE_CHECK_INTERVAL_MS);
 	} catch (error) {
 		console.warn("Failed to initialize Flashtype auto updates", error);
 	}
+}
+
+function setupTelemetryHeartbeat() {
+	if (!app.isPackaged || telemetryHeartbeatInterval !== null) {
+		return;
+	}
+	telemetryHeartbeatInterval = setInterval(() => {
+		if (!hasFocusedWorkspaceWindow()) {
+			return;
+		}
+		void captureAppOpened({ trigger: "heartbeat" });
+	}, TELEMETRY_HEARTBEAT_INTERVAL_MS);
+}
+
+function hasFocusedWorkspaceWindow() {
+	const focusedWindow = BrowserWindow.getFocusedWindow();
+	return Boolean(focusedWindow && workspaceWindows.has(focusedWindow));
 }
 
 function canUseAutoUpdates() {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -505,8 +505,8 @@ function showUpdateWindow(initialState) {
 			!window.isDestroyed() && window === BrowserWindow.getFocusedWindow(),
 	);
 	updateWindow = new BrowserWindow({
-		width: 560,
-		height: 260,
+		width: 440,
+		height: 184,
 		resizable: false,
 		minimizable: false,
 		maximizable: false,
@@ -517,7 +517,7 @@ function showUpdateWindow(initialState) {
 		...(process.platform === "darwin"
 			? {
 					titleBarStyle: "hiddenInset",
-					trafficLightPosition: { x: 18, y: 18 },
+					trafficLightPosition: { x: 16, y: 15 },
 				}
 			: {}),
 		...(parentWindow ? { parent: parentWindow } : {}),
@@ -602,33 +602,33 @@ function renderUpdateWindowHtml(initialState) {
 		}
 
 		.titlebar {
-			height: 58px;
+			height: 44px;
 			display: flex;
 			align-items: center;
-			padding-left: 160px;
+			padding-left: 92px;
 			border-bottom: 1px solid rgba(0, 0, 0, 0.32);
-			font-size: 26px;
-			font-weight: 760;
+			font-size: 13px;
+			font-weight: 650;
 			color: rgba(242, 244, 248, 0.72);
 			-webkit-app-region: drag;
 		}
 
 		.content {
 			display: grid;
-			grid-template-columns: 104px 1fr;
-			gap: 28px;
-			padding: 22px 32px 28px 42px;
+			grid-template-columns: 64px 1fr;
+			gap: 18px;
+			padding: 18px 24px 22px 28px;
 			align-items: center;
 		}
 
 		.icon {
-			width: 104px;
-			height: 104px;
-			border-radius: 24px;
+			width: 64px;
+			height: 64px;
+			border-radius: 14px;
 			background: linear-gradient(180deg, #ffffff, #eef1f5);
 			display: grid;
 			place-items: center;
-			box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);
+			box-shadow: 0 8px 22px rgba(0, 0, 0, 0.24);
 			overflow: hidden;
 		}
 
@@ -640,7 +640,7 @@ function renderUpdateWindowHtml(initialState) {
 		}
 
 		.fallback-icon {
-			font-size: 48px;
+			font-size: 30px;
 			font-weight: 900;
 			color: #f06f2a;
 		}
@@ -650,10 +650,10 @@ function renderUpdateWindowHtml(initialState) {
 		}
 
 		.heading {
-			margin: 0 0 24px;
-			font-size: 26px;
-			line-height: 1.05;
-			font-weight: 800;
+			margin: 0 0 14px;
+			font-size: 16px;
+			line-height: 1.2;
+			font-weight: 700;
 			letter-spacing: 0;
 			color: #f4f5f7;
 		}
@@ -661,7 +661,7 @@ function renderUpdateWindowHtml(initialState) {
 		.progress {
 			position: relative;
 			width: 100%;
-			height: 16px;
+			height: 8px;
 			border-radius: 999px;
 			background: rgba(255, 255, 255, 0.12);
 			overflow: hidden;
@@ -681,22 +681,22 @@ function renderUpdateWindowHtml(initialState) {
 		}
 
 		.detail {
-			margin-top: 38px;
-			font-size: 25px;
-			line-height: 1.15;
-			font-weight: 700;
+			margin-top: 14px;
+			font-size: 13px;
+			line-height: 1.35;
+			font-weight: 500;
 			color: rgba(242, 244, 248, 0.86);
 		}
 
 		.action {
 			display: none;
-			margin-top: 20px;
+			margin-top: 12px;
 			border: 0;
 			border-radius: 7px;
-			padding: 7px 16px;
+			padding: 6px 12px;
 			background: #1287ff;
 			color: white;
-			font-size: 13px;
+			font-size: 12px;
 			font-weight: 700;
 		}
 

--- a/electron/telemetry.mjs
+++ b/electron/telemetry.mjs
@@ -8,7 +8,7 @@ const ENV_VARIABLES_FILE = "build/env-variables.mjs";
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 const POSTHOG_CAPTURE_ENDPOINT = "/capture/";
 
-export async function captureAppOpened() {
+export async function captureAppOpened({ trigger = "launch" } = {}) {
 	if (!app.isPackaged) {
 		return;
 	}
@@ -28,6 +28,8 @@ export async function captureAppOpened() {
 				app_version: env.APP_VERSION ?? app.getVersion(),
 				platform: process.platform,
 				is_packaged: app.isPackaged,
+				trigger,
+				uptime_seconds: Math.floor(process.uptime()),
 			},
 		};
 


### PR DESCRIPTION
## Summary
- check for updates every 4 hours after the initial startup check
- keep using the existing app_opened telemetry event, adding trigger and uptime_seconds properties
- emit app_opened heartbeats every 4 hours only while a Flashtype workspace window is focused

## Verification
- node scripts/validate-changes.mjs
- pnpm run typecheck
- pnpm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Background update polling and optional PostHog heartbeats; no changes to auth, data handling, or install logic beyond scheduling.
> 
> **Overview**
> Long-running sessions now **re-check for updates every 4 hours** after the existing ~10s startup check, and **skip further checks** once an install-ready update is already downloaded so users can get the Update affordance without restarting first.
> 
> **Telemetry** reuses `app_opened` with new properties **`trigger`** (default `launch`, or `heartbeat`) and **`uptime_seconds`**. A **4-hour heartbeat** fires only when a **workspace window is focused** (packaged builds).
> 
> The manual update progress window is **visually tightened** (smaller window and typography). A patch changenote documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f6070d1c4341cb8146891a658c9f9866541e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->