### PR TITLE
[codex] Fix Cmd-Backspace word deletion

### DIFF
--- a/.changenotes/fix-markdown-cmd-backspace.md
+++ b/.changenotes/fix-markdown-cmd-backspace.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed Cmd+Backspace in the Markdown editor so it deletes the previous word instead of the whole line.
+
+The shortcut now stays within the editor while file deletion shortcuts continue to work from the file tree.

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ node_modules/
 /.pnpm-store/
 /test-results/
 /public/sqlite3.wasm
+/.flashtype-dev/
 
 /target/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"main": "electron/main.mjs",
 	"packageManager": "pnpm@10.13.1",
 	"scripts": {
-		"dev": "concurrently -k \"pnpm run dev:renderer\" \"pnpm run dev:electron\"",
+		"dev": "node scripts/dev.mjs",
 		"dev:renderer": "vite --host 127.0.0.1 --port 4173 --strictPort",
 		"dev:electron": "wait-on tcp:4173 && VITE_DEV_SERVER_URL=http://127.0.0.1:4173 electron ./electron/main.mjs",
 		"build:markdown-wc": "CARGO_TARGET_DIR=./target pnpm -C submodule/markdown-wc/js run build:web",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,172 @@
+import { spawn } from "node:child_process";
+import net from "node:net";
+import path from "node:path";
+
+const host = "127.0.0.1";
+const preferredPort = Number(
+	process.env.FLASHTYPE_DEV_RENDERER_PORT ?? process.env.PORT ?? "4173",
+);
+const userDataDir = path.resolve(
+	process.env.FLASHTYPE_DEV_USER_DATA_DIR ?? ".flashtype-dev/user-data",
+);
+const { electronFlags, appArgs } = splitElectronArgs(process.argv.slice(2));
+const electronArgs = [
+	`--user-data-dir=${userDataDir}`,
+	...electronFlags,
+	"./electron/main.mjs",
+	...appArgs,
+];
+const children = new Set();
+let shuttingDown = false;
+
+process.on("SIGINT", () => shutdown(130));
+process.on("SIGTERM", () => shutdown(143));
+
+try {
+	const rendererPort = await findAvailablePort(preferredPort);
+	const rendererUrl = `http://${host}:${rendererPort}`;
+	let rendererReady = false;
+
+	console.log(`Starting Flashtype renderer at ${rendererUrl}`);
+	const renderer = spawnCommand("vite", [
+		"--host",
+		host,
+		"--port",
+		String(rendererPort),
+		"--strictPort",
+	]);
+	renderer.on("exit", (code, signal) => {
+		if (shuttingDown) return;
+		console.error(
+			rendererReady
+				? `Renderer exited ${formatExitReason(code, signal)}; stopping Electron.`
+				: `Renderer exited ${formatExitReason(code, signal)} before becoming ready.`,
+		);
+		shutdown(code ?? 1);
+	});
+
+	await waitForTcp(rendererPort, host, 120_000);
+	rendererReady = true;
+
+	console.log(`Starting Flashtype Electron with ${rendererUrl}`);
+	const electron = spawnCommand("electron", electronArgs, {
+		env: {
+			...process.env,
+			VITE_DEV_SERVER_URL: rendererUrl,
+		},
+	});
+
+	electron.on("exit", (code, signal) => {
+		if (shuttingDown) return;
+		console.log(`Electron exited ${formatExitReason(code, signal)}.`);
+		shutdown(code ?? 0);
+	});
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	shutdown(1);
+}
+
+function spawnCommand(command, args, options = {}) {
+	const child = spawn(resolveBin(command), args, {
+		stdio: "inherit",
+		shell: process.platform === "win32",
+		...options,
+		env: options.env ?? process.env,
+	});
+	children.add(child);
+	child.on("exit", () => children.delete(child));
+	child.on("error", (error) => {
+		if (shuttingDown) return;
+		console.error(`${command} failed to start: ${error.message}`);
+		shutdown(1);
+	});
+	return child;
+}
+
+function resolveBin(command) {
+	return command;
+}
+
+function splitElectronArgs(args) {
+	const electronFlags = [];
+	const appArgs = [];
+	for (const arg of args) {
+		if (arg.startsWith("--")) {
+			electronFlags.push(arg);
+		} else {
+			appArgs.push(arg);
+		}
+	}
+	return { electronFlags, appArgs };
+}
+
+async function findAvailablePort(startPort) {
+	if (!Number.isInteger(startPort) || startPort <= 0 || startPort > 65535) {
+		throw new Error(`Invalid renderer port: ${startPort}`);
+	}
+	for (let port = startPort; port <= 65535; port += 1) {
+		if (await canListen(port)) {
+			return port;
+		}
+	}
+	throw new Error(`No available port found at or above ${startPort}.`);
+}
+
+function canListen(port) {
+	return new Promise((resolve) => {
+		const server = net.createServer();
+		server.unref();
+		server.once("error", () => resolve(false));
+		server.listen({ host, port }, () => {
+			server.close(() => resolve(true));
+		});
+	});
+}
+
+function waitForTcp(port, hostname, timeoutMs) {
+	const startedAt = Date.now();
+	return new Promise((resolve, reject) => {
+		const attempt = () => {
+			const socket = net.createConnection({ host: hostname, port });
+			socket.once("connect", () => {
+				socket.destroy();
+				resolve();
+			});
+			socket.once("error", () => {
+				socket.destroy();
+				if (Date.now() - startedAt >= timeoutMs) {
+					reject(new Error(`Timed out waiting for renderer on port ${port}.`));
+					return;
+				}
+				setTimeout(attempt, 100);
+			});
+		};
+		attempt();
+	});
+}
+
+function shutdown(exitCode) {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	for (const child of children) {
+		if (child.exitCode === null && child.signalCode === null) {
+			child.kill("SIGTERM");
+		}
+	}
+	setTimeout(() => {
+		for (const child of children) {
+			if (child.exitCode === null && child.signalCode === null) {
+				child.kill("SIGKILL");
+			}
+		}
+		process.exit(exitCode);
+	}, 500).unref();
+	if (children.size === 0) {
+		process.exit(exitCode);
+	}
+}
+
+function formatExitReason(code, signal) {
+	if (signal) return `with signal ${signal}`;
+	return `with code ${code ?? 0}`;
+}

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -129,7 +129,7 @@ describe("FilesView", () => {
 		await lix.close();
 	});
 
-	test("Cmd+Backspace deletes the selected file", async () => {
+	test("Cmd+Backspace deletes the selected file from the focused file row", async () => {
 		const lix = await openLix();
 		const closeFileViews = vi.fn();
 		await qb(lix)
@@ -161,7 +161,10 @@ describe("FilesView", () => {
 		});
 
 		await act(async () => {
-			fireEvent.keyDown(document, { key: "Backspace", metaKey: true });
+			fireEvent.keyDown(utils!.getByTestId("file-tree-item-hello-md"), {
+				key: "Backspace",
+				metaKey: true,
+			});
 		});
 
 		await waitFor(async () => {
@@ -181,7 +184,7 @@ describe("FilesView", () => {
 		await lix.close();
 	});
 
-	test("Cmd+Backspace closes a newly created selected file view", async () => {
+	test("Cmd+Backspace in an empty editor keeps a newly created selected file and editor event", async () => {
 		const lix = await openLix();
 		const openFile = vi.fn();
 		const closeFileViews = vi.fn();
@@ -215,22 +218,198 @@ describe("FilesView", () => {
 		await waitFor(() => {
 			expect(openFile).toHaveBeenCalled();
 		});
-		const createdFileId = openFile.mock.calls[0]?.[0]?.fileId;
-		expect(typeof createdFileId).toBe("string");
 
+		const emptyEditor = document.createElement("div");
+		emptyEditor.contentEditable = "true";
+		document.body.append(emptyEditor);
+		let emptyEditorEvent: KeyboardEvent;
 		await act(async () => {
-			fireEvent.keyDown(document, { key: "Backspace", metaKey: true });
+			emptyEditorEvent = new KeyboardEvent("keydown", {
+				key: "Backspace",
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			expect(emptyEditor.dispatchEvent(emptyEditorEvent)).toBe(true);
+		});
+		expect(emptyEditorEvent!.defaultPrevented).toBe(false);
+
+		const rows = await qb(lix)
+			.selectFrom("lix_file")
+			.select(["path"])
+			.execute();
+		expect(rows.some((row) => row.path === "/fresh.md")).toBe(true);
+		expect(closeFileViews).not.toHaveBeenCalled();
+		emptyEditor.remove();
+
+		utils!.unmount();
+		await lix.close();
+	});
+
+	test("Cmd+Backspace in a non-empty editor keeps the selected file and editor event", async () => {
+		const lix = await openLix();
+		const closeFileViews = vi.fn();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_with_text",
+				path: "/keep.md",
+				data: new TextEncoder().encode("Keep me"),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView context={createViewContext(lix, { closeFileViews })} />
+					</Suspense>
+				</LixProvider>,
+			);
 		});
 
-		await waitFor(async () => {
-			const rows = await qb(lix)
-				.selectFrom("lix_file")
-				.select(["path"])
-				.execute();
-			expect(rows.filter((row) => isUserPath(row.path))).toHaveLength(0);
+		const file = await utils!.findByText("keep.md");
+		await act(async () => {
+			fireEvent.click(file);
 		});
-		expect(closeFileViews).toHaveBeenCalledWith({ fileId: createdFileId });
 
+		const editor = document.createElement("div");
+		editor.contentEditable = "true";
+		editor.textContent = "Keep me";
+		document.body.append(editor);
+		let editorEvent: KeyboardEvent;
+		await act(async () => {
+			editorEvent = new KeyboardEvent("keydown", {
+				key: "Backspace",
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			expect(editor.dispatchEvent(editorEvent)).toBe(true);
+		});
+		expect(editorEvent!.defaultPrevented).toBe(false);
+
+		const rows = await qb(lix)
+			.selectFrom("lix_file")
+			.select(["path"])
+			.execute();
+		expect(rows.some((row) => row.path === "/keep.md")).toBe(true);
+		expect(closeFileViews).not.toHaveBeenCalled();
+
+		editor.remove();
+		utils!.unmount();
+		await lix.close();
+	});
+
+	test("Cmd+Backspace in a whitespace-only editor keeps the selected file and editor event", async () => {
+		const lix = await openLix();
+		const closeFileViews = vi.fn();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_with_spaces",
+				path: "/spaces.md",
+				data: new TextEncoder().encode("   "),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView context={createViewContext(lix, { closeFileViews })} />
+					</Suspense>
+				</LixProvider>,
+			);
+		});
+
+		const file = await utils!.findByText("spaces.md");
+		await act(async () => {
+			fireEvent.click(file);
+		});
+
+		const editor = document.createElement("div");
+		editor.contentEditable = "true";
+		editor.textContent = "   \n";
+		document.body.append(editor);
+		let editorEvent: KeyboardEvent;
+		await act(async () => {
+			editorEvent = new KeyboardEvent("keydown", {
+				key: "Backspace",
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			expect(editor.dispatchEvent(editorEvent)).toBe(true);
+		});
+		expect(editorEvent!.defaultPrevented).toBe(false);
+
+		const rows = await qb(lix)
+			.selectFrom("lix_file")
+			.select(["path"])
+			.execute();
+		expect(rows.some((row) => row.path === "/spaces.md")).toBe(true);
+		expect(closeFileViews).not.toHaveBeenCalled();
+
+		editor.remove();
+		utils!.unmount();
+		await lix.close();
+	});
+
+	test("Cmd+Backspace in an editor with non-text content keeps the selected file and editor event", async () => {
+		const lix = await openLix();
+		const closeFileViews = vi.fn();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_with_rule",
+				path: "/rule.md",
+				data: new TextEncoder().encode("---"),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView context={createViewContext(lix, { closeFileViews })} />
+					</Suspense>
+				</LixProvider>,
+			);
+		});
+
+		const file = await utils!.findByText("rule.md");
+		await act(async () => {
+			fireEvent.click(file);
+		});
+
+		const editor = document.createElement("div");
+		editor.contentEditable = "true";
+		editor.innerHTML = "<hr>";
+		document.body.append(editor);
+		let editorEvent: KeyboardEvent;
+		await act(async () => {
+			editorEvent = new KeyboardEvent("keydown", {
+				key: "Backspace",
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			expect(editor.dispatchEvent(editorEvent)).toBe(true);
+		});
+		expect(editorEvent!.defaultPrevented).toBe(false);
+
+		const rows = await qb(lix)
+			.selectFrom("lix_file")
+			.select(["path"])
+			.execute();
+		expect(rows.some((row) => row.path === "/rule.md")).toBe(true);
+		expect(closeFileViews).not.toHaveBeenCalled();
+
+		editor.remove();
 		utils!.unmount();
 		await lix.close();
 	});

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -278,6 +278,8 @@ export function FilesView({ context }: FilesViewProps) {
 				event.key === "Delete" ||
 				event.code?.toLowerCase() === "delete";
 			if (isDeleteKey) {
+				const shouldHandleDelete = !isInteractiveTarget(event.target);
+				if (!shouldHandleDelete) return;
 				event.preventDefault();
 				event.stopPropagation();
 				event.stopImmediatePropagation?.();
@@ -286,7 +288,7 @@ export function FilesView({ context }: FilesViewProps) {
 					event.type === "keydown" &&
 					!event.repeat &&
 					!event.shiftKey &&
-					!isInteractiveTarget(event.target)
+					shouldHandleDelete
 				) {
 					void handleDeleteSelection();
 				}

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
@@ -60,8 +60,8 @@ function sendModKey(editor: Editor, key: string, opts?: { shift?: boolean }) {
 	};
 	// Try meta-only first (mac style), then ctrl-only (windows/linux)
 	if (tryPress({ metaKey: true, ctrlKey: false, shiftKey: opts?.shift }))
-		return;
-	tryPress({ metaKey: false, ctrlKey: true, shiftKey: opts?.shift });
+		return true;
+	return tryPress({ metaKey: false, ctrlKey: true, shiftKey: opts?.shift });
 }
 
 function sendKey(editor: Editor, key: string, opts?: { shift?: boolean }) {
@@ -235,6 +235,41 @@ describe("Keyboard shortcuts (keymap)", () => {
 		editor.commands.setTextSelection({ from: 1, to: 4 });
 		sendModKey(editor, "s", { shift: true });
 		expect(editor.isActive("strike")).toBe(true);
+	});
+
+	test("Mod-Backspace deletes the previous word instead of the whole line", () => {
+		const editor = createEditor();
+		editor.commands.insertContent("alpha beta gamma");
+		editor.commands.setTextSelection(editor.state.doc.content.size);
+		sendModKey(editor, "Backspace");
+		expect(buildMarkdownFromEditor(editor)).toBe("alpha beta \n");
+	});
+
+	test("Mod-Backspace at the start of a text block does not merge blocks", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				{ type: "paragraph", content: [{ type: "text", text: "alpha" }] },
+				{ type: "paragraph", content: [{ type: "text", text: "beta" }] },
+			],
+		});
+		setCursorAfterText(editor, "beta");
+		editor.commands.setTextSelection(
+			editor.state.selection.from - "beta".length,
+		);
+
+		expect(sendModKey(editor, "Backspace")).toBe(true);
+		expect(buildMarkdownFromEditor(editor)).toBe("alpha\n\nbeta\n");
+	});
+
+	test("Mod-Backspace deletes the selection", () => {
+		const editor = createEditor();
+		editor.commands.insertContent("alpha beta gamma");
+		setCursorAfterText(editor, "alpha ");
+		const from = editor.state.selection.from;
+		editor.commands.setTextSelection({ from, to: from + "beta".length });
+		sendModKey(editor, "Backspace");
+		expect(buildMarkdownFromEditor(editor)).toBe("alpha  gamma\n");
 	});
 
 	test("Enter in bullet list creates another bullet item", () => {

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
@@ -13,6 +13,7 @@ import {
 // - Mod-b / Mod-i / Shift-Mod-s: Toggle bold/italic/strike
 export const MarkdownWcShortcuts = Extension.create({
 	name: "markdownWcShortcuts",
+	priority: 1000,
 
 	addInputRules() {
 		const rules: any[] = [];
@@ -147,12 +148,44 @@ export const MarkdownWcShortcuts = Extension.create({
 	},
 
 	addKeyboardShortcuts() {
+		const deletePreviousWord = () => {
+			const { state, view } = this.editor;
+			const { selection } = state;
+			if (!selection.empty) {
+				return this.editor.chain().focus().deleteSelection().run();
+			}
+
+			const $from: any = selection.$from;
+			const parent: any = $from.parent;
+			if (!parent?.isTextblock || $from.parentOffset === 0) return true;
+
+			const textBefore = parent.textBetween(
+				0,
+				$from.parentOffset,
+				"\uFFFC",
+				"\uFFFC",
+			);
+			const deleteFromOffset = findPreviousWordDeleteOffset(textBefore);
+			if (deleteFromOffset === textBefore.length) return false;
+
+			const deleteSize = textBefore.length - deleteFromOffset;
+			const from = Math.max($from.start(), $from.pos - deleteSize);
+			if (from >= $from.pos) return false;
+
+			view.dispatch(state.tr.delete(from, $from.pos).scrollIntoView());
+			return true;
+		};
+
 		return {
 			// Bold / Italic / Strike
 			"Mod-b": () => this.editor.chain().focus().toggleMark("bold").run(),
 			"Mod-i": () => this.editor.chain().focus().toggleMark("italic").run(),
 			"Shift-Mod-s": () =>
 				this.editor.chain().focus().toggleMark("strike").run(),
+
+			"Mod-Backspace": deletePreviousWord,
+			"Cmd-Backspace": deletePreviousWord,
+			"Ctrl-Backspace": deletePreviousWord,
 
 			Backspace: () => {
 				const { state } = this.editor;
@@ -215,3 +248,38 @@ export const MarkdownWcShortcuts = Extension.create({
 		};
 	},
 });
+
+function findPreviousWordDeleteOffset(text: string): number {
+	let end = text.length;
+	while (end > 0 && isWhitespace(text[end - 1] ?? "")) {
+		end -= 1;
+	}
+	if (end === 0) {
+		return 0;
+	}
+
+	let start = end;
+	if (isWordCharacter(text[start - 1] ?? "")) {
+		while (start > 0 && isWordCharacter(text[start - 1] ?? "")) {
+			start -= 1;
+		}
+		return start;
+	}
+
+	while (
+		start > 0 &&
+		!isWhitespace(text[start - 1] ?? "") &&
+		!isWordCharacter(text[start - 1] ?? "")
+	) {
+		start -= 1;
+	}
+	return start;
+}
+
+function isWhitespace(value: string): boolean {
+	return /\s/.test(value);
+}
+
+function isWordCharacter(value: string): boolean {
+	return /[\p{L}\p{N}_]/u.test(value);
+}


### PR DESCRIPTION
## Summary
- Fix Cmd+Backspace in the Markdown editor so it deletes the previous word instead of the whole line.
- Keep file deletion shortcuts scoped to the file tree instead of stealing editor events.
- Add a dev launcher that chooses the next available Vite port and uses a repo-local Electron user data dir.
- Add a patch changenote.

Closes https://github.com/opral/flashtype/issues/103

## Validation
- pnpm exec vitest run src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
- pnpm test src/extensions/files/index.test.tsx
- pnpm run typecheck
- node --check scripts/dev.mjs
- pnpm exec prettier --check package.json scripts/dev.mjs src/extensions/files/index.tsx src/extensions/files/index.test.tsx src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.ts src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
- git diff --check
- live scripts/dev.mjs smoke test with Electron attach flag and clean shutdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard and dev-script changes with broad test coverage; file delete still applies from non-editor targets, so accidental data loss risk is reduced rather than increased.
> 
> **Overview**
> **Cmd+Backspace** in the Markdown editor now deletes the **previous word** (or the current selection) via new TipTap keybindings in `shortcuts.ts`, with higher extension priority so the editor wins over default line-delete behavior.
> 
> The **Files** panel no longer captures Cmd+Backspace when the event target is an interactive control (`contenteditable`, inputs, textareas). File deletion still runs from the global listener when focus is not in those targets; tests were updated to fire delete from the file row and to assert editors keep the shortcut.
> 
> `pnpm dev` now runs **`scripts/dev.mjs`**, which picks the next free Vite port, waits for the renderer, starts Electron with `VITE_DEV_SERVER_URL`, uses a repo-local **`--user-data-dir`** under `.flashtype-dev/`, and tears down child processes on exit. A patch changenote documents the editor fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a61a089fe86e7385c848027e122c331070466b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->