### PR TITLE
[codex] Reset workspace restore after failed boot

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -33,10 +33,13 @@ import {
 } from "./launch-args.mjs";
 import {
 	filterExistingWorkspaceEntries,
+	clearWorkspaceSessionBootInProgressSync,
+	markWorkspaceSessionBootInProgressSync,
 	mergeRestoredAndExplicitWorkspaceRequests,
 	normalizeWorkspacePaths,
 	normalizeWorkspaceSessionEntries,
 	readWorkspaceSessionEntries,
+	recoverWorkspaceSessionAfterFailedBootSync,
 	workspaceToSessionEntry,
 	writeWorkspaceSessionEntriesSync,
 } from "./workspace-session.mjs";
@@ -96,6 +99,8 @@ let registerLixIpc = () => {};
 let disposeTerminalIpc = () => {};
 let registerTerminalIpc = () => {};
 let recentWorkspaceEntries = [];
+let workspaceBootRecoveryGuardArmed = false;
+let workspaceBootRecoveryInitialWindowsCreated = false;
 
 if (isHeadless && process.platform === "darwin") {
 	app.dock.hide();
@@ -211,6 +216,41 @@ function createWorkspaceOpenRequest(request, requestedSource) {
 
 function isCrashLikeProcessGoneReason(reason) {
 	return CRASH_LIKE_PROCESS_GONE_REASONS.has(reason);
+}
+
+function shouldUseWorkspaceBootRecoveryGuard() {
+	return app.isPackaged && !isHeadless;
+}
+
+function startWorkspaceBootRecoveryGuard() {
+	if (!shouldUseWorkspaceBootRecoveryGuard()) {
+		return;
+	}
+	const userDataPath = app.getPath("userData");
+	try {
+		if (recoverWorkspaceSessionAfterFailedBootSync(userDataPath)) {
+			console.warn(
+				"Previous Flashtype boot did not complete; reset saved workspace session",
+			);
+		}
+		markWorkspaceSessionBootInProgressSync(userDataPath);
+		workspaceBootRecoveryGuardArmed = true;
+		workspaceBootRecoveryInitialWindowsCreated = false;
+	} catch (error) {
+		console.warn("Failed to update Flashtype workspace boot guard", error);
+	}
+}
+
+function clearWorkspaceBootRecoveryGuard() {
+	if (!workspaceBootRecoveryGuardArmed) {
+		return;
+	}
+	try {
+		clearWorkspaceSessionBootInProgressSync(app.getPath("userData"));
+		workspaceBootRecoveryGuardArmed = false;
+	} catch (error) {
+		console.warn("Failed to clear Flashtype workspace boot guard", error);
+	}
 }
 
 function normalizeWorkspaceOpenRequest(
@@ -671,6 +711,7 @@ async function loadNativeIpcModules() {
 }
 
 async function startWorkspaceLifecycle() {
+	startWorkspaceBootRecoveryGuard();
 	await loadNativeIpcModules();
 	if (isQuitting) {
 		return;
@@ -799,6 +840,7 @@ async function startWorkspaceLifecycle() {
 		} else {
 			await createMainWindow();
 		}
+		workspaceBootRecoveryInitialWindowsCreated = true;
 	} finally {
 		initialWorkspaceOpenInProgress = false;
 	}
@@ -812,7 +854,18 @@ app.on("window-all-closed", () => {
 
 app.on("before-quit", () => {
 	isQuitting = true;
-	flushOpenWorkspacePaths();
+	if (
+		!workspaceBootRecoveryGuardArmed ||
+		workspaceBootRecoveryInitialWindowsCreated
+	) {
+		flushOpenWorkspacePaths();
+	}
+	if (
+		workspaceBootRecoveryGuardArmed &&
+		workspaceBootRecoveryInitialWindowsCreated
+	) {
+		clearWorkspaceBootRecoveryGuard();
+	}
 	void disposeLixIpc();
 	disposeTerminalIpc();
 });

--- a/electron/workspace-session.mjs
+++ b/electron/workspace-session.mjs
@@ -1,8 +1,18 @@
 import fs from "node:fs/promises";
-import { mkdirSync, writeFileSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
 export const WORKSPACE_SESSION_FILE = "workspace-session.json";
+export const WORKSPACE_SESSION_RECOVERY_BACKUP_FILE =
+	"workspace-session.recovery-backup.json";
+export const WORKSPACE_SESSION_BOOT_GUARD_FILE =
+	"workspace-session-boot-in-progress";
 export const WORKSPACE_SESSION_VERSION = 3;
 
 export async function readWorkspaceSessionEntries(userDataPath) {
@@ -45,6 +55,35 @@ export function writeWorkspaceSessionEntriesSync(
 		serializeWorkspaceSessionEntries(workspaceEntries),
 		"utf8",
 	);
+}
+
+export function recoverWorkspaceSessionAfterFailedBootSync(userDataPath) {
+	if (!existsSync(getWorkspaceSessionBootGuardPath(userDataPath))) {
+		return false;
+	}
+
+	try {
+		const workspaceSessionPath = getWorkspaceSessionPath(userDataPath);
+		const recoveryBackupPath =
+			getWorkspaceSessionRecoveryBackupPath(userDataPath);
+		if (existsSync(workspaceSessionPath) && !existsSync(recoveryBackupPath)) {
+			copyFileSync(workspaceSessionPath, recoveryBackupPath);
+		}
+	} catch {
+		// Recovery should still break the restore crash loop if backup fails.
+	}
+
+	writeWorkspaceSessionEntriesSync(userDataPath, []);
+	return true;
+}
+
+export function markWorkspaceSessionBootInProgressSync(userDataPath) {
+	mkdirSync(userDataPath, { recursive: true });
+	writeFileSync(getWorkspaceSessionBootGuardPath(userDataPath), "", "utf8");
+}
+
+export function clearWorkspaceSessionBootInProgressSync(userDataPath) {
+	rmSync(getWorkspaceSessionBootGuardPath(userDataPath), { force: true });
 }
 
 export async function filterExistingWorkspaceEntries(workspaceEntries) {
@@ -177,6 +216,14 @@ export function mergeRestoredAndExplicitWorkspaceRequests(
 
 export function getWorkspaceSessionPath(userDataPath) {
 	return path.join(userDataPath, WORKSPACE_SESSION_FILE);
+}
+
+function getWorkspaceSessionRecoveryBackupPath(userDataPath) {
+	return path.join(userDataPath, WORKSPACE_SESSION_RECOVERY_BACKUP_FILE);
+}
+
+function getWorkspaceSessionBootGuardPath(userDataPath) {
+	return path.join(userDataPath, WORKSPACE_SESSION_BOOT_GUARD_FILE);
 }
 
 function normalizeWorkspaceSessionEntry(workspaceEntry) {

--- a/electron/workspace-session.test.ts
+++ b/electron/workspace-session.test.ts
@@ -6,8 +6,11 @@ import { describe, expect, test } from "vitest";
 import {
 	filterExistingWorkspaceEntries,
 	getWorkspaceSessionPath,
+	markWorkspaceSessionBootInProgressSync,
 	mergeRestoredAndExplicitWorkspaceRequests,
 	readWorkspaceSessionEntries,
+	recoverWorkspaceSessionAfterFailedBootSync,
+	WORKSPACE_SESSION_RECOVERY_BACKUP_FILE,
 	writeWorkspaceSessionEntries,
 	writeWorkspaceSessionEntriesSync,
 	WORKSPACE_SESSION_VERSION,
@@ -86,6 +89,51 @@ describe("workspace session store", () => {
 		]);
 
 		await expect(readStore(userDataPath)).resolves.toEqual({
+			version: WORKSPACE_SESSION_VERSION,
+			workspaces: [{ ephemeral: false, path: workspacePath }],
+		});
+	});
+
+	test("boot recovery without guard leaves saved workspace entries alone", async () => {
+		const userDataPath = createUserDataPath();
+		const workspacePath = path.join(userDataPath, "workspace");
+		writeWorkspaceSessionEntriesSync(userDataPath, [
+			{ ephemeral: false, path: workspacePath },
+		]);
+
+		expect(recoverWorkspaceSessionAfterFailedBootSync(userDataPath)).toBe(
+			false,
+		);
+
+		await expect(readWorkspaceSessionEntries(userDataPath)).resolves.toEqual([
+			{ ephemeral: false, path: workspacePath },
+		]);
+	});
+
+	test("boot recovery backs up once and clears saved workspace entries", async () => {
+		const userDataPath = createUserDataPath();
+		const workspacePath = path.join(userDataPath, "workspace");
+		writeWorkspaceSessionEntriesSync(userDataPath, [
+			{ ephemeral: false, path: workspacePath },
+		]);
+		markWorkspaceSessionBootInProgressSync(userDataPath);
+
+		expect(recoverWorkspaceSessionAfterFailedBootSync(userDataPath)).toBe(true);
+
+		await expect(readWorkspaceSessionEntries(userDataPath)).resolves.toEqual(
+			[],
+		);
+		await expect(readRecoveryBackup(userDataPath)).resolves.toEqual({
+			version: WORKSPACE_SESSION_VERSION,
+			workspaces: [{ ephemeral: false, path: workspacePath }],
+		});
+
+		expect(recoverWorkspaceSessionAfterFailedBootSync(userDataPath)).toBe(true);
+
+		await expect(readWorkspaceSessionEntries(userDataPath)).resolves.toEqual(
+			[],
+		);
+		await expect(readRecoveryBackup(userDataPath)).resolves.toEqual({
 			version: WORKSPACE_SESSION_VERSION,
 			workspaces: [{ ephemeral: false, path: workspacePath }],
 		});
@@ -232,5 +280,14 @@ function createUserDataPath() {
 async function readStore(userDataPath: string): Promise<unknown> {
 	return JSON.parse(
 		await readFile(getWorkspaceSessionPath(userDataPath), "utf8"),
+	);
+}
+
+async function readRecoveryBackup(userDataPath: string): Promise<unknown> {
+	return JSON.parse(
+		await readFile(
+			path.join(userDataPath, WORKSPACE_SESSION_RECOVERY_BACKUP_FILE),
+			"utf8",
+		),
 	);
 }


### PR DESCRIPTION
## Summary

- add a packaged-app boot guard for workspace restore startup
- reset `workspace-session.json` on the next launch if the previous boot did not cleanly reach initial window creation and quit
- preserve the previous restore list once in `workspace-session.recovery-backup.json`
- add focused workspace-session recovery tests

## Why

Older FlashType versions can try to reopen very large saved workspaces on launch and OOM before users can recover. A stale boot guard now breaks that relaunch loop by clearing saved restore state while leaving explicit launch paths untouched.

## Validation

- `pnpm vitest run electron/workspace-session.test.ts`
- `pnpm run typecheck`
- `pnpm exec oxlint --tsconfig ./tsconfig.json --format stylish electron/main.mjs electron/workspace-session.mjs electron/workspace-session.test.ts`
- `pnpm exec prettier --check electron/main.mjs electron/workspace-session.mjs electron/workspace-session.test.ts electron/preload.mjs electron/types.d.ts src/main.tsx`

Note: full `pnpm run lint` still fails on an unrelated existing hook dependency issue in `website/src/routes/__root.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when workspace session is persisted and cleared on startup/shutdown; incorrect guard logic could drop restore state, though a one-time backup mitigates that.
> 
> **Overview**
> Adds a **packaged-app boot guard** so a crash or OOM during workspace restore does not trap users in a relaunch loop that keeps reopening huge saved workspaces.
> 
> On startup, if a `workspace-session-boot-in-progress` marker is still present from the last run, the app **backs up** `workspace-session.json` once to `workspace-session.recovery-backup.json`, then **clears** saved restore entries before reading the session. Each boot arms the marker at workspace lifecycle start and removes it only after **initial window creation** succeeds and the app quits cleanly.
> 
> **Quit behavior** changes so a failed boot (guard armed, windows never created) **skips** flushing open workspaces to disk, avoiding re-saving the same restore list that caused the failure. Explicit launch paths are unchanged; only persisted session restore is reset.
> 
> Unit tests cover no-op recovery without a guard and backup-once-then-clear when the guard is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8741b8b49b6762a57bf2d8d3d458273c66caa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->