### PR TITLE
Verify macOS app version metadata

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,6 +2,7 @@ appId: com.flashtype.app
 productName: Flashtype
 executableName: Flashtype
 artifactName: "${productName}-${version}-${os}-${arch}.${ext}"
+afterPack: scripts/verify-macos-app-version-hook.cjs
 directories:
   output: release
   buildResources: build

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
 		"build:env-variables": "node scripts/write-env-variables.mjs",
 		"rebuild:electron-native": "electron-rebuild -f -w node-pty",
 		"fix:lix-native-macos": "node scripts/fix-lix-native-macos.mjs",
-		"package:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish never",
+		"package:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish never && pnpm run verify:mac-app-version",
 		"install:mac": "pnpm run package:mac && node scripts/install-mac.mjs",
-		"release:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish always",
+		"release:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish always && pnpm run verify:mac-app-version",
 		"dev:web": "vite",
 		"predev": "pnpm run build:lix && pnpm run build:markdown-wc && pnpm run rebuild:electron-native",
 		"predev:web": "pnpm run build:markdown-wc",
@@ -37,6 +37,7 @@
 		"pretest:e2e:headed": "pnpm run pretest:e2e",
 		"test:e2e:headed": "FLASHTYPE_HEADLESS=0 playwright test",
 		"test:e2e:packaged-macos": "playwright test --config playwright.packaged.config.ts",
+		"verify:mac-app-version": "node scripts/verify-macos-app-version.mjs",
 		"ci": "pnpm run build && pnpm test"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
 		"build:env-variables": "node scripts/write-env-variables.mjs",
 		"rebuild:electron-native": "electron-rebuild -f -w node-pty",
 		"fix:lix-native-macos": "node scripts/fix-lix-native-macos.mjs",
-		"package:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish never && pnpm run verify:mac-app-version",
+		"package:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish never && pnpm run verify:mac-app-version && pnpm run verify:mac-release-artifacts",
 		"install:mac": "pnpm run package:mac && node scripts/install-mac.mjs",
-		"release:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish always && pnpm run verify:mac-app-version",
+		"release:mac": "pnpm run build:icons && pnpm run build && pnpm run build:env-variables && pnpm run rebuild:electron-native && pnpm run fix:lix-native-macos && electron-builder --mac --publish always && pnpm run verify:mac-app-version && pnpm run verify:mac-release-artifacts",
 		"dev:web": "vite",
 		"predev": "pnpm run build:lix && pnpm run build:markdown-wc && pnpm run rebuild:electron-native",
 		"predev:web": "pnpm run build:markdown-wc",
@@ -38,6 +38,7 @@
 		"test:e2e:headed": "FLASHTYPE_HEADLESS=0 playwright test",
 		"test:e2e:packaged-macos": "playwright test --config playwright.packaged.config.ts",
 		"verify:mac-app-version": "node scripts/verify-macos-app-version.mjs",
