### PR TITLE
[codex] Open direct markdown files without indexing huge folders

### DIFF
--- a/e2e/workspace-windows.spec.ts
+++ b/e2e/workspace-windows.spec.ts
@@ -317,17 +317,14 @@ test("macOS open-file events create workspace windows for folders and files", as
 		registerRendererConsoleLogging(folderPage);
 
 		await emitOpenFile(electronApp, filePath);
-		const filePage = await pageWithTitle(
-			electronApp,
-			path.basename(fileWorkspaceDir),
-		);
+		const filePage = await pageWithTitle(electronApp, "docs");
 		registerRendererConsoleLogging(filePage);
 
 		await expectWindowCount(electronApp, 3);
 		await expect(firstRunPage).toHaveTitle("Flashtype");
 		await expect(folderPage.getByText("folder-marker.md")).toBeVisible();
 		await expect(
-			filePage.getByRole("heading", { name: "docs/file-marker.md" }),
+			filePage.getByRole("heading", { name: "file-marker.md" }),
 		).toBeVisible();
 		await expect(
 			filePage
@@ -371,7 +368,7 @@ test("macOS open-file events open standalone files as transient workspaces", asy
 				.first(),
 		).toBeVisible();
 		await expect(filePage.getByRole("heading", { name: "Solo" })).toBeVisible();
-		await expect(filePage.getByText("sibling.md")).toBeVisible();
+		await expect(filePage.getByText("sibling.md")).toHaveCount(0);
 		await expectPathMissing(path.join(directory, ".lix"));
 		await expectPathMissing(path.join(directory, ".lix_system"));
 
@@ -392,12 +389,7 @@ test("macOS open-file events open standalone files as transient workspaces", asy
 				params: ["/generated.md", new TextEncoder().encode("# Generated\n")],
 			});
 		});
-		await expect
-			.poll(
-				async () =>
-					await readFile(path.join(directory, "generated.md"), "utf8"),
-			)
-			.toBe("# Generated\n");
+		await expectPathMissing(path.join(directory, "generated.md"));
 		await expectPathMissing(path.join(directory, ".lix"));
 		await expectPathMissing(path.join(directory, ".lix_system"));
 	} finally {
@@ -405,46 +397,58 @@ test("macOS open-file events open standalone files as transient workspaces", asy
 	}
 });
 
