### PR TITLE
[codex] Improve markdown autosave affordance colors

### DIFF
--- a/.changenotes/improve-markdown-autosave-affordance.md
+++ b/.changenotes/improve-markdown-autosave-affordance.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Improved the Markdown editor chrome around autosave and formatting controls.

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,14 +4,14 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
 	{
 		variants: {
 			variant: {
 				default:
 					"bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
 				destructive:
-					"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+					"bg-destructive text-[var(--color-text-on-action-primary)] shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				ghost:
 					"hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
 			},

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -32,7 +32,7 @@ function DropdownMenuContent({
 				data-slot="dropdown-menu-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+					"bg-[var(--color-bg-panel)] text-[var(--color-text-primary)] border-[var(--color-border-panel)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
 					className,
 				)}
 				{...props}
@@ -49,7 +49,7 @@ function DropdownMenuItem({
 		<DropdownMenuPrimitive.Item
 			data-slot="dropdown-menu-item"
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"focus:bg-[var(--color-bg-hover)] focus:text-[var(--color-text-primary)] [&_svg:not([class*='text-'])]:text-[var(--color-icon-secondary)] relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}
@@ -98,7 +98,7 @@ function DropdownMenuSubTrigger({
 		<DropdownMenuPrimitive.SubTrigger
 			data-slot="dropdown-menu-sub-trigger"
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none",
+				"focus:bg-[var(--color-bg-hover)] focus:text-[var(--color-text-primary)] data-[state=open]:bg-[var(--color-bg-hover)] data-[state=open]:text-[var(--color-text-primary)] flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none",
 				className,
 			)}
 			{...props}
@@ -117,7 +117,7 @@ function DropdownMenuSubContent({
 		<DropdownMenuPrimitive.SubContent
 			data-slot="dropdown-menu-sub-content"
 			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+				"bg-[var(--color-bg-panel)] text-[var(--color-text-primary)] border-[var(--color-border-panel)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -47,13 +47,13 @@ function TooltipContent({
 				data-slot="tooltip-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-secondary text-secondary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+					"bg-[var(--color-bg-tooltip)] text-[var(--color-text-tooltip)] animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
 					className,
 				)}
 				{...props}
 			>
 				{children}
-				<TooltipPrimitive.Arrow className="bg-secondary fill-secondary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+				<TooltipPrimitive.Arrow className="bg-[var(--color-bg-tooltip)] fill-[var(--color-bg-tooltip)] z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
 			</TooltipPrimitive.Content>
 		</TooltipPrimitive.Portal>
 	);

--- a/src/extension-runtime/external-write-review-controls.css
+++ b/src/extension-runtime/external-write-review-controls.css
@@ -39,15 +39,15 @@
 }
 
 .external-write-review-button-accept {
-	background: var(--color-brand-600);
-	color: white;
+	background: var(--color-bg-action-primary);
+	color: var(--color-text-on-action-primary);
 	box-shadow:
 		0 1px 0 rgba(255, 255, 255, 0.18) inset,
 		0 8px 18px rgba(0, 0, 0, 0.14);
 }
 
 .external-write-review-button-accept:hover {
-	background: var(--color-brand-700);
+	background: var(--color-bg-action-primary-hover);
 }
 
 .external-write-review-button-reject {

--- a/src/extensions/csv/index.tsx
+++ b/src/extensions/csv/index.tsx
@@ -86,7 +86,7 @@ function CsvViewContent({
 
 	if (!fileRow) {
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-neutral-500">
+			<div className="flex h-full items-center justify-center text-sm text-[var(--color-text-tertiary)]">
 				File not found in the workspace.
 			</div>
 		);
@@ -99,7 +99,7 @@ function CsvViewContent({
 	return (
 		<div className="csv-view flex min-h-0 flex-1 flex-col bg-background">
 			{parsed.warnings.length > 0 ? (
-				<div className="mx-5 mt-3 flex shrink-0 items-start gap-2 rounded-[8px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+				<div className="mx-5 mt-3 flex shrink-0 items-start gap-2 rounded-[8px] border border-[var(--color-border-notice-warning)] bg-[var(--color-bg-notice-warning)] px-3 py-2 text-xs text-[var(--color-text-notice-warning)]">
 					<AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
 					<span className="min-w-0 truncate">{parsed.warnings[0]}</span>
 				</div>
@@ -191,11 +191,11 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 			className="h-full min-h-0 flex-1 overflow-auto bg-background"
 		>
 			<div style={{ minWidth: totalWidth }} className="relative w-full">
-				<div className="sticky top-0 z-10 flex h-10 w-full border-b border-island-divider bg-neutral-50 text-[11px] font-bold uppercase tracking-[0.04em] text-neutral-600">
+				<div className="sticky top-0 z-10 flex h-10 w-full border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-panel-muted)] text-[11px] font-bold uppercase tracking-[0.04em] text-[var(--color-text-secondary)]">
 					{table.getHeaderGroups()[0]?.headers.map((header) => (
 						<div
 							key={header.id}
-							className="flex h-10 items-center border-r border-[#f1ece5] px-4 last:border-r-0"
+							className="flex h-10 items-center border-r border-[var(--color-border-table-grid)] px-4 last:border-r-0"
 							style={columnStyle()}
 							title={String(header.column.columnDef.header ?? "")}
 						>
@@ -220,7 +220,7 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 								key={row.id}
 								data-index={virtualRow.index}
 								ref={virtualizer.measureElement}
-								className="absolute left-0 flex w-full border-b border-[#f4f1ec] text-[13.5px] text-neutral-700 transition-colors hover:bg-[#faf6f0]"
+								className="absolute left-0 flex w-full border-b border-[var(--color-border-table-grid)] text-[13.5px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-table-row-hover)]"
 								style={{
 									minHeight: virtualRow.size,
 									transform: `translateY(${virtualRow.start}px)`,
@@ -229,7 +229,7 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 								{row.getVisibleCells().map((cell) => (
 									<div
 										key={cell.id}
-										className="border-r border-[#f4f1ec] px-4 py-0 last:border-r-0"
+										className="border-r border-[var(--color-border-table-grid)] px-4 py-0 last:border-r-0"
 										style={columnStyle()}
 										title={String(cell.getValue() ?? "")}
 									>
@@ -258,15 +258,15 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 function cellValueClassName(value: string, isFirstColumn: boolean): string {
 	const base = "flex min-h-12 items-center whitespace-normal break-words py-2";
 	if (isEmailLike(value)) {
-		return `${base} font-mono text-[12.5px] text-brand-700`;
+		return `${base} font-mono text-[12.5px] text-[var(--color-text-link-hover)]`;
 	}
 	if (isNumericValue(value)) {
-		return `${base} font-mono text-[13px] text-neutral-700`;
+		return `${base} font-mono text-[13px] text-[var(--color-text-secondary)]`;
 	}
 	if (isFirstColumn) {
-		return `${base} font-mono text-[12.5px] text-neutral-400`;
+		return `${base} font-mono text-[12.5px] text-[var(--color-icon-tertiary)]`;
 	}
-	return `${base} font-normal text-neutral-900`;
+	return `${base} font-normal text-[var(--color-text-primary)]`;
 }
 
 function isEmailLike(value: string): boolean {
@@ -280,10 +280,14 @@ function isNumericValue(value: string): boolean {
 function CsvEmptyState({ filePath }: { readonly filePath: string }) {
 	return (
 		<div className="flex h-full items-center justify-center px-6 py-8 text-center">
-			<div className="max-w-sm space-y-2 text-sm text-neutral-600">
-				<p className="font-medium text-neutral-800">No CSV rows to display.</p>
+			<div className="max-w-sm space-y-2 text-sm text-[var(--color-text-secondary)]">
+				<p className="font-medium text-[var(--color-text-primary)]">
+					No CSV rows to display.
+				</p>
 				<p>
-					<span className="font-mono text-xs text-neutral-700">{filePath}</span>{" "}
+					<span className="font-mono text-xs text-[var(--color-text-secondary)]">
+						{filePath}
+					</span>{" "}
 					is empty or does not contain a header row.
 				</p>
 			</div>

--- a/src/extensions/csv/style.css
+++ b/src/extensions/csv/style.css
@@ -33,11 +33,11 @@
 
 .csv-review-table th {
 	height: 2.5rem;
-	border-right: 1px solid #f1ece5;
-	border-bottom: 1px solid var(--color-island-divider);
-	background: var(--color-neutral-50);
+	border-right: 1px solid var(--color-border-table-grid);
+	border-bottom: 1px solid var(--color-border-subtle);
+	background: var(--color-bg-panel-muted);
 	padding: 0 1rem;
-	color: var(--color-neutral-600);
+	color: var(--color-text-secondary);
 	font-size: 11px;
 	font-weight: 700;
 	letter-spacing: 0.04em;
@@ -48,10 +48,10 @@
 .csv-review-table td {
 	min-width: 72px;
 	min-height: 3rem;
-	border-right: 1px solid #f4f1ec;
-	border-bottom: 1px solid #f4f1ec;
+	border-right: 1px solid var(--color-border-table-grid);
+	border-bottom: 1px solid var(--color-border-table-grid);
 	padding: 0.65rem 1rem;
-	color: var(--color-neutral-900);
+	color: var(--color-text-primary);
 	font-size: 13.5px;
 	font-weight: 400;
 	line-height: 1.35;
@@ -60,25 +60,18 @@
 }
 
 .csv-review-table [data-diff-status="added"] {
-	background-color: color-mix(in srgb, var(--color-green-500) 8%, transparent);
-	color: color-mix(
-		in srgb,
-		var(--color-green-700) 88%,
-		var(--color-neutral-900)
-	);
+	background-color: var(--color-bg-diff-added);
+	color: var(--color-text-diff-added);
 }
 
 .csv-review-table [data-diff-status="removed"] {
-	background-color: color-mix(in srgb, var(--color-red-500) 7%, transparent);
-	color: color-mix(in srgb, var(--color-red-700) 82%, var(--color-neutral-900));
+	background-color: var(--color-bg-diff-removed);
+	color: var(--color-text-diff-removed);
 	text-decoration: line-through;
-	text-decoration-color: color-mix(
-		in srgb,
-		var(--color-red-700) 68%,
-		transparent
-	);
+	text-decoration-color: var(--color-border-diff-removed);
 }
 
 .csv-review-table [data-diff-status="modified"] {
-	background-color: color-mix(in srgb, var(--color-amber-400) 9%, transparent);
+	background-color: var(--color-bg-diff-modified);
+	color: var(--color-text-diff-modified);
 }

--- a/src/extensions/files/file-tree.test.tsx
+++ b/src/extensions/files/file-tree.test.tsx
@@ -64,9 +64,13 @@ describe("FileTree", () => {
 		const fileRow = screen.getByRole("button", { name: /README.md/i });
 		const fileName = screen.getByText("README.md");
 
-		expect(fileRow).toHaveClass("focus-visible:ring-focus-ring");
+		expect(fileRow).toHaveClass(
+			"focus-visible:ring-[var(--color-ring-focus-visible)]",
+		);
 		expect(fileRow).toHaveClass("select-none");
-		expect(fileName).not.toHaveClass("focus-visible:ring-focus-ring");
+		expect(fileName).not.toHaveClass(
+			"focus-visible:ring-[var(--color-ring-focus-visible)]",
+		);
 	});
 
 	test("renders percent text literally instead of URI-decoding filenames", () => {
@@ -105,8 +109,10 @@ describe("FileTree", () => {
 			/>,
 		);
 		const selectedFile = screen.getByRole("button", { name: /README.md/i });
-		expect(selectedFile).toHaveClass("bg-focus-tint");
-		expect(selectedFile).toHaveClass("ring-focus-ring");
+		expect(selectedFile).toHaveClass("bg-[var(--color-bg-selection-current)]");
+		expect(selectedFile).toHaveClass(
+			"ring-[var(--color-border-selection-current)]",
+		);
 
 		rerender(
 			<FileTree
@@ -115,9 +121,13 @@ describe("FileTree", () => {
 				isPanelFocused={false}
 			/>,
 		);
-		expect(selectedFile).toHaveClass("bg-hover-soft");
-		expect(selectedFile).not.toHaveClass("bg-focus-tint");
-		expect(selectedFile).not.toHaveClass("ring-focus-ring");
+		expect(selectedFile).toHaveClass("bg-[var(--color-bg-hover)]");
+		expect(selectedFile).not.toHaveClass(
+			"bg-[var(--color-bg-selection-current)]",
+		);
+		expect(selectedFile).not.toHaveClass(
+			"ring-[var(--color-border-selection-current)]",
+		);
 	});
 });
 

--- a/src/extensions/files/file-tree.tsx
+++ b/src/extensions/files/file-tree.tsx
@@ -39,7 +39,7 @@ const sanitizeForTestId = (value: string): string =>
 		.replace(/(^-|-$)/g, "") || "root";
 
 const rowInteractionClass =
-	"select-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-focus-ring";
+	"select-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--color-ring-focus-visible)]";
 
 /**
  * Minimal prototype file tree that mirrors the structure of the left sidebar.
@@ -154,15 +154,15 @@ function FileTreeNode({
 	if (node.type === "file") {
 		const displayName = formatDisplayName(node.name);
 		const isSelected = selectedPath === node.path;
-		// Orange indicates the focused panel; inactive selections stay visible but quiet.
+		// Current selection is vivid only when the file panel owns keyboard input.
 		const buttonClass = clsx(
 			"flex h-7 w-full min-w-0 items-center gap-2 rounded-[7px] pr-2.25 text-left transition-[background-color,color,box-shadow] duration-100 ease-out [&_svg]:transition-colors [&_svg]:duration-100",
 			rowInteractionClass,
 			isSelected && isPanelFocused
-				? "bg-focus-tint text-neutral-900 ring-1 ring-inset ring-focus-ring [&_svg]:text-brand-700"
+				? "bg-[var(--color-bg-selection-current)] text-[var(--color-text-primary)] ring-1 ring-inset ring-[var(--color-border-selection-current)] [&_svg]:text-[var(--color-icon-selection-current)]"
 				: isSelected
-					? "bg-hover-soft text-neutral-700 [&_svg]:text-neutral-500"
-					: "text-neutral-600 hover:bg-hover-soft [&_svg]:text-neutral-400",
+					? "bg-[var(--color-bg-hover)] text-[var(--color-text-secondary)] [&_svg]:text-[var(--color-icon-secondary)]"
+					: "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] [&_svg]:text-[var(--color-icon-tertiary)]",
 		);
 		const itemTestId = `file-tree-item-${sanitizeForTestId(node.path)}`;
 		return (
@@ -196,12 +196,12 @@ function FileTreeNode({
 	// Open/closed icons carry directory state. Selection stays quiet:
 	// orange is reserved for the selected file row.
 	const buttonClass = clsx(
-		"flex h-7 w-full min-w-0 items-center gap-2 rounded-[7px] pr-2.25 text-left transition-colors hover:bg-hover-soft",
+		"flex h-7 w-full min-w-0 items-center gap-2 rounded-[7px] pr-2.25 text-left transition-colors hover:bg-[var(--color-bg-hover)]",
 		rowInteractionClass,
-		isSelected && "bg-hover-soft",
+		isSelected && "bg-[var(--color-bg-hover)]",
 		isOpen
-			? "font-normal text-neutral-700 [&_svg]:text-neutral-500"
-			: "text-neutral-600 [&_svg]:text-neutral-400",
+			? "font-normal text-[var(--color-text-secondary)] [&_svg]:text-[var(--color-icon-secondary)]"
+			: "text-[var(--color-text-secondary)] [&_svg]:text-[var(--color-icon-tertiary)]",
 	);
 
 	return (
@@ -269,11 +269,11 @@ function DraftRow({
 	const isFile = draft.kind === "file";
 	const Icon = isFile ? FileText : Folder;
 	const suffix = isFile ? (
-		<span className="shrink-0 text-neutral-400">.md</span>
+		<span className="shrink-0 text-[var(--color-icon-tertiary)]">.md</span>
 	) : null;
 	const ringClasses = isPanelFocused
-		? "ring-1 ring-inset ring-focus-ring bg-focus-tint"
-		: "ring-1 ring-inset ring-island-border";
+		? "ring-1 ring-inset ring-[var(--color-border-selection-current)] bg-[var(--color-bg-selection-current)]"
+		: "ring-1 ring-inset ring-[var(--color-border-panel)]";
 
 	useEffect(() => {
 		setValue(draft.value);
@@ -311,12 +311,12 @@ function DraftRow({
 			<div
 				ref={rowRef}
 				className={clsx(
-					"flex h-7 items-center gap-2 rounded-[7px] pr-2.25 text-left text-xs text-neutral-900",
+					"flex h-7 items-center gap-2 rounded-[7px] pr-2.25 text-left text-xs text-[var(--color-text-primary)]",
 					ringClasses,
 				)}
 				style={rowIndentStyle(depth)}
 			>
-				<Icon className="size-3.25 shrink-0 text-neutral-400" />
+				<Icon className="size-3.25 shrink-0 text-[var(--color-icon-tertiary)]" />
 				<input
 					ref={inputRef}
 					data-testid="files-view-draft-input"

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -465,19 +465,24 @@ export function FilesView({ context }: FilesViewProps) {
 				<button
 					type="button"
 					onClick={handleNewFile}
-					className="mb-px flex h-7 w-full select-none items-center justify-between gap-2 rounded-[7px] px-2.25 text-left text-xs text-neutral-600 transition-colors hover:bg-hover-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600"
+					className="mb-px flex h-7 w-full select-none items-center justify-between gap-2 rounded-[7px] px-2.25 text-left text-xs text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)]"
 					aria-label="New file"
 					title="New file (⌘.)"
 				>
 					<span className="flex items-center gap-2">
-						<FilePlus className="size-3.25 text-neutral-400" strokeWidth={2} />
+						<FilePlus
+							className="size-3.25 text-[var(--color-icon-tertiary)]"
+							strokeWidth={2}
+						/>
 						<span>New file</span>
 					</span>
-					<span className="text-[10px] font-semibold text-ink-faint">⌘ ·</span>
+					<span className="text-[10px] font-semibold text-[var(--color-icon-tertiary)]">
+						⌘ ·
+					</span>
 				</button>
 			)}
 			{isDraggingOver && (
-				<div className="absolute inset-1 z-50 flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-amber-400 bg-amber-50/50 backdrop-blur-sm pointer-events-none">
+				<div className="absolute inset-1 z-50 flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-[var(--color-border-notice-warning)] bg-[color-mix(in_srgb,var(--color-bg-notice-warning)_50%,transparent)] backdrop-blur-sm pointer-events-none">
 					<FileUp className="h-12 w-12 text-foreground" />
 					<p className="mt-3 text-center text-sm font-medium text-foreground">
 						Drop markdown files here

--- a/src/extensions/markdown/components/formatting-toolbar.tsx
+++ b/src/extensions/markdown/components/formatting-toolbar.tsx
@@ -40,14 +40,14 @@ type FormatState = {
 
 /** 28px square icon button, matching the panel-header chips in the islands UI. */
 const iconButtonClass =
-	"inline-flex size-7 shrink-0 select-none items-center justify-center rounded-[7px] text-neutral-500 transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-hover-soft hover:text-neutral-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring disabled:cursor-not-allowed disabled:opacity-40 [&_svg]:stroke-[1.9]";
+	"inline-flex size-7 shrink-0 select-none items-center justify-center rounded-[7px] text-[var(--color-text-tertiary)] transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)] disabled:cursor-not-allowed disabled:opacity-40 [&_svg]:stroke-[1.9]";
 
 /** Pressed state for a formatting toggle. */
 const iconButtonActiveClass =
-	"bg-secondary-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-secondary-ring)] [&_svg]:text-secondary-icon";
+	"bg-[var(--color-bg-control-selected)] text-[var(--color-text-primary)] [&_svg]:text-[var(--color-icon-control-selected)]";
 
 const ToolbarSeparator = () => (
-	<Toolbar.Separator className="mx-1.5 h-3.5 w-px bg-island-divider" />
+	<Toolbar.Separator className="mx-1.5 h-3.5 w-px bg-[var(--color-border-subtle)]" />
 );
 
 const initialFormatState: FormatState = {
@@ -225,7 +225,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 	return (
 		<Toolbar.Root
 			className={clsx(
-				"flex h-10 w-full shrink-0 items-center gap-0.5 border-b border-island-divider bg-neutral-0 px-2 text-foreground",
+				"flex h-10 w-full shrink-0 items-center gap-0.5 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-panel)] px-2 text-foreground",
 				className,
 			)}
 			aria-label="Formatting toolbar"
@@ -241,16 +241,16 @@ export function FormattingToolbar({ className }: { className?: string }) {
 						render={<Select.Trigger />}
 						nativeButton={false}
 						className={clsx(
-							"inline-flex h-7 shrink-0 select-none items-center gap-1 rounded-[7px] pr-1.5 pl-2.25 text-[12.5px] font-medium text-neutral-700 transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-hover-soft hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring",
+							"inline-flex h-7 shrink-0 select-none items-center gap-1 rounded-[7px] pr-1.5 pl-2.25 text-[12.5px] font-medium text-[var(--color-text-secondary)] transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)]",
 							blockMenuOpen &&
-								"bg-secondary-tint text-neutral-900 shadow-[inset_0_0_0_1px_var(--color-secondary-ring)]",
+								"bg-[var(--color-bg-control-selected)] text-[var(--color-text-primary)]",
 						)}
 						onMouseDown={suppressMouseDown}
 					>
 						<Select.Value className="block w-[4.25rem] truncate">
 							{activeBlockLabel}
 						</Select.Value>
-						<Select.Icon className="text-neutral-400 transition-transform duration-100 data-[popup-open]:rotate-180">
+						<Select.Icon className="text-[var(--color-icon-tertiary)] transition-transform duration-100 data-[popup-open]:rotate-180">
 							<ChevronDown className="size-[13px] stroke-[2]" aria-hidden />
 						</Select.Icon>
 					</Toolbar.Button>
@@ -262,28 +262,28 @@ export function FormattingToolbar({ className }: { className?: string }) {
 							sideOffset={6}
 							alignItemWithTrigger={false}
 						>
-							<Select.Popup className="min-w-[10.75rem] origin-[var(--transform-origin)] rounded-[8px] border border-island-border bg-neutral-0 p-1 shadow-lg transition-[transform,opacity] duration-150 data-[side=bottom]:mt-2 data-[side=top]:mb-2 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-100 data-[ending-style]:opacity-100">
-								<div className="px-2 pb-0.75 pt-1 text-[11px] font-medium leading-4 text-neutral-400">
+							<Select.Popup className="min-w-[10.75rem] origin-[var(--transform-origin)] rounded-[8px] border border-[var(--color-border-panel)] bg-[var(--color-bg-panel)] p-1 shadow-lg transition-[transform,opacity] duration-150 data-[side=bottom]:mt-2 data-[side=top]:mb-2 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-100 data-[ending-style]:opacity-100">
+								<div className="px-2 pb-0.75 pt-1 text-[11px] font-medium leading-4 text-[var(--color-icon-tertiary)]">
 									Turn into
 								</div>
 								{TOOLBAR_BLOCK_OPTIONS.map((option) => (
 									<Select.Item
 										key={option.value}
 										value={option.value}
-										className="group flex min-h-9 cursor-default items-center gap-2 rounded-[7px] px-2 py-1 text-[12.5px] outline-none focus-visible:ring-0 data-[highlighted]:bg-hover-soft data-[highlighted]:text-neutral-900"
+										className="group flex min-h-9 cursor-default items-center gap-2 rounded-[7px] px-2 py-1 text-[12.5px] outline-none focus-visible:ring-0 data-[highlighted]:bg-[var(--color-bg-hover)] data-[highlighted]:text-[var(--color-text-primary)]"
 									>
-										<span className="flex size-4.5 items-center justify-center text-[12px] text-neutral-400 group-data-[highlighted]:text-neutral-600 [&_svg]:stroke-[1.8]">
+										<span className="flex size-4.5 items-center justify-center text-[12px] text-[var(--color-icon-tertiary)] group-data-[highlighted]:text-[var(--color-text-secondary)] [&_svg]:stroke-[1.8]">
 											<option.icon className="h-3.5 w-3.5" aria-hidden />
 										</span>
 										<div className="flex flex-1 flex-col">
-											<span className="text-[12.5px] font-semibold leading-4 text-neutral-800">
+											<span className="text-[12.5px] font-semibold leading-4 text-[var(--color-text-primary)]">
 												{option.label}
 											</span>
-											<span className="text-[11.5px] font-normal leading-4 text-neutral-500">
+											<span className="text-[11.5px] font-normal leading-4 text-[var(--color-text-tertiary)]">
 												{option.description}
 											</span>
 										</div>
-										<Select.ItemIndicator className="text-brand-700">
+										<Select.ItemIndicator className="text-[var(--color-text-link-hover)]">
 											<Check className="h-3.5 w-3.5 stroke-[2]" aria-hidden />
 										</Select.ItemIndicator>
 									</Select.Item>
@@ -383,7 +383,8 @@ export function FormattingToolbar({ className }: { className?: string }) {
 							className={clsx(
 								iconButtonClass,
 								"ml-auto",
-								copyStatus === "error" && "text-error-600",
+								copyStatus === "error" &&
+									"text-[var(--color-text-status-danger)]",
 							)}
 							onClick={handleCopyMarkdown}
 							onMouseDown={suppressMouseDown}
@@ -403,7 +404,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 								/>
 								<Check
 									className={clsx(
-										"absolute size-3.5 text-success-600 transition-all duration-150",
+										"absolute size-3.5 text-[var(--color-text-status-success)] transition-all duration-150",
 										copyStatus === "success"
 											? "scale-100 opacity-100"
 											: "scale-75 opacity-0",
@@ -416,7 +417,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 				/>
 				<Tooltip.Portal>
 					<Tooltip.Positioner side="top" align="center" sideOffset={6}>
-						<Tooltip.Popup className="rounded-md border border-border bg-popover px-2 py-1 text-xs text-foreground shadow-md transition-opacity duration-150 data-[state=closed]:opacity-0 data-[state=open]:opacity-100">
+						<Tooltip.Popup className="rounded-md border border-[var(--color-border-panel)] bg-[var(--color-bg-panel)] px-2 py-1 text-xs text-[var(--color-text-primary)] shadow-md transition-opacity duration-150 data-[state=closed]:opacity-0 data-[state=open]:opacity-100">
 							{copyStatus === "success" ? "Copied Markdown" : "Copy Markdown"}
 						</Tooltip.Popup>
 					</Tooltip.Positioner>

--- a/src/extensions/markdown/components/slash-command-menu.tsx
+++ b/src/extensions/markdown/components/slash-command-menu.tsx
@@ -226,7 +226,7 @@ export function SlashCommandMenu() {
 	return createPortal(
 		<div
 			ref={menuRef}
-			className="bg-popover text-popover-foreground border rounded-md shadow-md z-50 p-1 min-w-[180px] max-h-80 overflow-y-auto"
+			className="z-50 max-h-80 min-w-[180px] overflow-y-auto rounded-md border border-[var(--color-border-panel)] bg-[var(--color-bg-panel)] p-1 text-[var(--color-text-primary)] shadow-md"
 			style={{
 				position: "fixed",
 				top: position.top,
@@ -239,7 +239,7 @@ export function SlashCommandMenu() {
 				<div
 					key={command.id}
 					data-index={index}
-					className="flex items-center gap-2 px-2 py-1.5 rounded-sm text-sm cursor-pointer select-none hover:bg-accent hover:text-accent-foreground data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground"
+					className="flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] data-[selected=true]:bg-[var(--color-bg-hover)] data-[selected=true]:text-[var(--color-text-primary)]"
 					data-selected={index === selectedIndex}
 					role="option"
 					aria-selected={index === selectedIndex}
@@ -254,7 +254,7 @@ export function SlashCommandMenu() {
 					tabIndex={0}
 				>
 					<command.icon
-						className="size-4 shrink-0 text-muted-foreground"
+						className="size-4 shrink-0 text-[var(--color-icon-secondary)]"
 						aria-hidden
 					/>
 					<span>{command.label}</span>

--- a/src/extensions/markdown/index.test.tsx
+++ b/src/extensions/markdown/index.test.tsx
@@ -66,6 +66,58 @@ describe("MarkdownView", () => {
 		});
 	});
 
+	test("shows an autosave hint when pressing Cmd+S", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_autosave_hint",
+				path: "/docs/autosave.md",
+				data: new TextEncoder().encode("# Autosave"),
+			})
+			.execute();
+
+		let utils: ReturnType<typeof render> | undefined;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
+						<Suspense fallback={null}>
+							<MarkdownView
+								fileId="file_autosave_hint"
+								filePath="/docs/autosave.md"
+								isActiveView
+								isPanelFocused
+								syncActiveFile={false}
+							/>
+						</Suspense>
+					</KeyValueProvider>
+				</LixProvider>,
+			);
+		});
+
+		expect(await screen.findByTestId("tiptap-editor")).toBeInTheDocument();
+
+		const event = new KeyboardEvent("keydown", {
+			key: "s",
+			metaKey: true,
+			bubbles: true,
+			cancelable: true,
+		});
+		await act(async () => {
+			window.dispatchEvent(event);
+		});
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(await screen.findByRole("status")).toHaveTextContent(
+			/auto-saved.*no cmd\+s needed/i,
+		);
+
+		await act(async () => {
+			utils?.unmount();
+		});
+	});
+
 	test("renders the TipTap editor for .markdown files", async () => {
 		const lix = await openLix();
 		await qb(lix)

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect } from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { ExternalLink, FileText, Github, Loader2 } from "lucide-react";
+import { Check, ExternalLink, FileText, Github, Loader2 } from "lucide-react";
 import {
 	LixProvider,
 	useLix,
@@ -117,7 +117,7 @@ function MarkdownViewContent({
 
 	if (!fileRow) {
 		content = (
-			<div className="flex h-full items-center justify-center text-sm text-neutral-500">
+			<div className="flex h-full items-center justify-center text-sm text-[var(--color-text-tertiary)]">
 				File not found in the workspace.
 			</div>
 		);
@@ -140,6 +140,9 @@ function MarkdownViewContent({
 							fileId={fileRow.id}
 							isActiveView={isActiveView}
 							focusOnLoad={focusOnLoad}
+						/>
+						<MarkdownAutosaveHint
+							enabled={isActiveView && isPanelFocused && !reviewDiff}
 						/>
 						{reviewDiff && externalWriteReview ? (
 							<Suspense fallback={<MarkdownReviewOverlayFallback />}>
@@ -168,6 +171,56 @@ function MarkdownViewContent({
 				<ActiveFileSync fileId={fileRow?.id} isActiveView={isActiveView} />
 			) : null}
 			{content}
+		</div>
+	);
+}
+
+function MarkdownAutosaveHint({ enabled }: { readonly enabled: boolean }) {
+	const [hintKey, setHintKey] = useState(0);
+
+	useEffect(() => {
+		if (enabled) return;
+		setHintKey(0);
+	}, [enabled]);
+
+	useEffect(() => {
+		if (!enabled) return;
+		const handleKeyDown = (event: KeyboardEvent) => {
+			const usesPrimaryModifier = event.metaKey || event.ctrlKey;
+			if (!usesPrimaryModifier || event.altKey || event.shiftKey) return;
+			if (event.key.toLowerCase() !== "s") return;
+			event.preventDefault();
+			event.stopPropagation();
+			setHintKey((current) => current + 1);
+		};
+		window.addEventListener("keydown", handleKeyDown, { capture: true });
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown, { capture: true });
+		};
+	}, [enabled]);
+
+	useEffect(() => {
+		if (hintKey === 0) return;
+		const timeoutId = window.setTimeout(() => setHintKey(0), 2400);
+		return () => window.clearTimeout(timeoutId);
+	}, [hintKey]);
+
+	if (hintKey === 0) return null;
+
+	return (
+		<div
+			key={hintKey}
+			className="markdown-autosave-hint"
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+		>
+			<span className="markdown-autosave-hint-icon" aria-hidden="true">
+				<Check aria-hidden />
+			</span>
+			<span>
+				<strong>Auto-saved.</strong> No Cmd+S needed.
+			</span>
 		</div>
 	);
 }
@@ -353,13 +406,15 @@ function UnsupportedFilePlaceholder({
 }): ReactNode {
 	return (
 		<div className="flex h-full items-center justify-center px-6 py-8 text-center">
-			<div className="max-w-sm space-y-2 text-sm text-neutral-600">
-				<p className="font-medium text-neutral-800">
+			<div className="max-w-sm space-y-2 text-sm text-[var(--color-text-secondary)]">
+				<p className="font-medium text-[var(--color-text-primary)]">
 					This file type is not supported yet.
 				</p>
 				<p>
 					Flashtype only opens markdown files in this editor, so{" "}
-					<span className="font-mono text-xs text-neutral-700">{filePath}</span>{" "}
+					<span className="font-mono text-xs text-[var(--color-text-secondary)]">
+						{filePath}
+					</span>{" "}
 					was left blank to avoid damaging its formatting.
 				</p>
 				<p>
@@ -367,7 +422,7 @@ function UnsupportedFilePlaceholder({
 						href="https://github.com/opral/flashtype/issues"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="inline-flex items-center gap-1 font-medium text-brand-600 underline underline-offset-2 hover:text-brand-700"
+						className="inline-flex items-center gap-1 font-medium text-[var(--color-icon-brand)] underline underline-offset-2 hover:text-[var(--color-text-link-hover)]"
 					>
 						<Github className="size-3.5" aria-hidden="true" />
 						Open an issue on GitHub

--- a/src/extensions/markdown/style.css
+++ b/src/extensions/markdown/style.css
@@ -56,6 +56,59 @@
 	transition-timing-function: ease-out;
 }
 
+.markdown-autosave-hint {
+	position: absolute;
+	right: 1rem;
+	top: 1rem;
+	z-index: 20;
+	display: inline-flex;
+	max-width: min(24rem, calc(100% - 2rem));
+	align-items: center;
+	gap: 0.375rem;
+	border: 0;
+	border-radius: 7px;
+	background: var(--color-bg-notice-neutral);
+	box-shadow: inset 0 0 0 1px var(--color-border-notice-neutral);
+	color: var(--color-text-notice-neutral);
+	font-size: 0.75rem;
+	font-weight: 600;
+	height: 1.75rem;
+	line-height: 1rem;
+	padding: 0 0.5625rem;
+	pointer-events: none;
+	transform: translateY(0);
+	animation: markdown-autosave-hint-in 160ms ease-out;
+}
+
+.markdown-autosave-hint strong {
+	font-weight: 600;
+}
+
+.markdown-autosave-hint-icon {
+	display: inline-flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	color: var(--color-icon-notice-neutral);
+}
+
+.markdown-autosave-hint-icon svg {
+	width: 0.8125rem;
+	height: 0.8125rem;
+	stroke-width: 2;
+}
+
+@keyframes markdown-autosave-hint-in {
+	from {
+		opacity: 0;
+		transform: translateY(0.35rem);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
 .markdown-view .tiptap {
 	/* Exactly fill the viewport (border-box includes padding-bottom) so a short
 	   document does not force a scrollbar; longer content overflows normally. */
@@ -65,21 +118,21 @@
 
 .markdown-view .ProseMirror {
 	box-sizing: border-box;
-	color: var(--color-neutral-800);
+	color: var(--color-text-primary);
 	font-family:
 		-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
 	font-size: 14.5px;
 	line-height: 1.7;
 	min-height: 100%;
 	padding: 0 max(2rem, calc((100% - 760px) / 2)) 4rem;
-	caret-color: var(--color-brand-700);
+	caret-color: var(--color-ring-focus-visible);
 	cursor: auto;
 	width: 100%;
 }
 
 /* Headings */
 .markdown-view .ProseMirror h1 {
-	color: var(--color-neutral-900);
+	color: var(--color-text-primary);
 	font-size: 27px;
 	font-weight: 700;
 	letter-spacing: -0.02em;
@@ -89,7 +142,7 @@
 }
 
 .markdown-view .ProseMirror h2 {
-	color: var(--color-neutral-900);
+	color: var(--color-text-primary);
 	font-size: 22px;
 	font-weight: 700;
 	letter-spacing: -0.015em;
@@ -99,7 +152,7 @@
 }
 
 .markdown-view .ProseMirror h3 {
-	color: var(--color-neutral-900);
+	color: var(--color-text-primary);
 	font-size: 18px;
 	font-weight: 700;
 	line-height: 1.35;
@@ -108,7 +161,7 @@
 }
 
 .markdown-view .ProseMirror h4 {
-	color: var(--color-neutral-900);
+	color: var(--color-text-primary);
 	font-size: 16px;
 	font-weight: 700;
 	margin-top: 1.25rem;
@@ -123,7 +176,7 @@
 
 /* Links */
 .markdown-view .ProseMirror a {
-	color: var(--color-brand-700);
+	color: var(--color-text-link);
 	text-decoration: underline;
 	text-decoration-thickness: 1px;
 	text-underline-offset: 2px;
@@ -131,7 +184,7 @@
 }
 
 .markdown-view .ProseMirror a:hover {
-	color: var(--color-brand-800);
+	color: var(--color-text-link-hover);
 }
 
 /* Lists */
@@ -252,9 +305,9 @@
 	height: 0.875rem;
 	margin: calc((1.7em - 0.875rem) / 2) 0 0;
 	justify-self: center;
-	border: 1.5px solid var(--color-neutral-400);
+	border: 1.5px solid var(--color-icon-tertiary);
 	border-radius: 4px;
-	background-color: var(--color-neutral-0);
+	background-color: var(--color-bg-panel);
 	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 	transition:
 		background-color 120ms ease,
@@ -263,8 +316,8 @@
 }
 
 .markdown-view .ProseMirror li[data-task] > input[type="checkbox"]:checked {
-	border-color: var(--color-brand-600);
-	background-color: var(--color-brand-600);
+	border-color: var(--color-bg-action-primary);
+	background-color: var(--color-bg-action-primary);
 	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 6.2 5 8.1 9 3.8' fill='none' stroke='white' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 	background-position: center;
 	background-repeat: no-repeat;
@@ -308,33 +361,26 @@
 }
 
 .markdown-review .ProseMirror [data-diff-status="added"] {
-	background-color: color-mix(in srgb, var(--color-green-500) 8%, transparent);
+	background-color: var(--color-bg-diff-added);
 	box-decoration-break: clone;
 	-webkit-box-decoration-break: clone;
 	border-radius: 0.25rem;
-	color: color-mix(
-		in srgb,
-		var(--color-green-700) 88%,
-		var(--color-neutral-900)
-	);
+	color: var(--color-text-diff-added);
 	text-decoration: none;
 }
 
 .markdown-review .ProseMirror [data-diff-status="removed"] {
-	background-color: color-mix(in srgb, var(--color-red-500) 7%, transparent);
+	background-color: var(--color-bg-diff-removed);
 	box-decoration-break: clone;
 	-webkit-box-decoration-break: clone;
 	border-radius: 0.25rem;
-	color: color-mix(in srgb, var(--color-red-700) 82%, var(--color-neutral-900));
+	color: var(--color-text-diff-removed);
 	text-decoration: line-through;
-	text-decoration-color: color-mix(
-		in srgb,
-		var(--color-red-700) 68%,
-		transparent
-	);
+	text-decoration-color: var(--color-border-diff-removed);
 }
 
 .markdown-review .ProseMirror [data-diff-status="modified"] {
-	background-color: color-mix(in srgb, var(--color-amber-400) 9%, transparent);
+	background-color: var(--color-bg-diff-modified);
 	border-radius: 0.25rem;
+	color: var(--color-text-diff-modified);
 }

--- a/src/extensions/terminal/index.tsx
+++ b/src/extensions/terminal/index.tsx
@@ -9,32 +9,40 @@ import { createTerminalOutputNormalizer } from "./ansi-style-normalizer";
 
 const TERMINAL_INITIAL_COMMAND_LAUNCH_ARG = "initialCommand";
 
-const XTERM_THEMES = {
-	light: {
-		background: "#ffffff",
-		foreground: "#1c1917",
-		cursor: "#1c1917",
-		selectionBackground: "#e8ded2",
-		selectionInactiveBackground: "#f4f1ec",
-		black: "#f4f1ec",
-		red: "#d6d3d1",
-		green: "#d6d3d1",
-		yellow: "#b7791f",
-		blue: "#78716c",
-		magenta: "#78716c",
+function cssColor(name: string, fallback: string): string {
+	if (typeof window === "undefined") return fallback;
+	const value = window
+		.getComputedStyle(document.documentElement)
+		.getPropertyValue(name)
+		.trim();
+	return value || fallback;
+}
+
+function buildTerminalTheme() {
+	return {
+		background: cssColor("--color-bg-panel", "#ffffff"),
+		foreground: cssColor("--color-text-primary", "#1c1917"),
+		cursor: cssColor("--color-text-primary", "#1c1917"),
+		selectionBackground: cssColor("--color-bg-selection-current", "#fbefe4"),
+		selectionInactiveBackground: cssColor("--color-bg-hover", "#f5f2ed"),
+		black: cssColor("--color-bg-hover", "#f5f2ed"),
+		red: cssColor("--color-error-700", "#b91c1c"),
+		green: cssColor("--color-success-700", "#15803d"),
+		yellow: cssColor("--color-warning-800", "#854d0e"),
+		blue: cssColor("--color-text-secondary", "#44403c"),
+		magenta: cssColor("--color-text-secondary", "#44403c"),
 		cyan: "#0e7490",
-		white: "#292524",
-		brightBlack: "#a8a29e",
-		brightRed: "#a8a29e",
-		brightGreen: "#a8a29e",
-		brightYellow: "#b45309",
-		brightBlue: "#57534e",
-		brightMagenta: "#57534e",
+		white: cssColor("--color-neutral-800", "#292524"),
+		brightBlack: cssColor("--color-icon-tertiary", "#78716c"),
+		brightRed: cssColor("--color-error-600", "#dc2626"),
+		brightGreen: cssColor("--color-success-600", "#16a34a"),
+		brightYellow: cssColor("--color-warning-700", "#a16207"),
+		brightBlue: cssColor("--color-icon-secondary", "#57534e"),
+		brightMagenta: cssColor("--color-icon-secondary", "#57534e"),
 		brightCyan: "#0891b2",
-		brightWhite: "#1c1917",
-	},
-} as const;
-const XTERM_THEME = XTERM_THEMES.light;
+		brightWhite: cssColor("--color-text-primary", "#1c1917"),
+	};
+}
 
 function TerminalView({
 	initialCommand,
@@ -65,7 +73,7 @@ function TerminalView({
 			scrollback: 3000,
 			minimumContrastRatio: 4.5,
 			allowTransparency: false,
-			theme: XTERM_THEME,
+			theme: buildTerminalTheme(),
 		});
 		terminalRef.current = terminal;
 		const fitAddon = new FitAddon();
@@ -156,7 +164,7 @@ function TerminalView({
 
 	if (!window.flashtypeDesktop?.terminal) {
 		return (
-			<div className="flex h-full min-h-0 items-center justify-center px-4 text-sm text-neutral-600">
+			<div className="flex h-full min-h-0 items-center justify-center px-4 text-sm text-[var(--color-text-secondary)]">
 				Terminal is only available in the desktop app.
 			</div>
 		);
@@ -165,7 +173,7 @@ function TerminalView({
 	return (
 		<div
 			className="h-full min-h-0"
-			style={{ backgroundColor: XTERM_THEME.background }}
+			style={{ backgroundColor: cssColor("--color-bg-panel", "#ffffff") }}
 		>
 			<div ref={containerRef} className="h-full w-full p-2" />
 		</div>

--- a/src/index.css
+++ b/src/index.css
@@ -81,41 +81,41 @@
 :root {
 	--radius: 0.625rem;
 
-	--background: oklch(1 0 0);
+	--background: var(--color-bg-panel);
 
-	--foreground: oklch(0.145 0 0);
+	--foreground: var(--color-text-primary);
 
-	--card: oklch(1 0 0);
+	--card: var(--color-bg-panel);
 
-	--card-foreground: oklch(0.145 0 0);
+	--card-foreground: var(--color-text-primary);
 
-	--popover: oklch(1 0 0);
+	--popover: var(--color-bg-panel);
 
-	--popover-foreground: oklch(0.145 0 0);
+	--popover-foreground: var(--color-text-primary);
 
-	--primary: oklch(0.77 0.18 85);
+	--primary: var(--color-bg-action-primary);
 
-	--primary-foreground: oklch(0.985 0 0);
+	--primary-foreground: var(--color-text-on-action-primary);
 
-	--secondary: oklch(0.97 0 0);
+	--secondary: var(--color-bg-notice-neutral);
 
-	--secondary-foreground: oklch(0.205 0 0);
+	--secondary-foreground: var(--color-text-notice-neutral);
 
-	--muted: oklch(0.97 0 0);
+	--muted: var(--color-bg-panel-muted);
 
-	--muted-foreground: oklch(0.556 0 0);
+	--muted-foreground: var(--color-text-secondary);
 
-	--accent: oklch(0.97 0 0);
+	--accent: var(--color-bg-hover);
 
-	--accent-foreground: oklch(0.205 0 0);
+	--accent-foreground: var(--color-text-primary);
 
-	--destructive: oklch(0.577 0.245 27.325);
+	--destructive: var(--color-error-700);
 
-	--border: oklch(0.922 0 0);
+	--border: var(--color-border-subtle);
 
-	--input: oklch(0.922 0 0);
+	--input: var(--color-border-subtle);
 
-	--ring: oklch(0.77 0.18 85);
+	--ring: var(--color-ring-focus-visible);
 
 	--chart-1: oklch(0.646 0.222 41.116);
 
@@ -127,38 +127,38 @@
 
 	--chart-5: oklch(0.769 0.188 70.08);
 
-	--sidebar: oklch(0.985 0 0);
+	--sidebar: var(--color-bg-panel);
 
-	--sidebar-foreground: oklch(0.145 0 0);
+	--sidebar-foreground: var(--color-text-primary);
 
-	--sidebar-primary: oklch(0.205 0 0);
+	--sidebar-primary: var(--color-bg-action-primary);
 
-	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-primary-foreground: var(--color-text-on-action-primary);
 
-	--sidebar-accent: oklch(0.97 0 0);
+	--sidebar-accent: var(--color-bg-hover);
 
-	--sidebar-accent-foreground: oklch(0.205 0 0);
+	--sidebar-accent-foreground: var(--color-text-primary);
 
-	--sidebar-border: oklch(0.922 0 0);
+	--sidebar-border: var(--color-border-subtle);
 
-	--sidebar-ring: oklch(0.708 0 0);
+	--sidebar-ring: var(--color-ring-focus-visible);
 }
 
 /* Diff rendering helpers */
 .lix-diff-content [data-diff-status="added"] {
-	color: #1f883d;
+	color: var(--color-text-diff-added);
 	text-decoration: none;
 	outline: none;
 }
 
 .lix-diff-content [data-diff-status="modified"] {
-	color: #f59e0b;
+	color: var(--color-text-diff-modified);
 	text-decoration: none;
 	outline: none;
 }
 
 .lix-diff-content [data-diff-status="removed"] {
-	color: #d1242f;
+	color: var(--color-text-diff-removed);
 	text-decoration: line-through;
 	text-decoration-color: currentColor;
 }
@@ -171,18 +171,18 @@
 }
 
 .lix-diff-content input[data-diff-status="added"] {
-	outline: 2px solid #1f883d;
+	outline: 2px solid var(--color-border-diff-added);
 	outline-offset: 2px;
 }
 
 .lix-diff-content input[data-diff-status="removed"] {
-	outline: 2px solid #d1242f;
+	outline: 2px solid var(--color-border-diff-removed);
 	outline-offset: 2px;
 	opacity: 0.6;
 }
 
 .lix-diff-content input[data-diff-status="modified"] {
-	outline: 2px solid #f59e0b;
+	outline: 2px solid var(--color-border-diff-modified);
 	outline-offset: 2px;
 }
 

--- a/src/main.error.tsx
+++ b/src/main.error.tsx
@@ -88,7 +88,7 @@ export function ErrorFallback(props: { error: unknown }) {
 		return (
 			<div className="min-h-dvh w-full flex items-center justify-center p-6">
 				<div className="max-w-lg w-full border rounded-lg p-6 bg-card text-card-foreground">
-					<div className="flex items-center gap-2 text-amber-600 mb-3">
+					<div className="flex items-center gap-2 text-[var(--color-text-notice-warning)] mb-3">
 						<AlertTriangle className="h-5 w-5" />
 						<h1 className="text-lg font-semibold">Flashtype is already open</h1>
 					</div>
@@ -139,7 +139,7 @@ export function ErrorFallback(props: { error: unknown }) {
 						<button
 							onClick={handleReset}
 							disabled={busy}
-							className="inline-flex items-center gap-2 rounded-md bg-red-600 px-3 py-2 text-white text-sm disabled:opacity-60"
+							className="inline-flex items-center gap-2 rounded-md bg-destructive px-3 py-2 text-[var(--color-text-on-action-primary)] text-sm disabled:opacity-60"
 						>
 							<Trash2 className="h-4 w-4" />
 							{busyAction === "reset" ? "Resetting..." : "Reset Lix repository"}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -205,7 +205,7 @@ export const AppRoot = () => {
 };
 
 function BootPlaceholder() {
-	return <div className="h-dvh w-full bg-shell" />;
+	return <div className="h-dvh w-full bg-[var(--color-bg-app)]" />;
 }
 
 createRoot(document.getElementById("root")!).render(

--- a/src/shell/agent-invite.tsx
+++ b/src/shell/agent-invite.tsx
@@ -26,10 +26,10 @@ export function AgentInvite({
 				/>
 				<img src={codexIcon} alt="Codex" className="size-8 object-contain" />
 			</div>
-			<div className="text-[14.5px] font-bold text-neutral-900">
+			<div className="text-[14.5px] font-bold text-[var(--color-text-primary)]">
 				Your agent writes here
 			</div>
-			<p className="max-w-55 text-[12.5px] leading-relaxed text-ink-muted text-pretty">
+			<p className="max-w-55 text-[12.5px] leading-relaxed text-[var(--color-text-secondary)] text-pretty">
 				Claude Code or Codex edits your files directly — every change is a diff
 				you approve.
 			</p>
@@ -38,7 +38,7 @@ export function AgentInvite({
 					<button
 						type="button"
 						onClick={onStartClaude}
-						className="flex items-center gap-1.75 rounded-lg bg-neutral-900 px-4.5 py-2.25 text-[12.5px] font-bold text-neutral-0 hover:bg-neutral-800"
+						className="flex items-center gap-1.75 rounded-lg bg-[var(--color-bg-action-secondary)] px-4.5 py-2.25 text-[12.5px] font-bold text-[var(--color-text-on-action-secondary)] hover:bg-[var(--color-bg-action-secondary-hover)]"
 					>
 						<img src={claudeIcon} alt="" className="size-3.25 object-contain" />
 						Start Claude Code
@@ -47,7 +47,7 @@ export function AgentInvite({
 						<button
 							type="button"
 							onClick={onStartCodex}
-							className="rounded-md px-1.5 py-0.5 text-[11.5px] text-neutral-400 hover:text-neutral-600"
+							className="rounded-md px-1.5 py-0.5 text-[11.5px] text-[var(--color-icon-tertiary)] hover:text-[var(--color-text-secondary)]"
 						>
 							Use Codex instead
 						</button>

--- a/src/shell/central-panel.tsx
+++ b/src/shell/central-panel.tsx
@@ -98,11 +98,14 @@ function EmptyStateContent({
 			className="flex h-full flex-col items-center justify-center p-10 text-center"
 			data-testid="central-panel-empty-state"
 		>
-			<FilePlus className="size-8 text-ink-faint" strokeWidth={1.5} />
-			<h1 className="mt-4 text-2xl font-bold tracking-[-0.02em] text-neutral-900">
+			<FilePlus
+				className="size-8 text-[var(--color-icon-tertiary)]"
+				strokeWidth={1.5}
+			/>
+			<h1 className="mt-4 text-2xl font-bold tracking-[-0.02em] text-[var(--color-text-primary)]">
 				Start writing
 			</h1>
-			<p className="mt-1.5 max-w-90 text-sm leading-relaxed text-ink-muted text-pretty">
+			<p className="mt-1.5 max-w-90 text-sm leading-relaxed text-[var(--color-text-secondary)] text-pretty">
 				Open a file from the left, or create a new document — saved as plain
 				markdown in this folder.
 			</p>
@@ -110,7 +113,7 @@ function EmptyStateContent({
 				<button
 					type="button"
 					onClick={() => void onCreateNewFile()}
-					className="mt-6 flex items-center gap-2 rounded-[10px] bg-linear-to-b from-brand-500 to-brand-600 px-6 py-2.75 text-sm font-bold text-neutral-0 shadow-[0_6px_18px_rgba(232,89,12,0.32),inset_0_1px_0_rgba(255,255,255,0.25)] hover:brightness-[1.06]"
+					className="mt-6 flex items-center gap-2 rounded-[10px] bg-[var(--color-bg-action-primary)] px-6 py-2.75 text-sm font-bold text-[var(--color-text-on-action-primary)] shadow-[0_6px_18px_rgba(154,52,18,0.24),inset_0_1px_0_rgba(255,255,255,0.18)] hover:bg-[var(--color-bg-action-primary-hover)]"
 				>
 					New document
 					<span className="text-[11.5px] font-semibold opacity-75">⌘.</span>
@@ -119,7 +122,7 @@ function EmptyStateContent({
 			<button
 				type="button"
 				onClick={onAskAgent}
-				className="mt-4.5 flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[12.5px] text-neutral-400 hover:text-neutral-600"
+				className="mt-4.5 flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[12.5px] text-[var(--color-icon-tertiary)] hover:text-[var(--color-text-secondary)]"
 			>
 				or ask your agent to draft one
 				<ArrowRight className="size-3" strokeWidth={2} />

--- a/src/shell/first-run-screen.tsx
+++ b/src/shell/first-run-screen.tsx
@@ -41,7 +41,7 @@ export function FirstRunScreen({
 	return (
 		<div
 			data-testid="first-run-screen"
-			className="flex h-dvh flex-col bg-shell text-neutral-900"
+			className="flex h-dvh flex-col bg-[var(--color-bg-app)] text-[var(--color-text-primary)]"
 			onDragOver={(event) => {
 				event.preventDefault();
 				setIsDropTarget(true);
@@ -54,7 +54,7 @@ export function FirstRunScreen({
 			<TopBar
 				menu={
 					<span className="flex h-7 w-7 items-center justify-center rounded-[7px]">
-						<Zap className="size-3.75 fill-brand-600 text-brand-600" />
+						<Zap className="size-3.75 fill-[var(--color-icon-brand)] text-[var(--color-icon-brand)]" />
 					</span>
 				}
 				isUpdateReady={isUpdateReady}
@@ -67,13 +67,15 @@ export function FirstRunScreen({
 						<AddViewButton />
 					</IslandTabRow>
 					<div className="flex flex-1 items-center justify-center">
-						<span className="text-[12.5px] text-ink-faint">No folder open</span>
+						<span className="text-[12.5px] text-[var(--color-icon-tertiary)]">
+							No folder open
+						</span>
 					</div>
 				</Island>
 				<Island
 					className={`flex-50 transition-[background-color,box-shadow] duration-150 ${
 						isDropTarget
-							? "bg-brand-50/45 shadow-[inset_0_0_0_2px_rgba(251,146,60,0.38)]"
+							? "bg-[color-mix(in_srgb,var(--color-bg-brand-soft)_45%,transparent)] shadow-[inset_0_0_0_2px_rgba(251,146,60,0.38)]"
 							: ""
 					}`}
 				>
@@ -81,25 +83,25 @@ export function FirstRunScreen({
 						<AddViewButton />
 					</IslandTabRow>
 					<div className="flex flex-1 flex-col items-center justify-center p-10 text-center">
-						<div className="flex size-9 items-center justify-center rounded-lg bg-brand-50 text-brand-700 ring-1 ring-inset ring-brand-100">
+						<div className="flex size-9 items-center justify-center rounded-lg bg-[var(--color-bg-brand-soft)] text-[var(--color-text-link-hover)] ring-1 ring-inset ring-[var(--color-border-brand-soft)]">
 							<FolderOpen className="size-4.5" strokeWidth={2.2} />
 						</div>
-						<h1 className="mt-4 text-[18px] font-bold text-neutral-900">
+						<h1 className="mt-4 text-[18px] font-bold text-[var(--color-text-primary)]">
 							Open a folder
 						</h1>
-						<p className="mt-1.5 max-w-78 text-[13px] leading-relaxed text-ink-muted text-pretty">
+						<p className="mt-1.5 max-w-78 text-[13px] leading-relaxed text-[var(--color-text-secondary)] text-pretty">
 							Choose a local repo, docs folder, or notes folder. Flashtype keeps
 							everything in plain markdown files.
 						</p>
 						<button
 							type="button"
 							onClick={() => void onOpenFolder()}
-							className={`mt-5 flex h-8.5 items-center gap-2 rounded-lg bg-brand-600 px-4.5 text-[12.5px] font-bold text-neutral-0 shadow-[0_5px_14px_rgba(232,89,12,0.24),inset_0_1px_0_rgba(255,255,255,0.2)] transition hover:bg-brand-700 ${
+							className={`mt-5 flex h-8.5 items-center gap-2 rounded-lg bg-[var(--color-bg-action-primary)] px-4.5 text-[12.5px] font-bold text-[var(--color-text-on-action-primary)] shadow-[0_5px_14px_rgba(154,52,18,0.22),inset_0_1px_0_rgba(255,255,255,0.18)] transition hover:bg-[var(--color-bg-action-primary-hover)] ${
 								isDropTarget ? "brightness-[1.06]" : ""
 							}`}
 						>
 							Open folder
-							<span className="rounded-[4px] bg-white/15 px-1.25 py-0.25 text-[11px] font-semibold leading-none text-white/80">
+							<span className="rounded-[4px] bg-white/15 px-1.25 py-0.25 text-[11px] font-semibold leading-none text-[var(--color-text-on-action-primary)]/80">
 								⌘O
 							</span>
 						</button>

--- a/src/shell/island.tsx
+++ b/src/shell/island.tsx
@@ -26,7 +26,7 @@ export function Island({
 	return (
 		<div
 			className={cn(
-				"flex h-full min-w-0 flex-col overflow-hidden rounded-[10px] border border-island-border bg-neutral-0",
+				"flex h-full min-w-0 flex-col overflow-hidden rounded-[10px] border border-[var(--color-border-panel)] bg-[var(--color-bg-panel)]",
 				className,
 			)}
 		>
@@ -41,7 +41,7 @@ export function IslandTabRow({
 	readonly children?: ReactNode;
 }): JSX.Element {
 	return (
-		<div className="flex h-10 shrink-0 items-center gap-1 border-b border-island-divider px-2">
+		<div className="flex h-10 shrink-0 items-center gap-1 border-b border-[var(--color-border-subtle)] px-2">
 			{children}
 		</div>
 	);
@@ -66,10 +66,10 @@ export function TabChip({
 			type="button"
 			onClick={onClick}
 			className={cn(
-				"flex h-7 items-center gap-1.5 rounded-[7px] px-2.25 text-xs font-semibold text-neutral-900",
+				"flex h-7 items-center gap-1.5 rounded-[7px] px-2.25 text-xs font-semibold text-[var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-bg-panel)]",
 				isFocused
-					? "bg-focus-tint ring-1 ring-inset ring-focus-ring [&_svg]:text-brand-700"
-					: "bg-hover-soft [&_svg]:text-neutral-500",
+					? "bg-[var(--color-bg-selection-current)] ring-1 ring-inset ring-[var(--color-border-selection-current)] [&_svg]:text-[var(--color-icon-selection-current)]"
+					: "bg-[var(--color-bg-hover)] [&_svg]:text-[var(--color-icon-secondary)]",
 			)}
 		>
 			{icon ? <span className="[&_svg]:size-3.25">{icon}</span> : null}
@@ -91,7 +91,7 @@ export function AddViewButton({
 			type="button"
 			onClick={onClick}
 			aria-label={ariaLabel}
-			className="flex size-6 items-center justify-center rounded-md text-ink-faint hover:bg-hover-soft hover:text-neutral-600"
+			className="flex size-6 items-center justify-center rounded-md text-[var(--color-icon-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-icon-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-bg-panel)]"
 		>
 			<Plus className="size-3.25" strokeWidth={2} />
 		</button>

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -1748,7 +1748,7 @@ function LayoutShellContent({
 		>
 			<ExternalWriteDetector onExternalWrites={handleExternalFileWrites} />
 			<div
-				className="relative flex flex-col bg-shell text-neutral-900"
+				className="relative flex flex-col bg-[var(--color-bg-app)] text-[var(--color-text-primary)]"
 				style={{
 					// Pin the shell to the available viewport (inspector offset included) to avoid vertical scrolling.
 					height: "calc(100dvh - var(--lix-inspector-offset, 0px))",
@@ -1791,7 +1791,7 @@ function LayoutShellContent({
 							/>
 						</Panel>
 						<PanelResizeHandle className="group relative flex w-1.75 items-center justify-center">
-							<div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 h-full rounded-full bg-gradient-to-b from-transparent via-brand-600/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
+							<div className="absolute inset-y-0 left-1/2 h-full w-0.5 -translate-x-1/2 rounded-full bg-[linear-gradient(to_bottom,transparent,color-mix(in_srgb,var(--color-icon-brand)_50%,transparent),transparent)] opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
 						</PanelResizeHandle>
 						<Panel
 							defaultSize={panelSizes.central}
@@ -1817,7 +1817,7 @@ function LayoutShellContent({
 							/>
 						</Panel>
 						<PanelResizeHandle className="group relative flex w-1.75 items-center justify-center">
-							<div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 h-full rounded-full bg-gradient-to-b from-transparent via-brand-600/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
+							<div className="absolute inset-y-0 left-1/2 h-full w-0.5 -translate-x-1/2 rounded-full bg-[linear-gradient(to_bottom,transparent,color-mix(in_srgb,var(--color-icon-brand)_50%,transparent),transparent)] opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
 						</PanelResizeHandle>
 						<Panel
 							ref={rightPanelRef}

--- a/src/shell/panel-v2.tsx
+++ b/src/shell/panel-v2.tsx
@@ -170,7 +170,9 @@ export function PanelV2({
 	const ContainerElement =
 		side === "central" ? ("section" as const) : ("aside" as const);
 	const hostTextClass =
-		side === "central" ? "text-neutral-900" : "text-neutral-600";
+		side === "central"
+			? "text-[var(--color-text-primary)]"
+			: "text-[var(--color-text-secondary)]";
 
 	const contentHandlers =
 		onActiveViewInteraction && activeInstance
@@ -188,8 +190,8 @@ export function PanelV2({
 		>
 			<div
 				className={clsx(
-					"flex min-h-0 flex-1 flex-col overflow-hidden rounded-[10px] border border-island-border bg-neutral-0",
-					isOver && "ring-2 ring-brand-600 ring-inset",
+					"flex min-h-0 flex-1 flex-col overflow-hidden rounded-[10px] border border-[var(--color-border-panel)] bg-[var(--color-bg-panel)]",
+					isOver && "ring-2 ring-[var(--color-ring-focus-visible)] ring-inset",
 				)}
 			>
 				{/* Most islands render the identical 40px tab row; the central
@@ -321,14 +323,14 @@ function AddViewMenu({
 					type="button"
 					title="Add view"
 					aria-label="Add view"
-					className="flex size-6 flex-none items-center justify-center rounded-md text-ink-faint hover:bg-hover-soft hover:text-neutral-600"
+					className="flex size-6 flex-none items-center justify-center rounded-md text-[var(--color-icon-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-icon-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-bg-panel)]"
 				>
 					<Plus className="size-3.25" strokeWidth={2} />
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
 				align={side === "right" ? "end" : "start"}
-				className="w-44 border border-island-border bg-neutral-0 p-1 shadow-lg"
+				className="w-44 border border-[var(--color-border-panel)] bg-[var(--color-bg-panel)] p-1 shadow-lg"
 			>
 				{hasTerminal ? (
 					<>
@@ -338,7 +340,7 @@ function AddViewMenu({
 								onSelect={() =>
 									onAddView(TERMINAL_EXTENSION_KIND, preset.state)
 								}
-								className="flex items-center gap-2 px-3 py-1.5 text-sm text-neutral-900 focus:bg-hover-soft"
+								className="flex items-center gap-2 px-3 py-1.5 text-sm text-[var(--color-text-primary)] focus:bg-[var(--color-bg-hover)]"
 							>
 								<preset.icon className="size-4" />
 								<span>{preset.label}</span>
@@ -351,7 +353,7 @@ function AddViewMenu({
 					<DropdownMenuItem
 						key={ext.kind}
 						onSelect={() => onAddView(ext.kind)}
-						className="flex items-center gap-2 px-3 py-1.5 text-sm text-neutral-900 focus:bg-hover-soft"
+						className="flex items-center gap-2 px-3 py-1.5 text-sm text-[var(--color-text-primary)] focus:bg-[var(--color-bg-hover)]"
 					>
 						<ext.icon className="h-4 w-4" />
 						<span>{ext.label}</span>
@@ -614,15 +616,15 @@ function SortableTab({
 }
 
 const tabBaseClasses =
-	"group relative flex h-7 flex-none max-w-80 items-center gap-1.5 rounded-[7px] px-2.25 text-xs font-semibold transition-colors whitespace-nowrap";
+	"group relative flex h-7 flex-none max-w-80 items-center gap-1.5 rounded-[7px] px-2.25 text-xs font-semibold transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-bg-panel)]";
 
 const tabStateClasses = {
-	// The focused chip is the one orange element on screen: the view
-	// receiving keyboard input.
+	// The focused chip marks the view receiving keyboard input.
 	focused:
-		"bg-focus-tint text-neutral-900 ring-1 ring-inset ring-focus-ring [&_[data-tab-icon]]:text-brand-700",
-	active: "bg-hover-soft text-neutral-900 [&_[data-tab-icon]]:text-neutral-500",
-	idle: "bg-transparent text-neutral-500 hover:bg-hover-soft hover:text-neutral-900",
+		"bg-[var(--color-bg-selection-current)] text-[var(--color-text-primary)] ring-1 ring-inset ring-[var(--color-border-selection-current)] [&_[data-tab-icon]]:text-[var(--color-icon-selection-current)]",
+	active:
+		"bg-[var(--color-bg-hover)] text-[var(--color-text-primary)] [&_[data-tab-icon]]:text-[var(--color-icon-secondary)]",
+	idle: "bg-transparent text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)]",
 } as const;
 
 interface TabBaseProps extends PanelTabPreviewProps {
@@ -687,8 +689,8 @@ const TabButtonBase = forwardRef<HTMLButtonElement, TabBaseProps>(
 							className={clsx(
 								"pointer-events-none absolute -top-1 -left-1 flex h-4 min-w-[16px] -translate-y-1/2 items-center justify-center rounded-full px-[3px] text-[0.65rem] font-semibold leading-none transform",
 								isActive
-									? "bg-brand-600 text-white"
-									: "bg-secondary text-secondary-foreground",
+									? "bg-[var(--color-bg-action-primary)] text-[var(--color-text-on-action-primary)]"
+									: "bg-[var(--color-bg-notice-neutral)] text-[var(--color-text-notice-neutral)]",
 							)}
 						>
 							{badgeCount > 99 ? "99+" : badgeCount}
@@ -707,10 +709,10 @@ const TabButtonBase = forwardRef<HTMLButtonElement, TabBaseProps>(
 							className={clsx(
 								"h-3 w-3",
 								isActive && isFocused
-									? "text-focus-close hover:text-brand-700"
+									? "text-[var(--color-action-selection-current)] hover:text-[var(--color-icon-selection-current)]"
 									: isActive
-										? "text-neutral-400 hover:text-neutral-600"
-										: "text-neutral-400 opacity-0 group-hover:opacity-100 hover:text-neutral-600",
+										? "text-[var(--color-icon-tertiary)] hover:text-[var(--color-icon-secondary)]"
+										: "text-[var(--color-icon-tertiary)] opacity-0 group-hover:opacity-100 hover:text-[var(--color-icon-secondary)]",
 							)}
 							onClick={(event) => {
 								event.stopPropagation();

--- a/src/shell/panel.module.css
+++ b/src/shell/panel.module.css
@@ -2,7 +2,7 @@
 	position: relative;
 	height: 40px;
 	flex-shrink: 0;
-	border-bottom: 1px solid var(--color-island-divider);
+	border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .indicatorTrack {

--- a/src/shell/side-panel.tsx
+++ b/src/shell/side-panel.tsx
@@ -54,7 +54,9 @@ export function SidePanel({
 			/>
 		) : (
 			<div className="flex flex-1 items-center justify-center">
-				<span className="text-[12.5px] text-ink-faint">No view open</span>
+				<span className="text-[12.5px] text-[var(--color-icon-tertiary)]">
+					No view open
+				</span>
 			</div>
 		);
 

--- a/src/shell/status-bar.tsx
+++ b/src/shell/status-bar.tsx
@@ -15,7 +15,7 @@ export function StatusBar({
 	readonly right?: ReactNode;
 }): JSX.Element {
 	return (
-		<footer className="flex h-6 shrink-0 items-center justify-between px-3 text-[11.5px] text-chrome-icon">
+		<footer className="flex h-6 shrink-0 items-center justify-between px-3 text-[11.5px] text-[var(--color-icon-tertiary)]">
 			<div className="flex min-w-0 items-center gap-1.5">{left}</div>
 			<div className="flex min-w-0 items-center gap-1.5">{right}</div>
 		</footer>

--- a/src/shell/theme.css
+++ b/src/shell/theme.css
@@ -29,20 +29,72 @@
 	--color-neutral-900: rgb(28, 25, 23);
 	--color-neutral-950: rgb(12, 10, 9);
 
-	/* Shell chrome — values off the stone scale, from the islands design. */
-	--color-shell: rgb(244, 242, 239); /* window background */
-	--color-island-border: rgb(236, 232, 226);
-	--color-island-divider: rgb(244, 241, 236); /* tab-row bottom border */
-	--color-ink-muted: rgb(140, 133, 128); /* secondary copy, header icons */
-	--color-ink-faint: rgb(181, 175, 166); /* empty states, "+" buttons */
-	--color-chrome-icon: rgb(163, 156, 149); /* footer + outer chrome icons */
-	--color-hover-soft: rgb(245, 242, 237); /* row + quiet-button hover, chips */
-	--color-focus-tint: rgb(251, 239, 228); /* focused chip / selected file */
-	--color-focus-ring: rgb(243, 216, 190);
-	--color-focus-close: rgb(201, 168, 136); /* ✕ on the focused chip */
-	--color-secondary-tint: rgb(243, 244, 246);
-	--color-secondary-ring: rgb(209, 213, 219);
-	--color-secondary-icon: rgb(75, 85, 99);
+	/* Flashtype semantic aliases. Named by role, prominence, and state. */
+	--color-bg-app: rgb(244, 242, 239);
+	--color-bg-panel: var(--color-neutral-0);
+	--color-bg-panel-muted: var(--color-neutral-50);
+	--color-bg-hover: rgb(245, 242, 237);
+	--color-border-panel: rgb(236, 232, 226);
+	--color-border-subtle: rgb(244, 241, 236);
+	--color-text-primary: var(--color-neutral-900);
+	--color-text-secondary: var(--color-neutral-700);
+	--color-text-tertiary: var(--color-neutral-500);
+	--color-icon-secondary: var(--color-neutral-600);
+	--color-icon-tertiary: var(--color-neutral-500);
+	--color-icon-brand: var(--color-brand-600);
+	--color-bg-brand-soft: var(--color-brand-50);
+	--color-border-brand-soft: var(--color-brand-100);
+	--color-text-link: var(--color-brand-600);
+	--color-text-link-hover: var(--color-brand-700);
+	--color-bg-tooltip: var(--color-neutral-900);
+	--color-text-tooltip: var(--color-neutral-0);
+	--color-bg-selection-current: rgb(251, 239, 228);
+	--color-border-selection-current: rgb(243, 216, 190);
+	--color-icon-selection-current: var(--color-brand-700);
+	--color-action-selection-current: var(--color-icon-selection-current);
+	--color-ring-focus-visible: var(--color-brand-700);
+	--color-bg-action-primary: var(--color-brand-700);
+	--color-bg-action-primary-hover: var(--color-brand-800);
+	--color-text-on-action-primary: var(--color-neutral-0);
+	--color-bg-action-secondary: var(--color-neutral-900);
+	--color-bg-action-secondary-hover: var(--color-neutral-800);
+	--color-text-on-action-secondary: var(--color-neutral-0);
+	--color-bg-notice-neutral: var(--color-bg-hover);
+	--color-border-notice-neutral: transparent;
+	--color-icon-notice-neutral: var(--color-icon-secondary);
+	--color-text-notice-neutral: var(--color-text-primary);
+	--color-bg-notice-warning: var(--color-warning-50);
+	--color-border-notice-warning: var(--color-warning-200);
+	--color-text-notice-warning: var(--color-warning-900);
+	--color-text-status-danger: var(--color-error-600);
+	--color-text-status-success: var(--color-success-600);
+	--color-bg-control-selected: var(--color-bg-hover);
+	--color-border-control-selected: var(--color-border-panel);
+	--color-icon-control-selected: var(--color-icon-secondary);
+	--color-bg-diff-added: color-mix(
+		in srgb,
+		var(--color-success-500) 8%,
+		transparent
+	);
+	--color-text-diff-added: var(--color-success-800);
+	--color-border-diff-added: var(--color-success-700);
+	--color-bg-diff-removed: color-mix(
+		in srgb,
+		var(--color-error-500) 7%,
+		transparent
+	);
+	--color-text-diff-removed: var(--color-error-800);
+	--color-border-diff-removed: var(--color-error-700);
+	--color-bg-diff-modified: color-mix(
+		in srgb,
+		var(--color-warning-400) 11%,
+		transparent
+	);
+	--color-text-diff-modified: var(--color-warning-800);
+	--color-border-diff-modified: var(--color-warning-700);
+	--color-border-table-grid: var(--color-border-subtle);
+	--color-bg-table-row-hover: rgb(250, 246, 240);
+
 	--color-error-50: rgb(254, 242, 242);
 	--color-error-100: rgb(254, 226, 226);
 	--color-error-200: rgb(254, 202, 202);
@@ -74,51 +126,14 @@
 	--color-success-800: rgb(22, 101, 52);
 	--color-success-900: rgb(20, 83, 45);
 
-	/* Semantic tokens - clearer naming */
-	--color-text-primary: var(--color-neutral-900);
-	--color-text-secondary: var(--color-neutral-600);
-	--color-text-tertiary: var(--color-neutral-400);
-	--color-surface-primary: var(--color-neutral-0);
-	--color-surface-secondary: var(--color-neutral-50);
-	--color-surface-tertiary: var(--color-neutral-100);
-	--color-border-primary: var(--color-neutral-200);
-	--color-border-secondary: var(--color-neutral-100);
-	--color-brand-primary: var(--color-brand-600);
-	--color-brand-subtle: var(--color-brand-200);
-
-	/* Font families */
-	--font-caption: Inter;
-	--font-caption-bold: Inter;
-	--font-body: Inter;
-	--font-body-bold: Inter;
-	--font-heading-3: Inter;
-	--font-heading-2: Inter;
-	--font-heading-1: Inter;
-	--font-monospace-body: monospace;
-
 	/* Box shadows */
-	--shadow-sm: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
-	--shadow-default: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
 	--shadow-md:
 		0px 4px 16px -2px rgba(0, 0, 0, 0.08), 0px 2px 4px -1px rgba(0, 0, 0, 0.08);
 	--shadow-lg:
 		0px 12px 32px -4px rgba(0, 0, 0, 0.08), 0px 4px 8px -2px rgba(0, 0, 0, 0.08);
-	--shadow-overlay:
-		0px 12px 32px -4px rgba(0, 0, 0, 0.08), 0px 4px 8px -2px rgba(0, 0, 0, 0.08);
 
 	/* Border radiuses */
-	--radius-sm: 2px;
-	--radius-md: 4px;
-	--radius-DEFAULT: 4px;
-	--radius-lg: 8px;
 	--radius-full: 9999px;
-
-	/* Spacing */
-	--spacing-112: 28rem;
-	--spacing-144: 36rem;
-	--spacing-192: 48rem;
-	--spacing-256: 64rem;
-	--spacing-320: 80rem;
 }
 
 /* Container */

--- a/src/shell/top-bar/branch-switcher.tsx
+++ b/src/shell/top-bar/branch-switcher.tsx
@@ -195,7 +195,7 @@ function BranchSwitcherContent({
 					type="button"
 					variant="ghost"
 					size="sm"
-					className="inline-flex h-5.5 items-center gap-1 rounded-md px-1.5 font-normal text-chrome-icon hover:bg-hover-soft hover:text-neutral-600"
+					className="inline-flex h-5.5 items-center gap-1 rounded-md px-1.5 font-normal text-[var(--color-icon-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-secondary)]"
 					aria-label="Select branch"
 				>
 					<GitBranch className="size-3" />
@@ -212,7 +212,7 @@ function BranchSwitcherContent({
 				align="start"
 				sideOffset={6}
 			>
-				<DropdownMenuLabel className="text-[11px] uppercase tracking-wide text-neutral-500">
+				<DropdownMenuLabel className="text-[11px] uppercase tracking-wide text-[var(--color-text-tertiary)]">
 					Branches
 				</DropdownMenuLabel>
 				{branches.length === 0 ? (
@@ -242,12 +242,14 @@ function BranchSwitcherContent({
 								}}
 								className={clsx(
 									"group flex items-center gap-1.5 rounded-sm px-2 py-1.5 text-xs",
-									isActive ? "text-neutral-900" : "text-neutral-600",
+									isActive
+										? "text-[var(--color-text-primary)]"
+										: "text-[var(--color-text-secondary)]",
 								)}
 							>
 								<span className="flex w-3 justify-center" aria-hidden>
 									{isActive ? (
-										<Check className="h-3 w-3 text-brand-600" />
+										<Check className="h-3 w-3 text-[var(--color-icon-brand)]" />
 									) : null}
 								</span>
 								<span id={branchLabelId} className="truncate">
@@ -268,7 +270,7 @@ function BranchSwitcherContent({
 												Branch actions for {branch.name}
 											</span>
 											<MoreVertical
-												className="h-3.5 w-3.5 text-neutral-400"
+												className="h-3.5 w-3.5 text-[var(--color-icon-tertiary)]"
 												aria-hidden="true"
 											/>
 										</button>
@@ -308,7 +310,7 @@ function BranchSwitcherContent({
 				<DropdownMenuSeparator />
 				<DropdownMenuItem
 					onSelect={handleCreateBranch}
-					className="flex items-center gap-2 px-2 py-1.5 text-xs text-neutral-600"
+					className="flex items-center gap-2 px-2 py-1.5 text-xs text-[var(--color-text-secondary)]"
 				>
 					<Plus className="h-3 w-3" />
 					<span>Create branch</span>

--- a/src/shell/top-bar/flashtype-menu.tsx
+++ b/src/shell/top-bar/flashtype-menu.tsx
@@ -76,9 +76,9 @@ export function FlashtypeMenu() {
 				<Button
 					variant="ghost"
 					size="icon"
-					className="flex h-8 w-8 items-center justify-center rounded-md text-neutral-600 hover:bg-neutral-200 hover:text-neutral-900 data-[state=open]:bg-neutral-200 data-[state=open]:text-neutral-900 [-webkit-app-region:no-drag]"
+					className="flex h-8 w-8 items-center justify-center rounded-md text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] data-[state=open]:bg-[var(--color-bg-hover)] data-[state=open]:text-[var(--color-text-primary)] [-webkit-app-region:no-drag]"
 				>
-					<Zap className="size-4 text-brand-600" />
+					<Zap className="size-4 text-[var(--color-icon-brand)]" />
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent

--- a/src/shell/top-bar/index.tsx
+++ b/src/shell/top-bar/index.tsx
@@ -73,7 +73,7 @@ export function TopBar({
 	};
 
 	return (
-		<header className="relative flex h-9 shrink-0 items-center px-3 text-ink-muted [-webkit-app-region:drag]">
+		<header className="relative flex h-9 shrink-0 items-center px-3 text-[var(--color-text-secondary)] [-webkit-app-region:drag]">
 			<div
 				className={`flex min-w-0 flex-1 items-center gap-1 text-sm ${
 					isMacPlatform ? "pl-[68px]" : ""
@@ -84,7 +84,7 @@ export function TopBar({
 						<Button
 							variant="ghost"
 							size="icon"
-							className="h-7 w-7 rounded-[7px] text-ink-muted hover:bg-hover-soft hover:text-neutral-900 [-webkit-app-region:no-drag]"
+							className="h-7 w-7 rounded-[7px] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] [-webkit-app-region:no-drag]"
 							type="button"
 							onClick={onToggleLeftSidebar}
 							aria-label="Toggle left panel"
@@ -94,7 +94,7 @@ export function TopBar({
 							<PanelToggleIcon side="left" isActive={isLeftSidebarVisible} />
 						</Button>
 					</TooltipTrigger>
-					<TooltipContent className="bg-neutral-900 text-neutral-0 [&_[class*='bg-secondary']]:bg-neutral-900 [&_[class*='fill-secondary']]:fill-neutral-900">
+					<TooltipContent className="bg-[var(--color-bg-tooltip)] text-[var(--color-text-tooltip)] [&_[class*='bg-secondary']]:bg-[var(--color-bg-tooltip)] [&_[class*='fill-secondary']]:fill-[var(--color-bg-tooltip)]">
 						Toggle left panel ({leftShortcut})
 					</TooltipContent>
 				</Tooltip>
@@ -108,19 +108,24 @@ export function TopBar({
 							onClick={onWorkspaceTitleClick}
 							disabled={!onWorkspaceTitleClick}
 							title="Switch workspace"
-							className={`flex h-7 min-w-0 items-center gap-1.5 rounded-[7px] px-2 enabled:hover:bg-hover-soft ${
+							className={`flex h-7 min-w-0 items-center gap-1.5 rounded-[7px] px-2 enabled:hover:bg-[var(--color-bg-hover)] ${
 								activeFileName
-									? "font-medium text-ink-muted"
-									: "font-semibold text-neutral-700"
+									? "font-medium text-[var(--color-text-secondary)]"
+									: "font-semibold text-[var(--color-text-secondary)]"
 							}`}
 						>
-							<Folder className="size-3.25 text-ink-muted" strokeWidth={2} />
+							<Folder
+								className="size-3.25 text-[var(--color-text-secondary)]"
+								strokeWidth={2}
+							/>
 							<span className="max-w-60 truncate">{workspaceName}</span>
 						</button>
 						{activeFileName ? (
 							<>
-								<span className="mx-0.5 shrink-0 text-neutral-300">/</span>
-								<span className="max-w-60 truncate px-1 font-semibold text-neutral-900">
+								<span className="mx-0.5 shrink-0 text-[var(--color-border-panel)]">
+									/
+								</span>
+								<span className="max-w-60 truncate px-1 font-semibold text-[var(--color-text-primary)]">
 									{activeFileName}
 								</span>
 							</>
@@ -132,7 +137,7 @@ export function TopBar({
 				{showUpdateButton ? (
 					<Button
 						type="button"
-						className="h-6 rounded-md bg-linear-to-b from-brand-500 to-brand-600 px-2.5 text-[11.5px] font-bold text-neutral-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.24),0_1px_2px_rgba(123,62,27,0.16)] hover:brightness-[1.06] [-webkit-app-region:no-drag]"
+						className="h-6 rounded-md bg-[var(--color-bg-action-primary)] px-2.5 text-[11.5px] font-bold text-[var(--color-text-on-action-primary)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_1px_2px_rgba(123,62,27,0.16)] hover:bg-[var(--color-bg-action-primary-hover)] [-webkit-app-region:no-drag]"
 						disabled={isInstallingUpdate}
 						onClick={() => {
 							void handleInstallUpdate();
@@ -147,7 +152,7 @@ export function TopBar({
 					target="_blank"
 					rel="noreferrer"
 					title="GitHub"
-					className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-[7px] text-sm font-medium whitespace-nowrap text-chrome-icon transition-all outline-none hover:bg-hover-soft hover:text-neutral-900 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [-webkit-app-region:no-drag] [&_svg]:pointer-events-none [&_svg]:shrink-0"
+					className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-[7px] text-sm font-medium whitespace-nowrap text-[var(--color-icon-tertiary)] transition-all outline-none hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring [-webkit-app-region:no-drag] [&_svg]:pointer-events-none [&_svg]:shrink-0"
 				>
 					<svg
 						className="size-3.75"
@@ -167,7 +172,7 @@ export function TopBar({
 						<Button
 							variant="ghost"
 							size="icon"
-							className="h-7 w-7 rounded-[7px] text-chrome-icon hover:bg-hover-soft hover:text-neutral-900 [-webkit-app-region:no-drag]"
+							className="h-7 w-7 rounded-[7px] text-[var(--color-icon-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] [-webkit-app-region:no-drag]"
 							type="button"
 							onClick={onToggleRightSidebar}
 							aria-label="Toggle right panel"
@@ -177,7 +182,7 @@ export function TopBar({
 							<PanelToggleIcon side="right" isActive={isRightSidebarVisible} />
 						</Button>
 					</TooltipTrigger>
-					<TooltipContent className="bg-neutral-900 text-neutral-0 [&_[class*='bg-secondary']]:bg-neutral-900 [&_[class*='fill-secondary']]:fill-neutral-900">
+					<TooltipContent className="bg-[var(--color-bg-tooltip)] text-[var(--color-text-tooltip)] [&_[class*='bg-secondary']]:bg-[var(--color-bg-tooltip)] [&_[class*='fill-secondary']]:fill-[var(--color-bg-tooltip)]">
 						Toggle right panel ({rightShortcut})
 					</TooltipContent>
 				</Tooltip>


### PR DESCRIPTION
## Summary

- Add a lightweight Markdown autosave hint when users press Cmd+S/Ctrl+S.
- Consolidate Flashtype color usage onto semantic tokens across Markdown, shell chrome, files, CSV, terminal, tooltips, and dropdowns.
- Clean up legacy theme aliases and improve focus/selected-state contrast.
- Add a patch changenote for the Markdown editor chrome update.

## Validation

- `pnpm vitest run src/extensions/markdown/index.test.tsx src/extensions/files/file-tree.test.tsx src/extensions/files/index.test.tsx src/shell/panel-v2.test.tsx`
- `pnpm typecheck`
- `pnpm exec oxlint ...` on touched files
- `pnpm exec vite build`
- `git diff --check`

## Note

Full `pnpm lint` still reports the existing `website/src/routes/__root.tsx` React hook dependency issue, unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-surface visual token migration could cause contrast or focus-ring regressions, though behavior changes are limited to the Cmd/Ctrl+S autosave hint.
> 
> **Overview**
> Adds a **Markdown autosave affordance**: when the active, focused editor receives **Cmd/Ctrl+S**, the shortcut is intercepted and a short-lived **“Auto-saved. No Cmd+S needed.”** status chip appears over the editor (with styling in `style.css` and coverage in `index.test.tsx`).
> 
> The rest of the PR is a **broad theming pass** that replaces ad hoc neutrals, island chrome, and inline diff colors with **semantic CSS variables** defined in `theme.css` and wired through shadcn tokens in `index.css`. Markdown formatting toolbar, slash menu, file tree, CSV tables/review diff, shell panels/top bar, dropdowns, tooltips, terminal xterm theme, and external-write review controls now read from roles like `--color-bg-panel`, `--color-bg-selection-current`, and `--color-bg-diff-*`.
> 
> Legacy shell aliases (`shell`, `hover-soft`, `focus-tint`, etc.) are dropped in favor of the new names; related tests (e.g. file tree focus/selection classes) are updated accordingly. A patch changenote documents the Markdown editor chrome update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af730a16e61dcd0e7fa3b5e13a9158d24df00f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->