### PR TITLE
[codex] Inject active file context into agent launches

### DIFF
--- a/src/extensions/terminal/index.tsx
+++ b/src/extensions/terminal/index.tsx
@@ -7,6 +7,8 @@ import { createReactExtensionDefinition } from "../../extension-runtime/react-ex
 import { TERMINAL_EXTENSION_KIND } from "../../extension-runtime/extension-instance-helpers";
 import { createTerminalOutputNormalizer } from "./ansi-style-normalizer";
 
+const TERMINAL_INITIAL_COMMAND_LAUNCH_ARG = "initialCommand";
+
 const XTERM_THEMES = {
 	light: {
 		background: "#ffffff",
@@ -179,9 +181,12 @@ export const extension = createReactExtensionDefinition({
 	component: ({ instance }) => (
 		<TerminalView
 			initialCommand={
-				typeof instance.state?.command === "string"
-					? instance.state.command
-					: undefined
+				typeof instance.launchArgs?.[TERMINAL_INITIAL_COMMAND_LAUNCH_ARG] ===
+				"string"
+					? instance.launchArgs[TERMINAL_INITIAL_COMMAND_LAUNCH_ARG]
+					: typeof instance.state?.command === "string"
+						? instance.state.command
+						: undefined
 			}
 		/>
 	),

--- a/src/shell/agent-launch.test.ts
+++ b/src/shell/agent-launch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import {
+	TERMINAL_INITIAL_COMMAND_LAUNCH_ARG,
+	buildAgentLaunchArgsWithActiveFile,
+	buildFlashtypeActiveFilePrompt,
+} from "./agent-launch";
+
+describe("buildFlashtypeActiveFilePrompt", () => {
+	test("uses the Flashtype.com launch-context sentence", () => {
+		expect(buildFlashtypeActiveFilePrompt("/docs/intro.md")).toBe(
+			"The user is using Flashtype.com. The active file right now, which may change later, is: ./docs/intro.md",
+		);
+	});
+
+	test("preserves already-relative dot paths", () => {
+		expect(buildFlashtypeActiveFilePrompt("./docs/intro.md")).toContain(
+			"./docs/intro.md",
+		);
+	});
+
+	test("returns null without a file path", () => {
+		expect(buildFlashtypeActiveFilePrompt("")).toBeNull();
+	});
+});
+
+describe("buildAgentLaunchArgsWithActiveFile", () => {
+	test("adds a Claude append-system-prompt launch command", () => {
+		const launchArgs = buildAgentLaunchArgsWithActiveFile({
+			state: {
+				command: "claude --dangerously-skip-permissions",
+				flashtype: { icon: "claude" },
+			},
+			activeFilePath: "/docs/intro.md",
+		});
+
+		expect(launchArgs?.[TERMINAL_INITIAL_COMMAND_LAUNCH_ARG]).toBe(
+			"claude --dangerously-skip-permissions --append-system-prompt 'The user is using Flashtype.com. The active file right now, which may change later, is: ./docs/intro.md'",
+		);
+	});
+
+	test("adds a Codex developer-instructions launch command", () => {
+		const launchArgs = buildAgentLaunchArgsWithActiveFile({
+			state: {
+				command: "codex --dangerously-bypass-approvals-and-sandbox",
+				flashtype: { icon: "codex" },
+			},
+			activeFilePath: "/docs/intro.md",
+		});
+
+		expect(launchArgs?.[TERMINAL_INITIAL_COMMAND_LAUNCH_ARG]).toBe(
+			"codex --dangerously-bypass-approvals-and-sandbox -c 'developer_instructions=\"The user is using Flashtype.com. The active file right now, which may change later, is: ./docs/intro.md\"'",
+		);
+	});
+
+	test("does not alter non-agent terminal launches", () => {
+		expect(
+			buildAgentLaunchArgsWithActiveFile({
+				state: { command: "zsh" },
+				activeFilePath: "/docs/intro.md",
+			}),
+		).toBeUndefined();
+	});
+});

--- a/src/shell/agent-launch.ts
+++ b/src/shell/agent-launch.ts
@@ -1,0 +1,74 @@
+import type {
+	ExtensionLaunchArgs,
+	ExtensionState,
+} from "../extension-runtime/types";
+
+export const TERMINAL_INITIAL_COMMAND_LAUNCH_ARG = "initialCommand";
+
+const FLASHTYPE_AGENT_ICONS = new Set(["claude", "codex"]);
+
+export function buildAgentLaunchArgsWithActiveFile(args: {
+	readonly state?: ExtensionState;
+	readonly activeFilePath?: string | null;
+}): ExtensionLaunchArgs | undefined {
+	const command =
+		typeof args.state?.command === "string" ? args.state.command : null;
+	const agentIcon = args.state?.flashtype?.icon;
+	if (!command || !agentIcon || !FLASHTYPE_AGENT_ICONS.has(agentIcon)) {
+		return undefined;
+	}
+	const prompt = buildFlashtypeActiveFilePrompt(args.activeFilePath);
+	if (!prompt) {
+		return undefined;
+	}
+	return {
+		[TERMINAL_INITIAL_COMMAND_LAUNCH_ARG]: buildAgentCommandWithPrompt({
+			command,
+			agentIcon,
+			prompt,
+		}),
+	};
+}
+
+export function buildFlashtypeActiveFilePrompt(
+	filePath: string | null | undefined,
+): string | null {
+	const promptPath = normalizePromptFilePath(filePath);
+	if (!promptPath) {
+		return null;
+	}
+	return `The user is using Flashtype.com. The active file right now, which may change later, is: ${promptPath}`;
+}
+
+function buildAgentCommandWithPrompt(args: {
+	readonly command: string;
+	readonly agentIcon: string;
+	readonly prompt: string;
+}): string {
+	if (args.agentIcon === "claude") {
+		return `${args.command} --append-system-prompt ${shellQuote(args.prompt)}`;
+	}
+	if (args.agentIcon === "codex") {
+		return `${args.command} -c ${shellQuote(
+			`developer_instructions=${JSON.stringify(args.prompt)}`,
+		)}`;
+	}
+	return args.command;
+}
+
+function normalizePromptFilePath(
+	filePath: string | null | undefined,
+): string | null {
+	const trimmed = filePath?.trim();
+	if (!trimmed) {
+		return null;
+	}
+	if (trimmed.startsWith("./")) {
+		return trimmed;
+	}
+	return `./${trimmed.replace(/^\/+/, "")}`;
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -84,6 +84,7 @@ import {
 	cloneExtensionInstance,
 	reorderPanelExtensionsByIndex,
 } from "./panel-utils";
+import { buildAgentLaunchArgsWithActiveFile } from "./agent-launch";
 
 const stripLaunchArgs = (view: ExtensionInstance): ExtensionInstance => {
 	const { launchArgs: _omitLaunch, ...rest } = view as any;
@@ -1166,6 +1167,16 @@ function LayoutShellContent({
 		[setPanelState],
 	);
 
+	const activeCentralEntry = useMemo(() => {
+		const activeInstance =
+			centralPanel.activeInstance ?? centralPanel.views[0]?.instance ?? null;
+		if (!activeInstance) return null;
+		return (
+			centralPanel.views.find((entry) => entry.instance === activeInstance) ??
+			null
+		);
+	}, [centralPanel]);
+
 	const handleAddView = useCallback(
 		(side: PanelSide, kind: ExtensionKind, state?: ExtensionState) => {
 			// Multi-instance kinds (agent terminals) get a fresh instance per
@@ -1173,9 +1184,16 @@ function LayoutShellContent({
 			const instance = extensionMap.get(kind)?.multiInstance
 				? createExtensionInstanceId(kind)
 				: undefined;
-			handleOpenView({ panel: side, kind, state, instance });
+			const launchArgs = buildAgentLaunchArgsWithActiveFile({
+				state,
+				activeFilePath:
+					typeof activeCentralEntry?.state?.filePath === "string"
+						? activeCentralEntry.state.filePath
+						: null,
+			});
+			handleOpenView({ panel: side, kind, state, launchArgs, instance });
 		},
-		[handleOpenView, extensionMap],
+		[activeCentralEntry, handleOpenView, extensionMap],
 	);
 
 	const focusPanel = useCallback((side: PanelSide) => {
@@ -1359,15 +1377,6 @@ function LayoutShellContent({
 		});
 	}, [handleOpenFile, lix]);
 
-	const activeCentralEntry = useMemo(() => {
-		const activeInstance =
-			centralPanel.activeInstance ?? centralPanel.views[0]?.instance ?? null;
-		if (!activeInstance) return null;
-		return (
-			centralPanel.views.find((entry) => entry.instance === activeInstance) ??
-			null
-		);
-	}, [centralPanel]);
 	const activeCentralFileId =
 		activeMarkdownFileIdFromExtensionInstance(activeCentralEntry);
 


### PR DESCRIPTION
## Summary
- inject a short Flashtype.com active-file context prompt when launching Claude Code or Codex
- keep the enriched launch command transient via terminal launchArgs so persisted terminal state stays clean
- add focused tests for prompt text, command generation, and non-agent terminal behavior

## Validation
- pnpm vitest run src/shell/agent-launch.test.ts
- pnpm typecheck
- pnpm prettier --check src/shell/agent-launch.ts src/shell/agent-launch.test.ts src/extensions/terminal/index.tsx src/shell/layout-shell.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Constructs shell commands with user file paths and agent bypass flags; mistakes could break launches or mishandle quoting, but scope is limited to Claude/Codex add-view flows.
> 
> **Overview**
> When users open a **Claude Code** or **Codex** agent terminal from the shell, the app now passes a short Flashtype.com context sentence that names the **currently active central-panel file** (as a `./…` path).
> 
> That enriched command is delivered through transient **`launchArgs.initialCommand`**, which the terminal prefers over persisted `state.command`, so saved terminal state is not polluted with one-off prompt flags. Plain shells (e.g. `zsh`) are unchanged.
> 
> New `agent-launch` helpers build the prompt and agent-specific CLI flags (`--append-system-prompt` for Claude, `-c developer_instructions=…` for Codex), with unit tests covering prompt text, both agents, and non-agent launches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b715fb38973401ef69d380618894e42acffcb61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->