+		"verify:mac-release-artifacts": "node scripts/verify-macos-release-artifacts.mjs",
 		"ci": "pnpm run build && pnpm test"
 	},
 	"dependencies": {

--- a/scripts/install-mac.mjs
+++ b/scripts/install-mac.mjs
@@ -33,6 +33,12 @@ try {
 	console.log("Refreshing Launch Services...");
 	await run(lsregisterPath, ["-f", installedAppPath]);
 
+	console.log("Verifying installed app version metadata...");
+	await run(process.execPath, [
+		path.resolve("scripts/verify-macos-app-version.mjs"),
+		installedAppPath,
+	]);
+
 	console.log(`Opening ${installedAppPath}...`);
 	await run("/usr/bin/open", [installedAppPath]);
 

--- a/scripts/verify-macos-app-version-hook.cjs
+++ b/scripts/verify-macos-app-version-hook.cjs
@@ -1,0 +1,54 @@
+const { execFile } = require("node:child_process");
+const { readFile } = require("node:fs/promises");
+const path = require("node:path");
+const { promisify } = require("node:util");
+
+const execFileAsync = promisify(execFile);
+
+exports.default = async function verifyMacosAppVersionHook(context) {
+	if (context.electronPlatformName !== "darwin") {
+		return;
+	}
+
+	const appPath = path.join(context.appOutDir, "Flashtype.app");
+	await verifyMacosAppVersion(appPath, context.packager.projectDir);
+};
+
+async function verifyMacosAppVersion(appPath, projectDir) {
+	const packageJson = JSON.parse(
+		await readFile(path.join(projectDir, "package.json"), "utf8"),
+	);
+	const expectedVersion = packageJson.version;
+	if (!expectedVersion) {
+		throw new Error("Missing version in package.json");
+	}
+
+	const infoPlistPath = path.join(appPath, "Contents/Info.plist");
+	const [shortVersion, bundleVersion] = await Promise.all([
+		readPlistValue(infoPlistPath, "CFBundleShortVersionString"),
+		readPlistValue(infoPlistPath, "CFBundleVersion"),
+	]);
+
+	if (shortVersion !== expectedVersion || bundleVersion !== expectedVersion) {
+		throw new Error(
+			[
+				"macOS app version metadata does not match package.json.",
+				`App: ${appPath}`,
+				`Expected: ${expectedVersion}`,
+				`CFBundleShortVersionString: ${shortVersion}`,
+				`CFBundleVersion: ${bundleVersion}`,
+			].join("\n"),
+		);
+	}
+
+	console.log(`Verified ${appPath} reports version ${expectedVersion}.`);
+}
+
+async function readPlistValue(infoPlistPath, key) {
+	const { stdout } = await execFileAsync("/usr/libexec/PlistBuddy", [
+		"-c",
+		`Print :${key}`,
+		infoPlistPath,
+	]);
+	return stdout.trim();
+}

--- a/scripts/verify-macos-app-version.mjs
+++ b/scripts/verify-macos-app-version.mjs
@@ -1,0 +1,55 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = process.cwd();
+const packageJsonPath = path.join(root, "package.json");
+const defaultAppPath = path.join(root, "release/mac-arm64/Flashtype.app");
+const appPath = path.resolve(process.argv[2] ?? defaultAppPath);
+
+if (process.platform !== "darwin") {
+	console.error("verify-macos-app-version can only run on macOS.");
+	process.exit(1);
+}
+
+try {
+	const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+	const expectedVersion = packageJson.version;
+	if (!expectedVersion) {
+		throw new Error(`Missing version in ${packageJsonPath}`);
+	}
+
+	const infoPlistPath = path.join(appPath, "Contents/Info.plist");
+	const [shortVersion, bundleVersion] = await Promise.all([
+		readPlistValue(infoPlistPath, "CFBundleShortVersionString"),
+		readPlistValue(infoPlistPath, "CFBundleVersion"),
+	]);
+
+	if (shortVersion !== expectedVersion || bundleVersion !== expectedVersion) {
+		throw new Error(
+			[
+				`macOS app version metadata does not match package.json.`,
+				`App: ${appPath}`,
+				`Expected: ${expectedVersion}`,
+				`CFBundleShortVersionString: ${shortVersion}`,
+				`CFBundleVersion: ${bundleVersion}`,
+			].join("\n"),
+		);
+	}
+
+	console.log(`Verified ${appPath} reports version ${expectedVersion}.`);
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+}
+
+async function readPlistValue(infoPlistPath, key) {
+	const { stdout } = await execFileAsync("/usr/libexec/PlistBuddy", [
+		"-c",
+		`Print :${key}`,
+		infoPlistPath,
+	]);
+	return stdout.trim();
+}

--- a/scripts/verify-macos-release-artifacts.mjs
+++ b/scripts/verify-macos-release-artifacts.mjs
@@ -1,0 +1,257 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { gunzip } from "node:zlib";
+
+const execFileAsync = promisify(execFile);
+const gunzipAsync = promisify(gunzip);
+const root = process.cwd();
+const releaseDir = path.resolve(process.argv[2] ?? "release");
+const appPath = path.join(releaseDir, "mac-arm64/Flashtype.app");
+const appInfoPlistPath = path.join(appPath, "Contents/Info.plist");
+const packageJson = JSON.parse(
+	await readFile(path.join(root, "package.json"), "utf8"),
+);
+const expectedVersion = packageJson.version;
+const expectedArtifacts = [
+	`Flashtype-${expectedVersion}-mac-arm64.dmg`,
+	`Flashtype-${expectedVersion}-mac-arm64.zip`,
+	`Flashtype-${expectedVersion}-mac-arm64.zip.blockmap`,
+	"latest-mac.yml",
+];
+
+if (process.platform !== "darwin") {
+	console.error("verify-macos-release-artifacts can only run on macOS.");
+	process.exit(1);
+}
+
+try {
+	if (!expectedVersion) {
+		throw new Error("Missing version in package.json");
+	}
+
+	await assertDirectory(releaseDir);
+	await assertDirectory(appPath);
+	for (const artifact of expectedArtifacts) {
+		await assertFile(path.join(releaseDir, artifact));
+	}
+
+	await verifyAppIdentity();
+	await verifyArtifactMetadata();
+	await verifyLatestMacYaml();
+
+	console.log(
+		`Verified macOS release artifacts in ${releaseDir} for version ${expectedVersion}.`,
+	);
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+}
+
+async function verifyAppIdentity() {
+	const values = Object.fromEntries(
+		await Promise.all(
+			[
+				"CFBundleDisplayName",
+				"CFBundleIdentifier",
+				"CFBundleName",
+				"CFBundleShortVersionString",
+				"CFBundleVersion",
+			].map(async (key) => [key, await readPlistValue(appInfoPlistPath, key)]),
+		),
+	);
+
+	const expectedValues = {
+		CFBundleDisplayName: "Flashtype",
+		CFBundleIdentifier: "com.flashtype.app",
+		CFBundleName: "Flashtype",
+		CFBundleShortVersionString: expectedVersion,
+		CFBundleVersion: expectedVersion,
+	};
+
+	for (const [key, expectedValue] of Object.entries(expectedValues)) {
+		if (values[key] !== expectedValue) {
+			throw new Error(
+				`${key} mismatch in ${appInfoPlistPath}: expected ${expectedValue}, got ${values[key]}`,
+			);
+		}
+	}
+}
+
+async function verifyArtifactMetadata() {
+	for (const artifact of expectedArtifacts.filter((name) => name !== "latest-mac.yml")) {
+		const artifactPath = path.join(releaseDir, artifact);
+		const artifactStats = await stat(artifactPath);
+		if (artifactStats.size <= 0) {
+			throw new Error(`Artifact is empty: ${artifactPath}`);
+		}
+	}
+
+	const zipPath = path.join(
+		releaseDir,
+		`Flashtype-${expectedVersion}-mac-arm64.zip`,
+	);
+	const blockmapPath = `${zipPath}.blockmap`;
+	const zipBlockmap = await readBlockmap(blockmapPath);
+
+	verifyBlockmapShape(zipBlockmap, blockmapPath);
+	verifyBlockmapShape(
+		await readBlockmap(
+			path.join(releaseDir, `Flashtype-${expectedVersion}-mac-arm64.dmg.blockmap`),
+		),
+		path.join(releaseDir, `Flashtype-${expectedVersion}-mac-arm64.dmg.blockmap`),
+	);
+}
+
+async function verifyLatestMacYaml() {
+	const latestMacPath = path.join(releaseDir, "latest-mac.yml");
+	const latestMac = await parseSimpleYaml(latestMacPath);
+	const expectedZip = `Flashtype-${expectedVersion}-mac-arm64.zip`;
+	const expectedDmg = `Flashtype-${expectedVersion}-mac-arm64.dmg`;
+	const zipPath = path.join(releaseDir, expectedZip);
+	const zipStats = await stat(zipPath);
+	const zipSha512 = await sha512Base64(zipPath);
+	const dmgPath = path.join(releaseDir, expectedDmg);
+	const dmgStats = await stat(dmgPath);
+	const dmgSha512 = await sha512Base64(dmgPath);
+
+	if (latestMac.version !== expectedVersion) {
+		throw new Error(
+			`latest-mac.yml version mismatch: expected ${expectedVersion}, got ${latestMac.version}`,
+		);
+	}
+
+	if (latestMac.path !== expectedZip) {
+		throw new Error(
+			`latest-mac.yml path mismatch: expected ${expectedZip}, got ${latestMac.path}`,
+		);
+	}
+
+	if (latestMac.sha512 !== zipSha512) {
+		throw new Error("latest-mac.yml sha512 does not match the generated zip.");
+	}
+
+	const fileEntry = latestMac.files.find((file) => file.url === expectedZip);
+	if (!fileEntry) {
+		throw new Error(`latest-mac.yml files list is missing ${expectedZip}`);
+	}
+
+	if (fileEntry.sha512 !== zipSha512) {
+		throw new Error(`latest-mac.yml files sha512 mismatch for ${expectedZip}`);
+	}
+
+	if (fileEntry.size !== zipStats.size) {
+		throw new Error(
+			`latest-mac.yml files size mismatch for ${expectedZip}: expected ${zipStats.size}, got ${fileEntry.size}`,
+		);
+	}
+
+	const dmgEntry = latestMac.files.find((file) => file.url === expectedDmg);
+	if (!dmgEntry) {
+		throw new Error(`latest-mac.yml files list is missing ${expectedDmg}`);
+	}
+
+	if (dmgEntry.sha512 !== dmgSha512) {
+		throw new Error(`latest-mac.yml files sha512 mismatch for ${expectedDmg}`);
+	}
+
+	if (dmgEntry.size !== dmgStats.size) {
+		throw new Error(
+			`latest-mac.yml files size mismatch for ${expectedDmg}: expected ${dmgStats.size}, got ${dmgEntry.size}`,
+		);
+	}
+}
+
+async function parseSimpleYaml(filePath) {
+	const lines = (await readFile(filePath, "utf8")).split(/\r?\n/);
+	const result = { files: [] };
+	let currentFile = null;
+
+	for (const line of lines) {
+		if (!line.trim()) {
+			continue;
+		}
+
+		const fileMatch = line.match(/^  - (url): (.+)$/);
+		if (fileMatch) {
+			currentFile = { url: fileMatch[2] };
+			result.files.push(currentFile);
+			continue;
+		}
+
+		const nestedMatch = line.match(/^    ([A-Za-z0-9_-]+): (.+)$/);
+		if (nestedMatch && currentFile) {
+			currentFile[nestedMatch[1]] = parseYamlValue(nestedMatch[2]);
+			continue;
+		}
+
+		const topLevelMatch = line.match(/^([A-Za-z0-9_-]+): (.+)$/);
+		if (topLevelMatch) {
+			result[topLevelMatch[1]] = parseYamlValue(topLevelMatch[2]);
+		}
+	}
+
+	return result;
+}
+
+function parseYamlValue(value) {
+	if (/^\d+$/.test(value)) {
+		return Number(value);
+	}
+	return value.replace(/^"|"$/g, "");
+}
+
+async function readPlistValue(infoPlistPath, key) {
+	const { stdout } = await execFileAsync("/usr/libexec/PlistBuddy", [
+		"-c",
+		`Print :${key}`,
+		infoPlistPath,
+	]);
+	return stdout.trim();
+}
+
+async function sha512Base64(filePath) {
+	const hash = createHash("sha512");
+	hash.update(await readFile(filePath));
+	return hash.digest("base64");
+}
+
+async function readBlockmap(filePath) {
+	return JSON.parse((await gunzipAsync(await readFile(filePath))).toString("utf8"));
+}
+
+function verifyBlockmapShape(blockmap, filePath) {
+	if (blockmap.version !== "2") {
+		throw new Error(`Unsupported blockmap version in ${filePath}: ${blockmap.version}`);
+	}
+	if (!Array.isArray(blockmap.files) || blockmap.files.length === 0) {
+		throw new Error(`Blockmap contains no files: ${filePath}`);
+	}
+	for (const file of blockmap.files) {
+		if (typeof file.name !== "string" || file.name.length === 0) {
+			throw new Error(`Blockmap file entry is missing a name: ${filePath}`);
+		}
+		if (!Array.isArray(file.checksums) || file.checksums.length === 0) {
+			throw new Error(`Blockmap file entry has no checksums: ${filePath}`);
+		}
+		if (!Array.isArray(file.sizes) || file.sizes.length === 0) {
+			throw new Error(`Blockmap file entry has no sizes: ${filePath}`);
+		}
+	}
+}
+
+async function assertFile(filePath) {
+	const stats = await stat(filePath);
+	if (!stats.isFile()) {
+		throw new Error(`Expected file: ${filePath}`);
+	}
+}
+
+async function assertDirectory(directoryPath) {
+	const stats = await stat(directoryPath);
+	if (!stats.isDirectory()) {
+		throw new Error(`Expected directory: ${directoryPath}`);
+	}
+}


### PR DESCRIPTION
Closes #178

## Summary
- add a macOS app version verifier that compares `Info.plist` version metadata with `package.json`
- run the version verifier as an electron-builder `afterPack` hook so bad metadata fails before macOS artifacts are produced/published
- run the same version verifier after `package:mac` and after copying the app in `install:mac`
- add a release artifact verifier for the generated macOS release directory
- validate artifact filenames, app bundle identity, app bundle version, `latest-mac.yml`, zip/dmg checksums, sizes, and gzipped blockmap structure

## Verification
- `node --check scripts/verify-macos-app-version.mjs && node --check scripts/verify-macos-app-version-hook.cjs && node --check scripts/install-mac.mjs`
- `node --check scripts/verify-macos-release-artifacts.mjs`
- `node scripts/verify-macos-app-version.mjs /Applications/Flashtype.app` verified the installed app reports `0.4.0`
- `electron-builder --mac dir --publish never` executed the `afterPack` hook and verified `release/mac-arm64/Flashtype.app` reports `0.4.0`
- `electron-builder --mac --publish never` generated real zip/dmg/latest/blockmap artifacts, then `node scripts/verify-macos-release-artifacts.mjs` verified them for `0.4.0`
- `oxlint --tsconfig ./tsconfig.json --ignore-path .gitignore --ignore-pattern "submodule/**" --format stylish scripts/install-mac.mjs scripts/verify-macos-app-version.mjs scripts/verify-macos-app-version-hook.cjs scripts/verify-macos-release-artifacts.mjs`
- `tsc -p . --pretty false`

Note: full `pnpm run package:mac` still requires the local `resvg` binary for icon regeneration. The release artifact verifier was tested against real electron-builder output generated with the existing icon assets.
