### PR TITLE
[codex] Cache Lix SDK build in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -73,6 +73,18 @@ jobs:
             submodule/markdown-wc/js -> target
           cache-on-failure: true
 
+      - name: Resolve Lix SDK cache key
+        id: lix-sdk-cache-key
+        run: echo "sha=$(git -C submodule/lix rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Lix SDK build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            submodule/lix/packages/js-sdk/dist
+            submodule/lix/packages/js-sdk/lix_js_sdk.node
+          key: lix-js-sdk-${{ runner.os }}-${{ runner.arch }}-node-${{ matrix.version }}-${{ steps.lix-sdk-cache-key.outputs.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Rust wasm tools
         run: |
           cargo install wasm-bindgen-cli --version 0.2.108 --locked
@@ -132,6 +144,18 @@ jobs:
             submodule/lix -> ../../target
             submodule/markdown-wc/js -> target
           cache-on-failure: true
+
+      - name: Resolve Lix SDK cache key
+        id: lix-sdk-cache-key
+        run: echo "sha=$(git -C submodule/lix rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Lix SDK build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            submodule/lix/packages/js-sdk/dist
+            submodule/lix/packages/js-sdk/lix_js_sdk.node
+          key: lix-js-sdk-${{ runner.os }}-${{ runner.arch }}-node-22-${{ steps.lix-sdk-cache-key.outputs.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Rust wasm tools
         run: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -96,6 +96,18 @@ jobs:
             submodule/markdown-wc/js -> target
           cache-on-failure: true
 
+      - name: Resolve Lix SDK cache key
+        id: lix-sdk-cache-key
+        run: echo "sha=$(git -C submodule/lix rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Lix SDK build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            submodule/lix/packages/js-sdk/dist
+            submodule/lix/packages/js-sdk/lix_js_sdk.node
+          key: lix-js-sdk-${{ runner.os }}-${{ runner.arch }}-node-22-${{ steps.lix-sdk-cache-key.outputs.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Rust wasm tools
         run: |
           cargo install wasm-bindgen-cli@0.2.108 cargo-bash resvg@0.47.0 --locked

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"build": "vite build",
 		"prebuild": "pnpm run build:lix && pnpm run build:markdown-wc",
 		"postinstall": "command -v cargo >/dev/null 2>&1 && cargo fetch --manifest-path submodule/lix/Cargo.toml || true",
-		"build:lix": "pnpm -C submodule/lix/packages/js-sdk run build",
+		"build:lix": "node scripts/build-lix.mjs",
 		"preview": "vite preview --strictPort --port 5173",
 		"typecheck": "tsc -p . --pretty false",
 		"format": "prettier --write .",

--- a/scripts/build-lix.mjs
+++ b/scripts/build-lix.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { access } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const packageDir = path.join(rootDir, "submodule/lix/packages/js-sdk");
+
+const cachedArtifacts = [
+	path.join(packageDir, "lix_js_sdk.node"),
+	path.join(packageDir, "dist/index.js"),
+];
+
+if (process.env.CI === "true" && (await allExist(cachedArtifacts))) {
+	console.log("Using cached @lix-js/sdk build artifacts.");
+	process.exit(0);
+}
+
+await run("pnpm", ["-C", packageDir, "run", "build"]);
+
+async function allExist(paths) {
+	for (const candidate of paths) {
+		try {
+			await access(candidate);
+		} catch {
+			return false;
+		}
+	}
+	return true;
+}
+
+function run(cmd, args) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(cmd, args, {
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
+		child.on("error", reject);
+		child.on("exit", (code) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+			reject(new Error(`${cmd} exited with code ${code ?? 1}`));
+		});
+	});
+}


### PR DESCRIPTION
## Summary

- cache the built `@lix-js/sdk` artifacts in CI and macOS release workflows
- route `build:lix` through a tiny CI-aware wrapper that skips rebuilding when cached artifacts are present
- keep local builds unchanged unless `CI=true` and the cache restored `dist/index.js` plus `lix_js_sdk.node`

## Validation

- `CI=true pnpm run build:lix`
- `pnpm exec prettier --check package.json scripts/build-lix.mjs .github/workflows/continuous-integration.yml .github/workflows/release-macos.yml`
- `actionlint -ignore 'label "blacksmith-' -ignore 'SC2016' .github/workflows/continuous-integration.yml .github/workflows/release-macos.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and workflow-only changes; no runtime app logic, with cache invalidation tied to submodule SHA and lockfile.
> 
> **Overview**
> Speeds up CI and macOS release pipelines by **caching** the built `@lix-js/sdk` outputs (`dist/` and `lix_js_sdk.node`) instead of rebuilding every run.
> 
> **CI workflows** (`continuous-integration.yml`, `release-macos.yml`) now resolve `submodule/lix` HEAD and restore/save that cache via `actions/cache@v4`, keyed by OS, arch, Node version, Lix submodule SHA, and `pnpm-lock.yaml`.
> 
> **`build:lix`** is routed through `scripts/build-lix.mjs`: when `CI=true` and both expected artifacts already exist (from cache), the script exits without invoking `pnpm` build; local dev without cache still runs the full Lix SDK build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb11e50bcfe6cb07142f6ccd7b4f7dc1c9b5be4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->