### PR TITLE
[codex] Polish markdown editing and terminal colors

### DIFF
--- a/electron/terminal-shell.mjs
+++ b/electron/terminal-shell.mjs
@@ -61,17 +61,20 @@ export function buildTerminalEnv(
 	env = process.env,
 	platform = process.platform,
 ) {
+	const terminalEnv = { ...env };
+	delete terminalEnv.NO_COLOR;
+
 	if (platform === "win32") {
 		return {
-			...env,
+			...terminalEnv,
 			TERM: "xterm-256color",
 		};
 	}
 
 	return {
-		...env,
+		...terminalEnv,
 		PATH: mergePathEntries([
-			...(env.PATH ?? "").split(":"),
+			...(terminalEnv.PATH ?? "").split(":"),
 			...(PATH_ENTRIES_BY_PLATFORM[platform] ??
 				PATH_ENTRIES_BY_PLATFORM.default),
 		]),

--- a/electron/terminal-shell.test.mjs
+++ b/electron/terminal-shell.test.mjs
@@ -39,6 +39,21 @@ describe("terminal shell launch", () => {
 		expect(env.TERM).toBe("xterm-256color");
 	});
 
+	test("does not pass NO_COLOR into spawned terminals", () => {
+		const env = buildTerminalEnv(
+			{
+				PATH: "/usr/bin",
+				NO_COLOR: "1",
+				COLORTERM: "truecolor",
+			},
+			"darwin",
+		);
+
+		expect(env.NO_COLOR).toBeUndefined();
+		expect(env.COLORTERM).toBe("truecolor");
+		expect(env.TERM).toBe("xterm-256color");
+	});
+
 	test("deduplicates fallback PATH entries", () => {
 		const env = buildTerminalEnv(
 			{ PATH: "/usr/local/bin:/custom/bin:/usr/local/bin" },

--- a/src/extensions/files/file-tree.tsx
+++ b/src/extensions/files/file-tree.tsx
@@ -159,9 +159,9 @@ function FileTreeNode({
 			"flex h-7 w-full min-w-0 items-center gap-2 rounded-[7px] pr-2.25 text-left transition-[background-color,color,box-shadow] duration-100 ease-out [&_svg]:transition-colors [&_svg]:duration-100",
 			rowInteractionClass,
 			isSelected && isPanelFocused
-				? "bg-focus-tint font-semibold text-neutral-900 ring-1 ring-inset ring-focus-ring [&_svg]:text-brand-700"
+				? "bg-focus-tint text-neutral-900 ring-1 ring-inset ring-focus-ring [&_svg]:text-brand-700"
 				: isSelected
-					? "bg-hover-soft font-semibold text-neutral-700 [&_svg]:text-neutral-500"
+					? "bg-hover-soft text-neutral-700 [&_svg]:text-neutral-500"
 					: "text-neutral-600 hover:bg-hover-soft [&_svg]:text-neutral-400",
 		);
 		const itemTestId = `file-tree-item-${sanitizeForTestId(node.path)}`;

--- a/src/extensions/markdown/components/formatting-toolbar.test.tsx
+++ b/src/extensions/markdown/components/formatting-toolbar.test.tsx
@@ -265,6 +265,34 @@ describe("FormattingToolbar", () => {
 		destroyEditor(setup);
 	});
 
+	test("converts a selected checklist item back to a plain bullet list", async () => {
+		const setup = createEditor(
+			astToTiptapDoc(parseMarkdown("- [ ] todo\n")) as JSONContent,
+		);
+		const utils = renderToolbar(setup.editor);
+
+		const bulletButton = await screen.findByLabelText("Bullet list");
+		const checklistButton = await screen.findByLabelText("Checklist");
+
+		await act(async () => {
+			setup.editor.commands.setTextSelection({ from: 3, to: 3 });
+			fireEvent.click(bulletButton);
+		});
+
+		const list = (setup.editor.getJSON() as any).content?.[0];
+		const listItem = list?.content?.[0];
+		expect(list?.attrs?.isTaskList).toBe(false);
+		expect(listItem?.attrs?.checked ?? null).toBeNull();
+		expect(buildMarkdownFromEditor(setup.editor)).toBe("- todo\n");
+		expect(bulletButton).toHaveAttribute("aria-pressed", "true");
+		expect(checklistButton).toHaveAttribute("aria-pressed", "false");
+
+		await act(async () => {
+			utils.unmount();
+		});
+		destroyEditor(setup);
+	});
+
 	test("shows plain bullets and checklist items separately in a mixed list", async () => {
 		const setup = createEditor(
 			astToTiptapDoc(parseMarkdown(mixedTaskListMarkdown)) as JSONContent,

--- a/src/extensions/markdown/components/formatting-toolbar.tsx
+++ b/src/extensions/markdown/components/formatting-toolbar.tsx
@@ -40,13 +40,14 @@ type FormatState = {
 
 /** 28px square icon button, matching the panel-header chips in the islands UI. */
 const iconButtonClass =
-	"inline-flex size-7 shrink-0 select-none items-center justify-center rounded-[7px] text-neutral-600 transition-colors hover:bg-hover-soft hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring disabled:cursor-not-allowed disabled:opacity-40";
+	"inline-flex size-7 shrink-0 select-none items-center justify-center rounded-[7px] text-neutral-500 transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-hover-soft hover:text-neutral-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring disabled:cursor-not-allowed disabled:opacity-40 [&_svg]:stroke-[1.9]";
 
 /** Pressed state for a formatting toggle. */
-const iconButtonActiveClass = "bg-neutral-200 text-neutral-900";
+const iconButtonActiveClass =
+	"bg-focus-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-focus-ring)] [&_svg]:text-brand-700";
 
 const ToolbarSeparator = () => (
-	<Toolbar.Separator className="mx-1.5 h-4 w-px bg-island-border" />
+	<Toolbar.Separator className="mx-1.5 h-3.5 w-px bg-island-divider" />
 );
 
 const initialFormatState: FormatState = {
@@ -151,6 +152,10 @@ export function FormattingToolbar({ className }: { className?: string }) {
 
 	const handleToggleBulletList = useCallback(() => {
 		if (!editor) return;
+		if (computeTaskListActive(editor, hasTaskListCommand)) {
+			setTaskListState(editor, null);
+			return;
+		}
 		if (editor.isActive("bulletList") && editor.state.selection.empty) {
 			return;
 		}
@@ -165,7 +170,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 				altChain.toggleBulletList?.()?.run?.() ??
 				false;
 		}
-	}, [editor]);
+	}, [editor, hasTaskListCommand]);
 
 	const handleToggleOrderedList = useCallback(() => {
 		if (!editor) return;
@@ -235,14 +240,18 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					<Toolbar.Button
 						render={<Select.Trigger />}
 						nativeButton={false}
-						className="inline-flex h-7 shrink-0 select-none items-center gap-1 rounded-[7px] pr-1.5 pl-2.5 text-[12.5px] font-semibold text-neutral-700 transition-colors hover:bg-hover-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring"
+						className={clsx(
+							"inline-flex h-7 shrink-0 select-none items-center gap-1 rounded-[7px] pr-1.5 pl-2.25 text-[12.5px] font-medium text-neutral-700 transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-hover-soft hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring",
+							blockMenuOpen &&
+								"bg-focus-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-focus-ring)]",
+						)}
 						onMouseDown={suppressMouseDown}
 					>
-						<Select.Value className="block w-[4.65rem] truncate">
+						<Select.Value className="block w-[4.25rem] truncate">
 							{activeBlockLabel}
 						</Select.Value>
-						<Select.Icon className="text-neutral-400">
-							<ChevronDown className="size-3.5" aria-hidden />
+						<Select.Icon className="text-neutral-400 transition-transform duration-100 data-[popup-open]:rotate-180">
+							<ChevronDown className="size-[13px] stroke-[2]" aria-hidden />
 						</Select.Icon>
 					</Toolbar.Button>
 					<Select.Portal>
@@ -253,29 +262,29 @@ export function FormattingToolbar({ className }: { className?: string }) {
 							sideOffset={6}
 							alignItemWithTrigger={false}
 						>
-							<Select.Popup className="min-w-[12rem] rounded-lg border border-border bg-card p-1 shadow-xl data-[side=bottom]:mt-2 data-[side=top]:mb-2 origin-[var(--transform-origin)] transition-[transform,opacity] duration-150 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-100 data-[ending-style]:opacity-100">
-								<div className="px-2 pb-1 pt-1 text-xs font-medium text-muted-foreground">
+							<Select.Popup className="min-w-[10.75rem] origin-[var(--transform-origin)] rounded-[8px] border border-island-border bg-neutral-0 p-1 shadow-lg transition-[transform,opacity] duration-150 data-[side=bottom]:mt-2 data-[side=top]:mb-2 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-100 data-[ending-style]:opacity-100">
+								<div className="px-2 pb-0.75 pt-1 text-[11px] font-medium leading-4 text-neutral-400">
 									Turn into
 								</div>
 								{TOOLBAR_BLOCK_OPTIONS.map((option) => (
 									<Select.Item
 										key={option.value}
 										value={option.value}
-										className="group flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none focus-visible:ring-0 data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+										className="group flex min-h-9 cursor-default items-center gap-2 rounded-[7px] px-2 py-1 text-[12.5px] outline-none focus-visible:ring-0 data-[highlighted]:bg-hover-soft data-[highlighted]:text-neutral-900"
 									>
-										<span className="flex size-5 items-center justify-center text-muted-foreground group-data-[highlighted]:text-foreground">
-											<option.icon className="h-4 w-4" aria-hidden />
+										<span className="flex size-4.5 items-center justify-center text-[12px] text-neutral-400 group-data-[highlighted]:text-neutral-600 [&_svg]:stroke-[1.8]">
+											<option.icon className="h-3.5 w-3.5" aria-hidden />
 										</span>
 										<div className="flex flex-1 flex-col">
-											<span className="text-sm font-medium">
+											<span className="text-[12.5px] font-semibold leading-4 text-neutral-800">
 												{option.label}
 											</span>
-											<span className="text-xs text-muted-foreground group-data-[highlighted]:text-muted-foreground/80">
+											<span className="text-[11.5px] font-normal leading-4 text-neutral-500">
 												{option.description}
 											</span>
 										</div>
-										<Select.ItemIndicator className="text-foreground">
-											<Check className="h-4 w-4" aria-hidden />
+										<Select.ItemIndicator className="text-brand-700">
+											<Check className="h-3.5 w-3.5 stroke-[2]" aria-hidden />
 										</Select.ItemIndicator>
 									</Select.Item>
 								))}
@@ -446,29 +455,58 @@ function toggleTaskListFallback(editor: Editor) {
 		}
 	}
 
-	const { state, view } = editor;
-	const { selection } = state;
-	const { from, to } = selection;
 	const listItemAttrs = editor.getAttributes("listItem");
 	const isCurrentlyTask =
 		listItemAttrs && typeof listItemAttrs.checked === "boolean";
+	setTaskListState(editor, isCurrentlyTask ? null : false);
+}
 
+function setTaskListState(editor: Editor, checked: boolean | null) {
+	const { state, view } = editor;
+	const { selection } = state;
 	const tr = state.tr;
 	let applied = false;
+	const touchedBulletLists = new Set<number>();
 
-	state.doc.nodesBetween(from, to, (node, pos) => {
+	const applyListItem = (node: any, pos: number) => {
 		if (node.type.name !== "listItem") return;
-		const attrs = { ...node.attrs };
-		if (isCurrentlyTask) {
-			if (attrs.checked == null) return;
-			attrs.checked = null;
-		} else {
-			if (attrs.checked === false) return;
-			attrs.checked = false;
-		}
-		tr.setNodeMarkup(pos, undefined, attrs);
+		if (checked === null && node.attrs.checked == null) return;
+		if (checked !== null && node.attrs.checked === checked) return;
+		tr.setNodeMarkup(pos, undefined, { ...node.attrs, checked });
 		applied = true;
-	});
+	};
+
+	const applyBulletList = (node: any, pos: number) => {
+		if (node.type.name !== "bulletList" || touchedBulletLists.has(pos)) return;
+		touchedBulletLists.add(pos);
+		const isTaskList = checked !== null;
+		if (node.attrs.isTaskList === isTaskList) return;
+		tr.setNodeMarkup(pos, undefined, { ...node.attrs, isTaskList });
+		applied = true;
+	};
+
+	const visitSelection = () => {
+		state.doc.nodesBetween(selection.from, selection.to, (node, pos) => {
+			applyListItem(node, pos);
+			applyBulletList(node, pos);
+		});
+	};
+
+	const visitAncestors = () => {
+		const $from: any = selection.$from;
+		for (let depth = $from.depth; depth > 0; depth--) {
+			const node = $from.node(depth);
+			const pos = $from.before(depth);
+			applyListItem(node, pos);
+			applyBulletList(node, pos);
+		}
+	};
+
+	if (selection.empty) {
+		visitAncestors();
+	} else {
+		visitSelection();
+	}
 
 	if (applied) {
 		view.dispatch(tr);

--- a/src/extensions/markdown/components/formatting-toolbar.tsx
+++ b/src/extensions/markdown/components/formatting-toolbar.tsx
@@ -44,7 +44,7 @@ const iconButtonClass =
 
 /** Pressed state for a formatting toggle. */
 const iconButtonActiveClass =
-	"bg-focus-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-focus-ring)] [&_svg]:text-brand-700";
+	"bg-secondary-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-secondary-ring)] [&_svg]:text-secondary-icon";
 
 const ToolbarSeparator = () => (
 	<Toolbar.Separator className="mx-1.5 h-3.5 w-px bg-island-divider" />
@@ -243,7 +243,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 						className={clsx(
 							"inline-flex h-7 shrink-0 select-none items-center gap-1 rounded-[7px] pr-1.5 pl-2.25 text-[12.5px] font-medium text-neutral-700 transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-hover-soft hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring",
 							blockMenuOpen &&
-								"bg-focus-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-focus-ring)]",
+								"bg-secondary-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-secondary-ring)]",
 						)}
 						onMouseDown={suppressMouseDown}
 					>

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/nodes.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/nodes.ts
@@ -140,7 +140,6 @@ export function markdownWcNodes(): Extensions {
 							type: "checkbox",
 							checked: node.attrs.checked ? "checked" : undefined,
 							disabled: "true",
-							style: "margin-right: 6px;",
 						},
 					],
 					["div", 0],
@@ -158,7 +157,6 @@ export function markdownWcNodes(): Extensions {
 						input = document.createElement("input");
 						input.type = "checkbox";
 						input.checked = node.attrs.checked === true;
-						input.style.marginRight = "6px";
 						input.addEventListener("mousedown", (e) => {
 							// Prevent focusing the checkbox from moving the caret unexpectedly
 							e.preventDefault();

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
@@ -292,6 +292,19 @@ describe("Keyboard shortcuts (keymap)", () => {
 		expect(root.child(1).type.name).toBe("paragraph");
 	});
 
+	test("Backspace on empty bullet list item exits the list", () => {
+		const editor = createEditor();
+		typeText(editor, "- ");
+		typeText(editor, "abc");
+		sendKey(editor, "Enter"); // create empty next item
+		sendKey(editor, "Backspace");
+		const root: any = editor.state.doc;
+		expect(root.childCount).toBe(2);
+		expect(root.child(0).type.name).toBe("bulletList");
+		expect(root.child(0).childCount).toBe(1);
+		expect(root.child(1).type.name).toBe("paragraph");
+	});
+
 	test("Enter on empty ordered list item exits the list", () => {
 		const editor = createEditor();
 		typeText(editor, "1. ");
@@ -306,6 +319,18 @@ describe("Keyboard shortcuts (keymap)", () => {
 		expect(root.child(1).type.name).toBe("paragraph");
 	});
 
+	test("Backspace on empty ordered list item exits the list", () => {
+		const editor = createEditor();
+		typeText(editor, "1. ");
+		typeText(editor, "abc");
+		sendKey(editor, "Enter"); // create empty next item
+		sendKey(editor, "Backspace");
+		const root: any = editor.state.doc;
+		expect(root.child(0).type.name).toBe("orderedList");
+		expect(root.child(0).childCount).toBe(1);
+		expect(root.child(1).type.name).toBe("paragraph");
+	});
+
 	test("Enter on empty todo item exits the list", () => {
 		const editor = createEditor();
 		typeText(editor, "[] ");
@@ -317,6 +342,18 @@ describe("Keyboard shortcuts (keymap)", () => {
 		sendKey(editor, "Enter");
 		const root: any = editor.state.doc;
 		expect(root.child(0).type.name).toBe("bulletList");
+		expect(root.child(1).type.name).toBe("paragraph");
+	});
+
+	test("Backspace on empty todo item exits the list", () => {
+		const editor = createEditor();
+		typeText(editor, "[] ");
+		typeText(editor, "abc");
+		sendKey(editor, "Enter"); // create empty next todo
+		sendKey(editor, "Backspace");
+		const root: any = editor.state.doc;
+		expect(root.child(0).type.name).toBe("bulletList");
+		expect(root.child(0).childCount).toBe(1);
 		expect(root.child(1).type.name).toBe("paragraph");
 	});
 

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
@@ -154,6 +154,31 @@ export const MarkdownWcShortcuts = Extension.create({
 			"Shift-Mod-s": () =>
 				this.editor.chain().focus().toggleMark("strike").run(),
 
+			Backspace: () => {
+				const { state } = this.editor;
+				const { selection } = state;
+				if (!selection.empty) return false;
+				const $from: any = selection.$from;
+				const para: any = $from.parent;
+				const isEmptyPara =
+					para?.type?.name === "paragraph" &&
+					(para.textContent || "").length === 0;
+				if (!isEmptyPara || $from.parentOffset !== 0) return false;
+
+				let listItemDepth = -1;
+				for (let d = $from.depth; d > 0; d--) {
+					const n = $from.node(d);
+					if (n?.type?.name === "listItem") {
+						listItemDepth = d;
+						break;
+					}
+				}
+				if (listItemDepth < 0) return false;
+				if ($from.node(listItemDepth).firstChild !== para) return false;
+
+				return this.editor.chain().focus().liftListItem("listItem").run();
+			},
+
 			// Enter in list: create a new list item; for tasks, make it unchecked
 			Enter: () => {
 				const { state } = this.editor;

--- a/src/extensions/markdown/style.css
+++ b/src/extensions/markdown/style.css
@@ -152,8 +152,17 @@
 }
 
 .markdown-view .ProseMirror li {
+	margin-top: 0.1rem;
+	margin-bottom: 0.1rem;
+}
+
+.markdown-view .ProseMirror li p {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.markdown-view .ProseMirror li p + p {
 	margin-top: 0.35rem;
-	margin-bottom: 0.35rem;
 }
 
 /* Tables */
@@ -229,16 +238,44 @@
 
 /* Task lists */
 .markdown-view .ProseMirror li[data-task] {
-	display: flex;
+	display: grid;
+	grid-template-columns: 1.5rem minmax(0, 1fr);
 	align-items: flex-start;
+	margin-left: -1.5rem;
+	list-style: none;
 }
 
 .markdown-view .ProseMirror li[data-task] > input[type="checkbox"] {
-	margin-top: 0.2em;
+	appearance: none;
+	grid-column: 1;
+	width: 0.875rem;
+	height: 0.875rem;
+	margin: calc((1.7em - 0.875rem) / 2) 0 0;
+	justify-self: center;
+	border: 1.5px solid var(--color-neutral-400);
+	border-radius: 4px;
+	background-color: var(--color-neutral-0);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+	transition:
+		background-color 120ms ease,
+		border-color 120ms ease,
+		box-shadow 120ms ease;
+}
+
+.markdown-view .ProseMirror li[data-task] > input[type="checkbox"]:checked {
+	border-color: var(--color-brand-600);
+	background-color: var(--color-brand-600);
+	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 6.2 5 8.1 9 3.8' fill='none' stroke='white' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: 0.75rem 0.75rem;
+	box-shadow: 0 1px 2px rgba(194, 65, 12, 0.18);
 }
 
 .markdown-view .ProseMirror li[data-task] > div {
+	grid-column: 2;
 	flex: 1 1 auto;
+	min-width: 0;
 }
 
 .markdown-view .ProseMirror li[data-task] p {

--- a/src/extensions/terminal/ansi-style-normalizer.test.ts
+++ b/src/extensions/terminal/ansi-style-normalizer.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+import { createTerminalOutputNormalizer } from "./ansi-style-normalizer";
+
+const mutedBackground = "\x1b[48;2;68;64;60m";
+const mutedForeground = "\x1b[38;2;231;229;228m";
+
+describe("terminal ANSI style normalizer", () => {
+	test("mutes basic ANSI diff backgrounds", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(
+			normalizer.write(
+				"\x1b[41mremoved\x1b[42madded\x1b[101mbright removed\x1b[102mbright added\x1b[0m",
+			),
+		).toBe(
+			`${mutedBackground}removed${mutedBackground}added${mutedBackground}bright removed${mutedBackground}bright added\x1b[0m`,
+		);
+	});
+
+	test("mutes dark truecolor red and green backgrounds", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(
+			normalizer.write(
+				"\x1b[48;2;69;10;0mremoved\x1b[48;2;0;46;0madded\x1b[0m",
+			),
+		).toBe(`${mutedBackground}removed${mutedBackground}added\x1b[0m`);
+	});
+
+	test("keeps ordinary foreground color outside muted blocks", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(normalizer.write("\x1b[32mprompt\x1b[0m")).toBe(
+			"\x1b[32mprompt\x1b[0m",
+		);
+	});
+
+	test("mutes diff foreground colors while a muted background is active", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(normalizer.write("\x1b[48;2;0;46;0m\x1b[32m+line\x1b[0m")).toBe(
+			`${mutedBackground}${mutedForeground}+line\x1b[0m`,
+		);
+	});
+
+	test("handles escape sequences split across chunks", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(normalizer.write("before \x1b[48;2;0;46")).toBe("before ");
+		expect(normalizer.write(";0madded")).toBe(`${mutedBackground}added`);
+	});
+
+	test("keeps unchanged extended colors intact", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(
+			normalizer.write(
+				"\x1b[38;2;42;42;42mfg\x1b[48;2;42;42;42mbg\x1b[48;5;15mindexed",
+			),
+		).toBe(
+			"\x1b[38;2;42;42;42mfg\x1b[48;2;42;42;42mbg\x1b[48;5;15mindexed",
+		);
+	});
+
+	test("clears muted state when a normal background replaces it", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(normalizer.write("\x1b[41mremoved\x1b[44mblue\x1b[32mgreen")).toBe(
+			`${mutedBackground}removed\x1b[44mblue\x1b[32mgreen`,
+		);
+		expect(
+			normalizer.write("\x1b[41mremoved\x1b[48;2;255;255;255mwhite\x1b[32mgreen"),
+		).toBe(`${mutedBackground}removed\x1b[48;2;255;255;255mwhite\x1b[32mgreen`);
+	});
+
+	test("mutes 256-color diff backgrounds", () => {
+		const normalizer = createTerminalOutputNormalizer();
+
+		expect(
+			normalizer.write("\x1b[48;5;2mgreen\x1b[48;5;22mdark green\x1b[48;5;1mred"),
+		).toBe(
+			`${mutedBackground}green${mutedBackground}dark green${mutedBackground}red`,
+		);
+	});
+});

--- a/src/extensions/terminal/ansi-style-normalizer.ts
+++ b/src/extensions/terminal/ansi-style-normalizer.ts
@@ -1,0 +1,231 @@
+const MUTED_BLOCK_BACKGROUND = ["48", "2", "68", "64", "60"];
+const MUTED_BLOCK_FOREGROUND = ["38", "2", "231", "229", "228"];
+const ESCAPE_PATTERN = "\\x1B";
+const SGR_PATTERN = new RegExp(`${ESCAPE_PATTERN}\\[([0-9;]*)m`, "g");
+const INCOMPLETE_ESCAPE_PATTERN = new RegExp(
+	`${ESCAPE_PATTERN}(?:\\[[0-9;]*)?$`,
+);
+
+export function createTerminalOutputNormalizer() {
+	let pending = "";
+	let mutedBackgroundActive = false;
+
+	const normalize = (data: string) => {
+		const combined = pending + data;
+		const { complete, remainder } = splitCompleteAnsiInput(combined);
+		pending = remainder;
+		return complete.replace(SGR_PATTERN, (_match, params) => {
+			const result = normalizeSgr(params, mutedBackgroundActive);
+			mutedBackgroundActive = result.mutedBackgroundActive;
+			return `\x1b[${result.params.join(";")}m`;
+		});
+	};
+
+	return {
+		write: normalize,
+		flush() {
+			const rest = pending;
+			pending = "";
+			return rest;
+		},
+	};
+}
+
+function splitCompleteAnsiInput(input: string) {
+	const incompleteMatch = input.match(INCOMPLETE_ESCAPE_PATTERN);
+	if (!incompleteMatch) {
+		return { complete: input, remainder: "" };
+	}
+	const index = incompleteMatch.index ?? input.length;
+	return {
+		complete: input.slice(0, index),
+		remainder: input.slice(index),
+	};
+}
+
+function normalizeSgr(paramsText: string, mutedBackgroundActive: boolean) {
+	const params = paramsText.length > 0 ? paramsText.split(";") : ["0"];
+	const next: string[] = [];
+	let active = mutedBackgroundActive;
+
+	for (let i = 0; i < params.length; i += 1) {
+		const raw = params[i] || "0";
+		const value = Number(raw);
+
+		if (value === 0) {
+			active = false;
+			next.push(raw);
+			continue;
+		}
+
+		if (value === 39) {
+			next.push(raw);
+			continue;
+		}
+
+		if (value === 49) {
+			active = false;
+			next.push(raw);
+			continue;
+		}
+
+		if (isBasicMutedBackground(value)) {
+			active = true;
+			next.push(...MUTED_BLOCK_BACKGROUND);
+			continue;
+		}
+
+		if (isBasicBackground(value)) {
+			active = false;
+			next.push(raw);
+			continue;
+		}
+
+		if (isBasicDiffForeground(value) && active) {
+			next.push(...MUTED_BLOCK_FOREGROUND);
+			continue;
+		}
+
+		if (value === 48 || value === 38) {
+			const parsed = parseExtendedColor(params, i);
+			if (parsed) {
+				const isBackground = value === 48;
+				const shouldMuteBackground =
+					isBackground && shouldMuteBackgroundColor(parsed.rgb);
+				const shouldMuteForeground =
+					!isBackground && active && shouldMuteDiffForeground(parsed.rgb);
+
+					if (shouldMuteBackground) {
+						active = true;
+						next.push(...MUTED_BLOCK_BACKGROUND);
+						i = parsed.endIndex;
+						continue;
+					}
+
+					if (shouldMuteForeground) {
+						next.push(...MUTED_BLOCK_FOREGROUND);
+						i = parsed.endIndex;
+						continue;
+					}
+
+					if (isBackground) {
+						active = false;
+					}
+					next.push(...params.slice(i, parsed.endIndex + 1));
+					i = parsed.endIndex;
+					continue;
+				}
+			}
+
+		next.push(raw);
+	}
+
+	return {
+		params: next.length > 0 ? next : ["0"],
+		mutedBackgroundActive: active,
+	};
+}
+
+function parseExtendedColor(params: string[], startIndex: number) {
+	const mode = Number(params[startIndex + 1]);
+	if (mode === 2) {
+		const rgb = [
+			Number(params[startIndex + 2]),
+			Number(params[startIndex + 3]),
+			Number(params[startIndex + 4]),
+		] as const;
+		if (rgb.every(Number.isFinite)) {
+			return { rgb, endIndex: startIndex + 4 };
+		}
+	}
+
+	if (mode === 5) {
+		const colorIndex = Number(params[startIndex + 2]);
+		if (Number.isFinite(colorIndex)) {
+			return {
+				rgb: xterm256ColorToRgb(colorIndex),
+				endIndex: startIndex + 2,
+			};
+		}
+	}
+
+	return null;
+}
+
+function isBasicMutedBackground(value: number) {
+	return (
+		value === 40 ||
+		value === 41 ||
+		value === 42 ||
+		value === 100 ||
+		value === 101 ||
+		value === 102
+	);
+}
+
+function isBasicBackground(value: number) {
+	return (value >= 40 && value <= 47) || (value >= 100 && value <= 107);
+}
+
+function isBasicDiffForeground(value: number) {
+	return value === 31 || value === 32 || value === 91 || value === 92;
+}
+
+function shouldMuteBackgroundColor([red, green, blue]: readonly number[]) {
+	const luminance = relativeLuminance(red, green, blue);
+	const spread = Math.max(red, green, blue) - Math.min(red, green, blue);
+	const looksRed = red > green * 1.25 && red > blue * 1.25;
+	const looksGreen = green > red * 1.15 && green > blue * 1.15;
+	const looksBlack = luminance < 0.06 && spread < 24;
+	return looksBlack || looksRed || looksGreen;
+}
+
+function shouldMuteDiffForeground([red, green, blue]: readonly number[]) {
+	const looksRed = red > green * 1.25 && red > blue * 1.25;
+	const looksGreen = green > red * 1.15 && green > blue * 1.15;
+	return looksRed || looksGreen;
+}
+
+function relativeLuminance(red: number, green: number, blue: number) {
+	return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+}
+
+function xterm256ColorToRgb(index: number): readonly [number, number, number] {
+	const basicColors: readonly (readonly [number, number, number])[] = [
+		[0, 0, 0],
+		[128, 0, 0],
+		[0, 128, 0],
+		[128, 128, 0],
+		[0, 0, 128],
+		[128, 0, 128],
+		[0, 128, 128],
+		[192, 192, 192],
+		[128, 128, 128],
+		[255, 0, 0],
+		[0, 255, 0],
+		[255, 255, 0],
+		[0, 0, 255],
+		[255, 0, 255],
+		[0, 255, 255],
+		[255, 255, 255],
+	];
+	if (index < basicColors.length) {
+		return basicColors[index] ?? [0, 0, 0];
+	}
+	if (index >= 16 && index <= 231) {
+		const color = index - 16;
+		const red = Math.floor(color / 36);
+		const green = Math.floor((color % 36) / 6);
+		const blue = color % 6;
+		return [cubeValue(red), cubeValue(green), cubeValue(blue)];
+	}
+	if (index >= 232 && index <= 255) {
+		const gray = 8 + (index - 232) * 10;
+		return [gray, gray, gray];
+	}
+	return [0, 0, 0];
+}
+
+function cubeValue(value: number) {
+	return value === 0 ? 0 : 55 + value * 40;
+}

--- a/src/extensions/terminal/index.tsx
+++ b/src/extensions/terminal/index.tsx
@@ -5,13 +5,31 @@ import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { createReactExtensionDefinition } from "../../extension-runtime/react-extension";
 import { TERMINAL_EXTENSION_KIND } from "../../extension-runtime/extension-instance-helpers";
+import { createTerminalOutputNormalizer } from "./ansi-style-normalizer";
 
 const XTERM_THEMES = {
 	light: {
 		background: "#ffffff",
-		foreground: "#111827",
-		cursor: "#111827",
-		selectionBackground: "#dbeafe",
+		foreground: "#1c1917",
+		cursor: "#1c1917",
+		selectionBackground: "#e8ded2",
+		selectionInactiveBackground: "#f4f1ec",
+		black: "#f4f1ec",
+		red: "#d6d3d1",
+		green: "#d6d3d1",
+		yellow: "#b7791f",
+		blue: "#78716c",
+		magenta: "#78716c",
+		cyan: "#0e7490",
+		white: "#292524",
+		brightBlack: "#a8a29e",
+		brightRed: "#a8a29e",
+		brightGreen: "#a8a29e",
+		brightYellow: "#b45309",
+		brightBlue: "#57534e",
+		brightMagenta: "#57534e",
+		brightCyan: "#0891b2",
+		brightWhite: "#1c1917",
 	},
 } as const;
 const XTERM_THEME = XTERM_THEMES.light;
@@ -43,6 +61,7 @@ function TerminalView({
 			fontSize: 13,
 			lineHeight: 1.2,
 			scrollback: 3000,
+			minimumContrastRatio: 4.5,
 			allowTransparency: false,
 			theme: XTERM_THEME,
 		});
@@ -67,13 +86,18 @@ function TerminalView({
 			handleResize();
 		});
 		resizeObserver.observe(container);
+		const outputNormalizer = createTerminalOutputNormalizer();
 
 		const stopData = terminalApi.onData((event) => {
 			if (event.id !== terminalId) return;
-			terminal.write(event.data);
+			terminal.write(outputNormalizer.write(event.data));
 		});
 		const stopExit = terminalApi.onExit((event) => {
 			if (event.id !== terminalId) return;
+			const pendingOutput = outputNormalizer.flush();
+			if (pendingOutput) {
+				terminal.write(pendingOutput);
+			}
 			terminal.writeln("");
 			terminal.writeln(
 				`[process exited${event.exitCode !== null ? ` (${event.exitCode})` : ""}]`,

--- a/src/shell/first-run-screen.tsx
+++ b/src/shell/first-run-screen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, type JSX } from "react";
-import { Files, Zap } from "lucide-react";
+import { Files, FolderOpen, Zap } from "lucide-react";
 import { TopBar } from "./top-bar";
 import { AddViewButton, Island, IslandTabRow, TabChip } from "./island";
 import { AgentInvite } from "./agent-invite";
@@ -70,32 +70,39 @@ export function FirstRunScreen({
 						<span className="text-[12.5px] text-ink-faint">No folder open</span>
 					</div>
 				</Island>
-				<Island className="flex-50">
+				<Island
+					className={`flex-50 transition-[background-color,box-shadow] duration-150 ${
+						isDropTarget
+							? "bg-brand-50/45 shadow-[inset_0_0_0_2px_rgba(251,146,60,0.38)]"
+							: ""
+					}`}
+				>
 					<IslandTabRow>
 						<AddViewButton />
 					</IslandTabRow>
 					<div className="flex flex-1 flex-col items-center justify-center p-10 text-center">
-						<Zap className="size-6.5 fill-brand-600 text-brand-600" />
-						<h1 className="mt-4 text-2xl font-bold tracking-[-0.02em] text-neutral-900">
+						<div className="flex size-9 items-center justify-center rounded-lg bg-brand-50 text-brand-700 ring-1 ring-inset ring-brand-100">
+							<FolderOpen className="size-4.5" strokeWidth={2.2} />
+						</div>
+						<h1 className="mt-4 text-[18px] font-bold text-neutral-900">
 							Open a folder
 						</h1>
-						<p className="mt-1.5 max-w-85 text-sm leading-relaxed text-ink-muted text-pretty">
-							Flashtype works on a folder on your disk — your notes, docs, or a
-							repo. Everything stays in plain markdown files.
+						<p className="mt-1.5 max-w-78 text-[13px] leading-relaxed text-ink-muted text-pretty">
+							Choose a local repo, docs folder, or notes folder. Flashtype keeps
+							everything in plain markdown files.
 						</p>
 						<button
 							type="button"
 							onClick={() => void onOpenFolder()}
-							className={`mt-6 flex items-center gap-2 rounded-[10px] bg-linear-to-b from-brand-500 to-brand-600 px-6 py-2.75 text-sm font-bold text-neutral-0 shadow-[0_6px_18px_rgba(232,89,12,0.32),inset_0_1px_0_rgba(255,255,255,0.25)] hover:brightness-[1.06] ${
+							className={`mt-5 flex h-8.5 items-center gap-2 rounded-lg bg-brand-600 px-4.5 text-[12.5px] font-bold text-neutral-0 shadow-[0_5px_14px_rgba(232,89,12,0.24),inset_0_1px_0_rgba(255,255,255,0.2)] transition hover:bg-brand-700 ${
 								isDropTarget ? "brightness-[1.06]" : ""
 							}`}
 						>
-							Open folder…
-							<span className="text-[11.5px] font-semibold opacity-75">⌘O</span>
+							Open folder
+							<span className="rounded-[4px] bg-white/15 px-1.25 py-0.25 text-[11px] font-semibold leading-none text-white/80">
+								⌘O
+							</span>
 						</button>
-						<p className="mt-4.5 text-[12.5px] text-neutral-400">
-							or drop a folder anywhere in this window
-						</p>
 					</div>
 				</Island>
 				<Island className="flex-30">

--- a/src/shell/theme.css
+++ b/src/shell/theme.css
@@ -40,6 +40,9 @@
 	--color-focus-tint: rgb(251, 239, 228); /* focused chip / selected file */
 	--color-focus-ring: rgb(243, 216, 190);
 	--color-focus-close: rgb(201, 168, 136); /* ✕ on the focused chip */
+	--color-secondary-tint: rgb(243, 244, 246);
+	--color-secondary-ring: rgb(209, 213, 219);
+	--color-secondary-icon: rgb(75, 85, 99);
 	--color-error-50: rgb(254, 242, 242);
 	--color-error-100: rgb(254, 226, 226);
 	--color-error-200: rgb(254, 202, 202);


### PR DESCRIPTION
## Summary

Polishes the markdown editing experience and tones down high-contrast terminal output in the embedded agent terminal.

### Markdown/editor UI

- Improves first-run folder opening copy and selected-file styling.
- Makes Backspace exit empty list items for a more Notion-like editing flow.
- Fixes checklist-to-bullet conversion from the formatting toolbar.
- Aligns bullet and checklist list items and gives checkboxes app-native styling.
- Softens the formatting toolbar and dropdown typography, with a neutral secondary active state instead of orange.

### Terminal

- Prevents inherited `NO_COLOR` from disabling Claude Code colors in spawned terminals.
- Adds a terminal output normalizer that mutes harsh Claude-style ANSI diff backgrounds while preserving ordinary prompt/status colors.
- Adds regression coverage for terminal env handling and ANSI normalization edge cases.

## Validation

- `pnpm vitest run src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts`
- `pnpm vitest run src/extensions/files/file-tree.test.tsx`
- `pnpm vitest run src/extensions/markdown/components/formatting-toolbar.test.tsx`
- `pnpm vitest run src/extensions/terminal/ansi-style-normalizer.test.ts electron/terminal-shell.test.mjs`
- `pnpm run typecheck`
- `pnpm run lint`
- Electron dev app smoke-tested via `agent-browser` on `127.0.0.1:9222`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, editor keymap/toolbar behavior, and display-layer terminal ANSI rewriting; well-covered by new tests and no auth or data-path changes.
> 
> **Overview**
> Polishes markdown editing UX and softens embedded terminal output, with small shell/onboarding tweaks.
> 
> **Markdown editing** adds **Backspace** on an empty first paragraph in a list item to lift out of bullet, ordered, and task lists (same idea as Enter). The formatting toolbar can turn a checklist back into plain bullets via shared `setTaskListState`, and toolbar/dropdown styling moves to neutral **secondary** active states plus tighter list/checkbox CSS (grid layout, custom checkboxes).
> 
> **Terminal** strips inherited `NO_COLOR` from spawned PTY env so child CLIs can emit color, pipes PTY output through a new ANSI normalizer that mutes harsh red/green diff backgrounds (including chunked escapes) while leaving normal prompts alone, and retunes xterm theme/contrast.
> 
> **UI** lightens file-tree selection weight, refreshes first-run “open folder” layout/copy with drop-target highlight on the center island, and adds `--color-secondary-*` theme tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b287e6d0d341db9c4664c94cbf9f18a6b8787f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->