-test("launching with multiple standalone markdown files creates one transient workspace", async ({
+test("launching with multiple standalone markdown files creates one window per file", async ({
 	browserName: _browserName,
 }, testInfo) => {
-	const directory = testInfo.outputPath("standalone-markdown");
-	const firstPath = path.join(directory, "alpha.md");
-	const secondPath = path.join(directory, "beta.markdown");
-	const siblingPath = path.join(directory, "sibling.md");
+	const firstDirectory = testInfo.outputPath("standalone-markdown-alpha");
+	const secondDirectory = testInfo.outputPath("standalone-markdown-beta");
+	const firstPath = path.join(firstDirectory, "alpha.md");
+	const secondPath = path.join(secondDirectory, "beta.markdown");
+	const siblingPath = path.join(firstDirectory, "sibling.md");
 
 	let electronApp: ElectronApplication | undefined;
 	try {
-		await mkdir(directory, { recursive: true });
+		await mkdir(firstDirectory, { recursive: true });
+		await mkdir(secondDirectory, { recursive: true });
 		await writeFile(firstPath, "# Alpha\n");
 		await writeFile(secondPath, "# Beta\n");
 		await writeFile(siblingPath, "# Sibling\n");
 
 		electronApp = await launchDevElectronAppWithArgs([firstPath, secondPath]);
-		const page = await pageWithTitle(electronApp, path.basename(directory));
-		registerRendererConsoleLogging(page);
+		const firstPage = await pageWithTitle(
+			electronApp,
+			path.basename(firstDirectory),
+		);
+		const secondPage = await pageWithTitle(
+			electronApp,
+			path.basename(secondDirectory),
+		);
+		registerRendererConsoleLogging(firstPage);
+		registerRendererConsoleLogging(secondPage);
 
-		await expectWindowCount(electronApp, 1);
-		await expect(page.getByRole("heading", { name: "Alpha" })).toBeVisible();
-		await expect(page.getByText("beta.markdown")).toBeVisible();
-		await expect(page.getByText("sibling.md")).toBeVisible();
-		await expectPathMissing(path.join(directory, ".lix"));
-		await expectPathMissing(path.join(directory, ".lix_system"));
+		await expectWindowCount(electronApp, 2);
+		await expect(firstPage.getByRole("heading", { name: "Alpha" })).toBeVisible();
+		await expect(firstPage.getByText("sibling.md")).toHaveCount(0);
+		await expect(secondPage.getByRole("heading", { name: "Beta" })).toBeVisible();
+		await expectPathMissing(path.join(firstDirectory, ".lix"));
+		await expectPathMissing(path.join(secondDirectory, ".lix"));
 	} finally {
 		await closeElectronApp(electronApp);
 	}
 });
 
-test("macOS open-file events group standalone markdown files", async ({
+test("macOS open-file events create one transient window per standalone file", async ({
 	browserName: _browserName,
 }, testInfo) => {
-	const directory = testInfo.outputPath("standalone-open-file-markdown");
-	const firstPath = path.join(directory, "first.md");
-	const secondPath = path.join(directory, "second.md");
+	const firstDirectory = testInfo.outputPath("standalone-open-file-first");
+	const secondDirectory = testInfo.outputPath("standalone-open-file-second");
+	const firstPath = path.join(firstDirectory, "first.md");
+	const secondPath = path.join(secondDirectory, "second.md");
 
 	let electronApp: ElectronApplication | undefined;
 	try {
-		await mkdir(directory, { recursive: true });
+		await mkdir(firstDirectory, { recursive: true });
+		await mkdir(secondDirectory, { recursive: true });
 		await writeFile(firstPath, "# First\n");
 		await writeFile(secondPath, "# Second\n");
 
@@ -453,32 +457,44 @@ test("macOS open-file events group standalone markdown files", async ({
 		registerRendererConsoleLogging(firstRunPage);
 
 		await emitOpenFiles(electronApp, [firstPath, secondPath]);
-		const filePage = await pageWithTitle(electronApp, path.basename(directory));
-		registerRendererConsoleLogging(filePage);
+		const firstPage = await pageWithTitle(
+			electronApp,
+			path.basename(firstDirectory),
+		);
+		const secondPage = await pageWithTitle(
+			electronApp,
+			path.basename(secondDirectory),
+		);
+		registerRendererConsoleLogging(firstPage);
+		registerRendererConsoleLogging(secondPage);
 
-		await expectWindowCount(electronApp, 2);
+		await expectWindowCount(electronApp, 3);
 		await expect(firstRunPage).toHaveTitle("Flashtype");
 		await expect(
-			filePage.getByRole("heading", { name: "First" }),
+			firstPage.getByRole("heading", { name: "First" }),
 		).toBeVisible();
-		await expect(filePage.getByText("second.md")).toBeVisible();
+		await expect(
+			secondPage.getByRole("heading", { name: "Second" }),
+		).toBeVisible();
 	} finally {
 		await closeElectronApp(electronApp);
 	}
 });
 
-test("mixed folder and standalone markdown args create folder and grouped file windows", async ({
+test("mixed folder and standalone markdown args create folder and file windows", async ({
 	browserName: _browserName,
 }, testInfo) => {
 	const folderWorkspaceDir = testInfo.outputPath("folder-workspace");
-	const markdownDir = testInfo.outputPath("standalone-mixed-markdown");
-	const firstPath = path.join(markdownDir, "one.md");
-	const secondPath = path.join(markdownDir, "two.md");
+	const firstMarkdownDir = testInfo.outputPath("standalone-mixed-one");
+	const secondMarkdownDir = testInfo.outputPath("standalone-mixed-two");
+	const firstPath = path.join(firstMarkdownDir, "one.md");
+	const secondPath = path.join(secondMarkdownDir, "two.md");
 
 	let electronApp: ElectronApplication | undefined;
 	try {
 		await writeMarkerFile(folderWorkspaceDir, "folder-marker.md");
-		await mkdir(markdownDir, { recursive: true });
+		await mkdir(firstMarkdownDir, { recursive: true });
+		await mkdir(secondMarkdownDir, { recursive: true });
 		await writeFile(firstPath, "# One\n");
 		await writeFile(secondPath, "# Two\n");
 
@@ -491,57 +507,76 @@ test("mixed folder and standalone markdown args create folder and grouped file w
 			electronApp,
 			path.basename(folderWorkspaceDir),
 		);
-		const filePage = await pageWithTitle(
+		const firstFilePage = await pageWithTitle(
 			electronApp,
-			path.basename(markdownDir),
+			path.basename(firstMarkdownDir),
+		);
+		const secondFilePage = await pageWithTitle(
+			electronApp,
+			path.basename(secondMarkdownDir),
 		);
 		registerRendererConsoleLogging(folderPage);
-		registerRendererConsoleLogging(filePage);
+		registerRendererConsoleLogging(firstFilePage);
+		registerRendererConsoleLogging(secondFilePage);
 
-		await expectWindowCount(electronApp, 2);
+		await expectWindowCount(electronApp, 3);
 		await expect(folderPage.getByText("folder-marker.md")).toBeVisible();
-		await expect(filePage.getByRole("heading", { name: "One" })).toBeVisible();
-		await expect(filePage.getByText("two.md")).toBeVisible();
+		await expect(
+			firstFilePage.getByRole("heading", { name: "One" }),
+		).toBeVisible();
+		await expect(
+			secondFilePage.getByRole("heading", { name: "Two" }),
+		).toBeVisible();
 	} finally {
 		await closeElectronApp(electronApp);
 	}
 });
 
-test("relaunch restores grouped transient file workspaces", async ({
+test("relaunch restores each transient file workspace", async ({
 	browserName: _browserName,
 }, testInfo) => {
 	const userDataDir = testInfo.outputPath("user-data");
-	const directory = testInfo.outputPath("restore-markdown");
-	const firstPath = path.join(directory, "first.md");
-	const secondPath = path.join(directory, "second.md");
+	const firstDirectory = testInfo.outputPath("restore-markdown-first");
+	const secondDirectory = testInfo.outputPath("restore-markdown-second");
+	const firstPath = path.join(firstDirectory, "first.md");
+	const secondPath = path.join(secondDirectory, "second.md");
 
 	let electronApp: ElectronApplication | undefined;
 	try {
-		await mkdir(directory, { recursive: true });
+		await mkdir(firstDirectory, { recursive: true });
+		await mkdir(secondDirectory, { recursive: true });
 		await writeFile(firstPath, "# First\n");
 		await writeFile(secondPath, "# Second\n");
 
 		electronApp = await launchDevElectronAppWithArgs([firstPath, secondPath], {
 			userDataDir,
 		});
-		await pageWithTitle(electronApp, path.basename(directory));
-		await expectWindowCount(electronApp, 1);
+		await pageWithTitle(electronApp, path.basename(firstDirectory));
+		await pageWithTitle(electronApp, path.basename(secondDirectory));
+		await expectWindowCount(electronApp, 2);
 
 		await closeElectronApp(electronApp);
 		electronApp = undefined;
 
 		electronApp = await launchDevElectronAppWithArgs([], { userDataDir });
-		const restoredPage = await pageWithTitle(
+		const firstRestoredPage = await pageWithTitle(
 			electronApp,
-			path.basename(directory),
+			path.basename(firstDirectory),
 		);
-		registerRendererConsoleLogging(restoredPage);
+		const secondRestoredPage = await pageWithTitle(
+			electronApp,
+			path.basename(secondDirectory),
+		);
+		registerRendererConsoleLogging(firstRestoredPage);
+		registerRendererConsoleLogging(secondRestoredPage);
 
-		await expectWindowCount(electronApp, 1);
+		await expectWindowCount(electronApp, 2);
 		await expect(
-			restoredPage.getByRole("heading", { name: "First" }),
+			firstRestoredPage.getByRole("heading", { name: "First" }),
 		).toBeVisible();
-		await expect(restoredPage.getByText("second.md")).toBeVisible();
+		await expect(
+			secondRestoredPage.getByRole("heading", { name: "Second" }),
+		).toBeVisible();
 	} finally {
 		await closeElectronApp(electronApp);
 	}

--- a/electron/lix.mjs
+++ b/electron/lix.mjs
@@ -1,9 +1,4 @@
-import {
-	FsBackend,
-	FsEphemeralBackend,
-	bundledPluginArchives,
-	openLix,
-} from "@lix-js/sdk";
+import { FsBackend, bundledPluginArchives, openLix } from "@lix-js/sdk";
 import path from "node:path";
 import { readFile, rm } from "node:fs/promises";
 import { getWorkspace, getWorkspaceLixDatabasePath } from "./workspace.mjs";
@@ -24,10 +19,23 @@ export async function ensureLixOpen(window) {
 					);
 				}
 				const isEphemeral = workspace.ephemeral === true;
+				const includePaths = isEphemeral
+					? sourceFilePathsToWorkspaceIncludePaths(workspace)
+					: undefined;
+				if (isEphemeral && includePaths.length === 0) {
+					throw new Error(
+						"Ephemeral workspaces require at least one source file.",
+					);
+				}
 				const nativeLix = await openLix({
-					backend: isEphemeral
-						? new FsEphemeralBackend({ path: workspace.path })
-						: new FsBackend({ path: workspace.path }),
+					backend: new FsBackend({
+						path: workspace.path,
+						storage: isEphemeral ? "memory" : "persistent",
+						filter:
+							includePaths && includePaths.length > 0
+								? { includePaths }
+								: undefined,
+					}),
 				});
 				await ensureDefaultPluginsInstalledOnCurrentBranch(nativeLix);
 				return createDesktopLixHandle(nativeLix, workspace.path);
@@ -42,6 +50,24 @@ export async function ensureLixOpen(window) {
 		outPromise = session.lixPromise;
 	});
 	return await outPromise;
+}
+
+function sourceFilePathsToWorkspaceIncludePaths(workspace) {
+	return (workspace.sourceFilePaths ?? [])
+		.map((sourceFilePath) => {
+			const relativePath = path.relative(workspace.path, sourceFilePath);
+			if (
+				relativePath.startsWith("..") ||
+				path.isAbsolute(relativePath) ||
+				relativePath.length === 0
+			) {
+				throw new Error(
+					`Ephemeral source file must be inside the workspace: ${sourceFilePath}`,
+				);
+			}
+			return relativePath.split(path.sep).filter(Boolean).join("/");
+		})
+		.filter((includePath) => includePath.length > 0);
 }
 
 async function ensureDefaultPluginsInstalledOnCurrentBranch(lix) {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -10,6 +10,7 @@ import {
 	applyWorkspaceWindowChrome,
 	getWorkspace,
 	registerWorkspaceIpc,
+	resolveDirectLaunchWorkspaceTargets,
 	resolveWorkspaceTargets,
 	setWorkspaceFromTarget,
 } from "./workspace.mjs";
@@ -24,6 +25,7 @@ import {
 } from "./launch-args.mjs";
 import {
 	filterExistingWorkspaceEntries,
+	mergeRestoredAndExplicitWorkspaceRequests,
 	normalizeWorkspacePaths,
 	normalizeWorkspaceSessionEntries,
 	readWorkspaceSessionEntries,
@@ -36,17 +38,14 @@ const execFileAsync = promisify(execFile);
 const AUTO_UPDATE_CHECK_DELAY_MS = 10_000;
 const AUTO_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const TELEMETRY_HEARTBEAT_INTERVAL_MS = 4 * 60 * 60 * 1000;
-const OPEN_FILE_BATCH_DELAY_MS = 50;
 const DEV_SERVER_URL =
 	process.env.VITE_DEV_SERVER_URL ?? "http://127.0.0.1:4173";
 const isHeadless = process.env.FLASHTYPE_HEADLESS === "1";
 const workspaceWindows = new Set();
 const openWorkspaceEntriesByWindowId = new Map();
 const pendingWorkspaceOpenRequests = [];
-const pendingOpenFileEventPaths = [];
 let readyForWorkspaceOpens = false;
 let isQuitting = false;
-let openFileBatchTimer = null;
 let autoUpdaterInstance = null;
 let autoUpdateListenersRegistered = false;
 let updateCheckInProgress = false;
@@ -89,15 +88,7 @@ function openWorkspacePathWhenReady(workspacePath) {
 		pendingWorkspaceOpenRequests.push(workspacePath);
 		return;
 	}
-	pendingOpenFileEventPaths.push(workspacePath);
-	if (openFileBatchTimer !== null) {
-		clearTimeout(openFileBatchTimer);
-	}
-	openFileBatchTimer = setTimeout(() => {
-		openFileBatchTimer = null;
-		const paths = pendingOpenFileEventPaths.splice(0);
-		void openWorkspaceRequests(paths);
-	}, OPEN_FILE_BATCH_DELAY_MS);
+	void openWorkspaceRequests([workspacePath]);
 }
 
 async function openWorkspacePathArguments(
@@ -126,7 +117,8 @@ async function openWorkspacePathArguments(
 }
 
 async function openWorkspaceRequests(workspaceRequests) {
-	const workspaceTargets = await resolveWorkspaceTargets(workspaceRequests);
+	const workspaceTargets =
+		await resolveDirectLaunchWorkspaceTargets(workspaceRequests);
 	for (const workspaceTarget of workspaceTargets) {
 		await createMainWindow(workspaceTarget);
 	}
@@ -206,31 +198,6 @@ function flushOpenWorkspacePaths() {
 	} catch (error) {
 		console.warn("Failed to flush Flashtype workspace session", error);
 	}
-}
-
-function mergeRestoredAndExplicitWorkspaceRequests(
-	restoredWorkspaceEntries,
-	explicitWorkspacePaths,
-) {
-	const normalizedExplicitWorkspacePaths = normalizeWorkspacePaths(
-		explicitWorkspacePaths,
-	);
-	const explicitWorkspacePathSet = new Set(normalizedExplicitWorkspacePaths);
-	const restoredOnlyWorkspaceEntries = normalizeWorkspaceSessionEntries(
-		restoredWorkspaceEntries,
-	).filter((workspaceEntry) => {
-		if (workspaceEntry.ephemeral === false) {
-			return !explicitWorkspacePathSet.has(workspaceEntry.path);
-		}
-		if (workspaceEntry.ephemeral === true) {
-			return !workspaceEntry.sourceFilePaths.some((sourceFilePath) =>
-				explicitWorkspacePathSet.has(sourceFilePath),
-			);
-		}
-		return true;
-	});
-
-	return [...restoredOnlyWorkspaceEntries, ...normalizedExplicitWorkspacePaths];
 }
 
 async function createMainWindow(workspaceRequest) {
@@ -340,7 +307,10 @@ if (hasSingleInstanceLock) {
 				afterChange: (workspace, window) =>
 					recordOpenWorkspacePath(window, workspace),
 				openInNewWindow: async (requestedPath) => {
-					const window = await createMainWindow(requestedPath);
+					const workspaceTarget = (
+						await resolveDirectLaunchWorkspaceTargets([requestedPath])
+					)[0];
+					const window = await createMainWindow(workspaceTarget);
 					return getWorkspace(window);
 				},
 			},

--- a/electron/workspace-session.mjs
+++ b/electron/workspace-session.mjs
@@ -153,6 +153,28 @@ export function normalizeWorkspacePaths(workspacePaths) {
 	return normalizedWorkspacePaths;
 }
 
+export function mergeRestoredAndExplicitWorkspaceRequests(
+	restoredWorkspaceEntries,
+	explicitWorkspacePaths,
+) {
+	const normalizedExplicitWorkspacePaths = normalizeWorkspacePaths(
+		explicitWorkspacePaths,
+	);
+	const explicitWorkspacePathSet = new Set(normalizedExplicitWorkspacePaths);
+	const restoredOnlyWorkspaceEntries = normalizeWorkspaceSessionEntries(
+		restoredWorkspaceEntries,
+	).filter(
+		(workspaceEntry) =>
+			!workspaceEntryOverlapsExplicitPaths(
+				workspaceEntry,
+				normalizedExplicitWorkspacePaths,
+				explicitWorkspacePathSet,
+			),
+	);
+
+	return [...restoredOnlyWorkspaceEntries, ...normalizedExplicitWorkspacePaths];
+}
+
 export function getWorkspaceSessionPath(userDataPath) {
 	return path.join(userDataPath, WORKSPACE_SESSION_FILE);
 }
@@ -190,6 +212,42 @@ function workspaceSessionEntryKey(workspaceEntry) {
 		return `ephemeral:${workspaceEntry.sourceFilePaths.join("\0")}`;
 	}
 	return `directory:${workspaceEntry.path}`;
+}
+
+function workspaceEntryOverlapsExplicitPaths(
+	workspaceEntry,
+	explicitWorkspacePaths,
+	explicitWorkspacePathSet,
+) {
+	if (workspaceEntry.ephemeral === false) {
+		return explicitWorkspacePaths.some(
+			(explicitWorkspacePath) =>
+				isSamePathOrInside(workspaceEntry.path, explicitWorkspacePath) ||
+				isSamePathOrInside(explicitWorkspacePath, workspaceEntry.path),
+		);
+	}
+	if (workspaceEntry.ephemeral === true) {
+		return workspaceEntry.sourceFilePaths.some(
+			(sourceFilePath) =>
+				explicitWorkspacePathSet.has(sourceFilePath) ||
+				explicitWorkspacePaths.some((explicitWorkspacePath) =>
+					isSamePathOrInside(explicitWorkspacePath, sourceFilePath),
+				),
+		);
+	}
+	return false;
+}
+
+function isSamePathOrInside(parentPath, childPath) {
+	if (childPath === parentPath) {
+		return true;
+	}
+	const relativePath = path.relative(parentPath, childPath);
+	return (
+		relativePath.length > 0 &&
+		!relativePath.startsWith("..") &&
+		!path.isAbsolute(relativePath)
+	);
 }
 
 function serializeWorkspaceSessionEntries(workspaceEntries) {

--- a/electron/workspace-session.test.ts
+++ b/electron/workspace-session.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "vitest";
 import {
 	filterExistingWorkspaceEntries,
 	getWorkspaceSessionPath,
+	mergeRestoredAndExplicitWorkspaceRequests,
 	readWorkspaceSessionEntries,
 	writeWorkspaceSessionEntries,
 	writeWorkspaceSessionEntriesSync,
@@ -113,6 +114,114 @@ describe("workspace session store", () => {
 			{ ephemeral: false, path: directoryWorkspacePath },
 			{ ephemeral: true, sourceFilePaths: [firstFilePath] },
 		]);
+	});
+
+	test("restores saved workspaces when launch has no explicit paths", () => {
+		const userDataPath = createUserDataPath();
+		const workspacePath = path.join(userDataPath, "workspace");
+		const firstFilePath = path.join(userDataPath, "files", "one.md");
+		const secondFilePath = path.join(userDataPath, "files", "two.md");
+
+		expect(
+			mergeRestoredAndExplicitWorkspaceRequests(
+				[
+					{ ephemeral: false, path: workspacePath },
+					{ ephemeral: false, path: workspacePath },
+					{
+						ephemeral: true,
+						sourceFilePaths: [firstFilePath, secondFilePath, firstFilePath],
+					},
+				],
+				[],
+			),
+		).toEqual([
+			{ ephemeral: false, path: workspacePath },
+			{ ephemeral: true, sourceFilePaths: [firstFilePath, secondFilePath] },
+		]);
+	});
+
+	test("keeps unrelated restored workspaces when launch has explicit paths", () => {
+		const userDataPath = createUserDataPath();
+		const restoredWorkspacePath = path.join(userDataPath, "Downloads");
+		const unrelatedWorkspacePath = path.join(userDataPath, "Projects");
+		const restoredFilePath = path.join(userDataPath, "notes", "draft.md");
+		const unrelatedFilePath = path.join(userDataPath, "notes", "other.md");
+		const explicitFilePath = path.join(
+			userDataPath,
+			"Downloads",
+			"docs",
+			"README.md",
+		);
+
+		expect(
+			mergeRestoredAndExplicitWorkspaceRequests(
+				[
+					{ ephemeral: false, path: restoredWorkspacePath },
+					{ ephemeral: false, path: unrelatedWorkspacePath },
+					{
+						ephemeral: true,
+						sourceFilePaths: [restoredFilePath, unrelatedFilePath],
+					},
+				],
+				[explicitFilePath, restoredFilePath],
+			),
+		).toEqual([
+			{ ephemeral: false, path: unrelatedWorkspacePath },
+			explicitFilePath,
+			restoredFilePath,
+		]);
+	});
+
+	test("does not duplicate explicitly opened restored workspace directories", () => {
+		const userDataPath = createUserDataPath();
+		const workspacePath = path.join(userDataPath, "workspace");
+
+		expect(
+			mergeRestoredAndExplicitWorkspaceRequests(
+				[{ ephemeral: false, path: workspacePath }],
+				[workspacePath],
+			),
+		).toEqual([workspacePath]);
+	});
+
+	test("drops restored workspace directories containing explicit launch files", () => {
+		const userDataPath = createUserDataPath();
+		const restoredWorkspacePath = path.join(userDataPath, "Downloads");
+		const explicitFilePath = path.join(
+			userDataPath,
+			"Downloads",
+			"docs",
+			"README.md",
+		);
+
+		expect(
+			mergeRestoredAndExplicitWorkspaceRequests(
+				[{ ephemeral: false, path: restoredWorkspacePath }],
+				[explicitFilePath],
+			),
+		).toEqual([explicitFilePath]);
+	});
+
+	test("drops restored nested entries contained by explicit launch folders", () => {
+		const userDataPath = createUserDataPath();
+		const explicitWorkspacePath = path.join(userDataPath, "Downloads");
+		const restoredWorkspacePath = path.join(userDataPath, "Downloads", "docs");
+		const restoredFilePath = path.join(
+			userDataPath,
+			"Downloads",
+			"notes",
+			"draft.md",
+		);
+
+		expect(
+			mergeRestoredAndExplicitWorkspaceRequests(
+				[
+					{ ephemeral: false, path: restoredWorkspacePath },
+					{ ephemeral: true, sourceFilePaths: [restoredFilePath] },
+				],
+				[explicitWorkspacePath],
+			),
+		).toEqual([explicitWorkspacePath]);
 	});
 });
 

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -23,11 +23,19 @@ export function getWorkspace(window) {
  * Resolves a requested folder directly, or a requested file to the nearest
  * ancestor Lix workspace and the file path within that workspace.
  */
-export async function resolveWorkspaceTarget(requestedPath) {
+export async function resolveWorkspaceTarget(requestedPath, options = {}) {
 	const resolved = path.resolve(requestedPath);
 	try {
 		const stats = await stat(resolved);
 		if (stats.isFile()) {
+			if (options.openFilesAsTransient === true) {
+				const workspace = createTransientDirectoryWorkspace([resolved]);
+				return {
+					workspace,
+					pendingOpenFilePaths:
+						pendingOpenFilePathsForTransientDirectoryWorkspace(workspace),
+				};
+			}
 			const workspaceDir = await findLixWorkspaceRoot(path.dirname(resolved));
 			if (!workspaceDir) {
 				const workspace = createTransientDirectoryWorkspace([resolved]);
@@ -62,7 +70,7 @@ export async function resolveWorkspaceTarget(requestedPath) {
 	};
 }
 
-export async function resolveWorkspaceTargets(requestedPaths) {
+export async function resolveWorkspaceTargets(requestedPaths, options = {}) {
 	const targets = [];
 	const standaloneFiles = [];
 	let standaloneFilesInsertIndex = null;
@@ -81,15 +89,19 @@ export async function resolveWorkspaceTargets(requestedPaths) {
 		}
 
 		const resolved = path.resolve(String(requestedPath));
-		const standaloneFileTarget = await resolveStandaloneFile(resolved);
+		const standaloneFileTarget = await resolveStandaloneFile(resolved, options);
 		if (standaloneFileTarget) {
+			if (options.openFilesAsTransient === true) {
+				targets.push(await resolveWorkspaceTarget(standaloneFileTarget, options));
+				continue;
+			}
 			if (standaloneFilesInsertIndex === null) {
 				standaloneFilesInsertIndex = targets.length;
 			}
 			standaloneFiles.push(standaloneFileTarget);
 			continue;
 		}
-		targets.push(await resolveWorkspaceTarget(resolved));
+		targets.push(await resolveWorkspaceTarget(resolved, options));
 	}
 
 	if (standaloneFiles.length > 0) {
@@ -102,6 +114,12 @@ export async function resolveWorkspaceTargets(requestedPaths) {
 	}
 
 	return targets;
+}
+
+export async function resolveDirectLaunchWorkspaceTargets(requestedPaths) {
+	return await resolveWorkspaceTargets(requestedPaths, {
+		openFilesAsTransient: true,
+	});
 }
 
 export async function resolveWorkspace(requestedPath) {
@@ -236,13 +254,16 @@ async function resolveWorkspaceSessionEntry(workspaceEntry) {
 	return null;
 }
 
-async function resolveStandaloneFile(resolvedPath) {
+async function resolveStandaloneFile(resolvedPath, options = {}) {
 	try {
 		if (!(await stat(resolvedPath)).isFile()) {
 			return null;
 		}
 	} catch {
 		return null;
+	}
+	if (options.openFilesAsTransient === true) {
+		return resolvedPath;
 	}
 	const workspaceDir = await findLixWorkspaceRoot(path.dirname(resolvedPath));
 	return workspaceDir ? null : resolvedPath;

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import {
+	resolveDirectLaunchWorkspaceTargets,
 	resolveWorkspace,
 	resolveWorkspaceTarget,
 	resolveWorkspaceTargets,
@@ -90,6 +91,116 @@ describe("workspace resolution", () => {
 			},
 			pendingOpenFilePaths: ["docs/readme.md"],
 		});
+	});
+
+	test("can resolve files inside Lix workspaces as transient launch targets", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		const filePath = path.join(directory, "readme.md");
+		await mkdir(path.join(directory, ".lix", ".internal"), { recursive: true });
+		await writeFile(path.join(directory, ".lix", ".internal", "db.sqlite"), "");
+		await writeFile(filePath, "# Hello\n");
+
+		await expect(
+			resolveWorkspaceTargets([filePath], { openFilesAsTransient: true }),
+		).resolves.toEqual([
+			{
+				workspace: {
+					ephemeral: true,
+					path: directory,
+					sourceFilePaths: [filePath],
+					name: "workspace",
+				},
+				pendingOpenFilePaths: ["readme.md"],
+			},
+		]);
+	});
+
+	test("resolves direct launch file targets as transient workspaces", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		const filePath = path.join(directory, "readme.md");
+		await mkdir(path.join(directory, ".lix", ".internal"), { recursive: true });
+		await writeFile(path.join(directory, ".lix", ".internal", "db.sqlite"), "");
+		await writeFile(filePath, "# Hello\n");
+
+		await expect(
+			resolveDirectLaunchWorkspaceTargets([filePath]),
+		).resolves.toEqual([
+			{
+				workspace: {
+					ephemeral: true,
+					path: directory,
+					sourceFilePaths: [filePath],
+					name: "workspace",
+				},
+				pendingOpenFilePaths: ["readme.md"],
+			},
+		]);
+	});
+
+	test("resolves each file in a direct launch batch independently", async () => {
+		const firstDirectory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"first",
+		);
+		const secondDirectory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"second",
+		);
+		const firstPath = path.join(firstDirectory, "readme.md");
+		const secondPath = path.join(secondDirectory, "readme.md");
+		await mkdir(path.join(firstDirectory, ".lix", ".internal"), {
+			recursive: true,
+		});
+		await mkdir(path.join(secondDirectory, ".lix", ".internal"), {
+			recursive: true,
+		});
+		await writeFile(
+			path.join(firstDirectory, ".lix", ".internal", "db.sqlite"),
+			"",
+		);
+		await writeFile(
+			path.join(secondDirectory, ".lix", ".internal", "db.sqlite"),
+			"",
+		);
+		await writeFile(firstPath, "# First\n");
+		await writeFile(secondPath, "# Second\n");
+
+		await expect(
+			resolveDirectLaunchWorkspaceTargets([firstPath, secondPath]),
+		).resolves.toEqual([
+			{
+				workspace: {
+					ephemeral: true,
+					path: firstDirectory,
+					sourceFilePaths: [firstPath],
+					name: "first",
+				},
+				pendingOpenFilePaths: ["readme.md"],
+			},
+			{
+				workspace: {
+					ephemeral: true,
+					path: secondDirectory,
+					sourceFilePaths: [secondPath],
+					name: "second",
+				},
+				pendingOpenFilePaths: ["readme.md"],
+			},
+		]);
 	});
 
 	test("resolves files outside a Lix workspace to transient directory workspaces", async () => {


### PR DESCRIPTION
## Summary
- open direct file launches as transient workspaces so Flashtype only syncs the requested Markdown file
- wire transient workspaces through `FsBackend` memory storage with exact include-path filtering
- move restored/explicit workspace merge logic into the session module and cover overlap cases
- update the Lix submodule pointer to opral/lix#544

## Root Cause
Double-clicking a Markdown file inside a huge folder, such as Downloads, resolved to the surrounding workspace directory and caused Lix filesystem sync to crawl much more than the requested file. In the reported crash, native Lix was collecting the local filesystem snapshot when the app terminated.

## Impact
Direct Markdown file opens now use an in-memory transient workspace filtered to the requested file. Opening a file from a large folder no longer requires indexing the whole folder.

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Notes
- `pnpm lint` currently fails on an unrelated existing React hook dependency warning in `website/src/routes/__root.tsx`, outside this PR diff.
- `pnpm build` passes with Vite's existing large chunk warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Electron launch, workspace restore merge, and Lix sync for all direct file opens; wrong filtering or overlap logic could drop windows or miss edits to disk.
> 
> **Overview**
> **Direct file opens** (CLI, macOS `open-file`, open in new window) now resolve through `resolveDirectLaunchWorkspaceTargets`, so each requested file gets its **own transient workspace and window** instead of grouping markdown files or opening the parent Lix folder.
> 
> Ephemeral workspaces use **`FsBackend` with in-memory storage** and **`includePaths`** limited to the source file(s), replacing `FsEphemeralBackend`. That avoids crawling large directories (e.g. Downloads) when double-clicking a single `.md`. E2E expectations change accordingly: siblings are not listed, and Lix inserts do not create extra files on disk without `.lix`.
> 
> **Launch/session behavior**: `open-file` no longer batches paths; each event opens one workspace immediately. Restored-vs-explicit launch merging moves to `workspace-session.mjs` with path overlap rules (nested folders, files inside restored directories).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4745b31eb5b7bd40f1e26e3cf40bca37bd8e8d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->