### PR TITLE
[codex] Fix markdown list keyboard shortcuts

### DIFF
--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts
@@ -310,6 +310,85 @@ describe("Keyboard shortcuts (keymap)", () => {
 		expect(buildMarkdownFromEditor(editor)).toBe("- [ ] abc\n- [ ] \n");
 	});
 
+	test("Tab in bullet list indents the current item", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "parent" }],
+								},
+							],
+						},
+						{
+							type: "listItem",
+							content: [
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "child" }],
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		setCursorAfterText(editor, "child");
+		sendKey(editor, "Tab");
+
+		expect(buildMarkdownFromEditor(editor)).toBe("- parent\n  - child\n");
+	});
+
+	test("Shift-Tab in nested bullet list outdents the current item", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "parent" }],
+								},
+								{
+									type: "bulletList",
+									content: [
+										{
+											type: "listItem",
+											content: [
+												{
+													type: "paragraph",
+													content: [{ type: "text", text: "child" }],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		setCursorAfterText(editor, "child");
+		sendKey(editor, "Tab", { shift: true });
+
+		expect(buildMarkdownFromEditor(editor)).toBe("- parent\n- child\n");
+		typeText(editor, " updated");
+		expect(buildMarkdownFromEditor(editor)).toBe("- parent\n- child updated\n");
+	});
+
 	test("Enter on empty bullet list item exits the list", () => {
 		const editor = createEditor();
 		typeText(editor, "- ");
@@ -327,17 +406,111 @@ describe("Keyboard shortcuts (keymap)", () => {
 		expect(root.child(1).type.name).toBe("paragraph");
 	});
 
-	test("Backspace on empty bullet list item exits the list", () => {
+	test("Backspace on empty bullet list item removes the empty item", () => {
 		const editor = createEditor();
 		typeText(editor, "- ");
 		typeText(editor, "abc");
 		sendKey(editor, "Enter"); // create empty next item
 		sendKey(editor, "Backspace");
 		const root: any = editor.state.doc;
-		expect(root.childCount).toBe(2);
+		expect(root.childCount).toBe(1);
 		expect(root.child(0).type.name).toBe("bulletList");
 		expect(root.child(0).childCount).toBe(1);
-		expect(root.child(1).type.name).toBe("paragraph");
+		expect(buildMarkdownFromEditor(editor)).toBe("- abc\n");
+	});
+
+	test("double Backspace after empty bullet list item keeps the list intact", () => {
+		const editor = createEditor();
+		typeText(editor, "- ");
+		typeText(editor, "abc");
+		sendKey(editor, "Enter");
+		sendKey(editor, "Backspace");
+		sendKey(editor, "Backspace");
+		const root: any = editor.state.doc;
+		expect(root.childCount).toBe(1);
+		expect(root.child(0).type.name).toBe("bulletList");
+		expect(root.child(0).childCount).toBe(1);
+		expect(buildMarkdownFromEditor(editor)).toBe("- abc\n");
+	});
+
+	test("Backspace on empty nested bullet removes it without flattening parent", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "Hello world" }],
+								},
+								{
+									type: "bulletList",
+									content: [
+										{
+											type: "listItem",
+											content: [{ type: "paragraph" }],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		const docSize = editor.state.doc.content.size;
+		editor.commands.setTextSelection(docSize - 3);
+		sendKey(editor, "Backspace");
+		sendKey(editor, "Backspace");
+
+		expect(buildMarkdownFromEditor(editor)).toBe("- Hello world\n");
+	});
+
+	test("Backspace on empty list item with nested content keeps nested content", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{ type: "paragraph" },
+								{
+									type: "bulletList",
+									content: [
+										{
+											type: "listItem",
+											content: [
+												{
+													type: "paragraph",
+													content: [{ type: "text", text: "child" }],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		editor.commands.setTextSelection(3);
+		sendKey(editor, "Backspace");
+
+		const root: any = editor.state.doc;
+		const item = root.child(0).child(0);
+		expect(item.childCount).toBe(2);
+		expect(item.child(1).type.name).toBe("bulletList");
+		expect(buildMarkdownFromEditor(editor)).toContain("child");
 	});
 
 	test("Enter on empty ordered list item exits the list", () => {
@@ -354,7 +527,7 @@ describe("Keyboard shortcuts (keymap)", () => {
 		expect(root.child(1).type.name).toBe("paragraph");
 	});
 
-	test("Backspace on empty ordered list item exits the list", () => {
+	test("Backspace on empty ordered list item removes the empty item", () => {
 		const editor = createEditor();
 		typeText(editor, "1. ");
 		typeText(editor, "abc");
@@ -363,7 +536,7 @@ describe("Keyboard shortcuts (keymap)", () => {
 		const root: any = editor.state.doc;
 		expect(root.child(0).type.name).toBe("orderedList");
 		expect(root.child(0).childCount).toBe(1);
-		expect(root.child(1).type.name).toBe("paragraph");
+		expect(buildMarkdownFromEditor(editor)).toBe("1. abc\n");
 	});
 
 	test("Enter on empty todo item exits the list", () => {
@@ -380,7 +553,7 @@ describe("Keyboard shortcuts (keymap)", () => {
 		expect(root.child(1).type.name).toBe("paragraph");
 	});
 
-	test("Backspace on empty todo item exits the list", () => {
+	test("Backspace on empty todo item removes the empty item", () => {
 		const editor = createEditor();
 		typeText(editor, "[] ");
 		typeText(editor, "abc");
@@ -389,7 +562,7 @@ describe("Keyboard shortcuts (keymap)", () => {
 		const root: any = editor.state.doc;
 		expect(root.child(0).type.name).toBe("bulletList");
 		expect(root.child(0).childCount).toBe(1);
-		expect(root.child(1).type.name).toBe("paragraph");
+		expect(buildMarkdownFromEditor(editor)).toBe("- [ ] abc\n");
 	});
 
 	// Why this matters: Top-level ids are used for persistence/threading. Pressing Enter

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.ts
@@ -4,6 +4,7 @@ import {
 	textblockTypeInputRule,
 	wrappingInputRule,
 } from "@tiptap/core";
+import { TextSelection } from "@tiptap/pm/state";
 
 // Markdown-like typing shortcuts and editor keybindings
 // - "# ": Convert to heading (level by number of #)
@@ -186,6 +187,84 @@ export const MarkdownWcShortcuts = Extension.create({
 			"Cmd-Backspace": deletePreviousWord,
 			"Ctrl-Backspace": deletePreviousWord,
 
+			Tab: () => {
+				const { state } = this.editor;
+				const $from: any = state.selection.$from;
+				for (let d = $from.depth; d > 0; d--) {
+					if ($from.node(d)?.type?.name === "listItem") {
+						return this.editor.chain().focus().sinkListItem("listItem").run();
+					}
+				}
+				return false;
+			},
+
+			"Shift-Tab": () => {
+				const { state } = this.editor;
+				const $from: any = state.selection.$from;
+				let listItemDepth = -1;
+				for (let d = $from.depth; d > 0; d--) {
+					if ($from.node(d)?.type?.name === "listItem") {
+						listItemDepth = d;
+						break;
+					}
+				}
+				if (listItemDepth < 3) return false;
+
+				const listDepth = listItemDepth - 1;
+				const parentListItemDepth = listItemDepth - 2;
+				const listNode = $from.node(listDepth);
+				const listItem = $from.node(listItemDepth);
+				const parentListItem = $from.node(parentListItemDepth);
+				if (
+					(listNode?.type?.name !== "bulletList" &&
+						listNode?.type?.name !== "orderedList") ||
+					parentListItem?.type?.name !== "listItem"
+				) {
+					return false;
+				}
+
+				return this.editor.commands.command(({ tr, dispatch }) => {
+					const listFrom = $from.before(listDepth);
+					const listTo = $from.after(listDepth);
+					const parentListItemTo = $from.after(parentListItemDepth);
+					const listItemIndex = $from.index(listDepth);
+					const offsetInListItem = $from.pos - $from.before(listItemDepth);
+					const beforeItems = [];
+					const afterItems = [];
+					for (let index = 0; index < listNode.childCount; index++) {
+						const child = listNode.child(index);
+						if (index < listItemIndex) beforeItems.push(child);
+						if (index > listItemIndex) afterItems.push(child);
+					}
+
+					if (listNode.childCount === 1) {
+						tr.delete(listFrom, listTo);
+					} else {
+						const replacementLists = [];
+						if (beforeItems.length > 0) {
+							replacementLists.push(
+								listNode.type.create(listNode.attrs, beforeItems),
+							);
+						}
+						if (afterItems.length > 0) {
+							replacementLists.push(
+								listNode.type.create(listNode.attrs, afterItems),
+							);
+						}
+						tr.replaceWith(listFrom, listTo, replacementLists);
+					}
+
+					const mappedInsertPos = tr.mapping.map(parentListItemTo);
+					tr.insert(mappedInsertPos, listItem);
+					const mappedSelectionPos = mappedInsertPos + offsetInListItem;
+					tr.setSelection(
+						TextSelection.near(tr.doc.resolve(mappedSelectionPos)),
+					);
+					if (dispatch) dispatch(tr.scrollIntoView());
+					return true;
+				});
+			},
+
 			Backspace: () => {
 				const { state } = this.editor;
 				const { selection } = state;
@@ -208,7 +287,53 @@ export const MarkdownWcShortcuts = Extension.create({
 				if (listItemDepth < 0) return false;
 				if ($from.node(listItemDepth).firstChild !== para) return false;
 
-				return this.editor.chain().focus().liftListItem("listItem").run();
+				const listDepth = listItemDepth - 1;
+				const listNode = listDepth > 0 ? $from.node(listDepth) : null;
+				const listItem = $from.node(listItemDepth);
+				const listItemIndex = $from.index(listDepth);
+				if (listNode?.childCount > 1 && listItem.childCount === 1) {
+					return this.editor
+						.chain()
+						.focus()
+						.deleteRange({
+							from: $from.before(listItemDepth),
+							to: $from.after(listItemDepth),
+						})
+						.run();
+				}
+				if (
+					listDepth > 1 &&
+					listNode?.childCount === 1 &&
+					listItem.childCount === 1
+				) {
+					return this.editor
+						.chain()
+						.focus()
+						.deleteRange({
+							from: $from.before(listDepth),
+							to: $from.after(listDepth),
+						})
+						.run();
+				}
+				if (
+					listDepth === 1 &&
+					listNode?.childCount === 1 &&
+					listItemIndex === 0 &&
+					listItem.childCount === 1
+				) {
+					return this.editor
+						.chain()
+						.focus()
+						.deleteRange({
+							from: $from.before(listDepth),
+							to: $from.after(listDepth),
+						})
+						.insertContent({ type: "paragraph" })
+						.run();
+				}
+				if (listItem.childCount > 1) return true;
+
+				return false;
 			},
 
 			// Enter in list: create a new list item; for tasks, make it unchecked


### PR DESCRIPTION
## Summary

- add Tab indentation and Shift-Tab outdent behavior for markdown list items
- replace empty-list Backspace handling with schema-specific transforms instead of generic `liftListItem`
- update list shortcut tests for nested empty bullets, double Backspace, ordered lists, and todo lists
- update the Lix submodule pointer to `origin/main`

## Why

The custom markdown list schema can produce invalid or surprising document shapes when generic list lifting is used for empty list items. This caused double Backspace and nested empty bullets to flatten or corrupt lists. The new behavior edits the list structure directly for the cases FlashType supports.

## Validation

- `pnpm vitest run src/extensions/markdown/editor/tiptap-markdown-bridge/shortcuts.test.ts`
- touched-file oxlint for `shortcuts.ts` and `shortcuts.test.ts`
- prettier check for `shortcuts.ts` and `shortcuts.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom ProseMirror list transforms affect everyday editing and can corrupt document structure if edge cases are wrong, though scope is limited to markdown list keybindings with broad test coverage.
> 
> **Overview**
> **List keyboard shortcuts** in the TipTap markdown bridge now indent/outdent with **Tab** / **Shift-Tab** and handle **Backspace** on empty items without relying on generic `liftListItem`.
> 
> **Tab** sinks the current `listItem` when the cursor is in a list. **Shift-Tab** uses a custom transaction to move a nested item up to the parent list (splitting sibling lists when needed) and restore selection.
> 
> **Backspace** on an empty first paragraph inside a list item no longer always lifts the item. It deletes the empty row when the list has other siblings, removes a lone nested sublist, or converts a single top-level empty item into a plain paragraph; items that still have nested list content are left intact.
> 
> **Tests** in `shortcuts.test.ts` were updated for the new Backspace semantics and expanded for Tab, Shift-Tab, double Backspace, and nested empty bullets (bullet, ordered, and todo lists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b13acbe7cbff8d920e7eac45bd975755e6234279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->