### PR TITLE
[codex] Collapse file tree directories by default

### DIFF
--- a/src/extensions/files/file-tree.test.tsx
+++ b/src/extensions/files/file-tree.test.tsx
@@ -8,26 +8,49 @@ describe("FileTree", () => {
 		render(<FileTree nodes={mockTree} />);
 
 		expect(screen.getByText("docs")).toBeInTheDocument();
-		expect(screen.getByText("guides")).toBeInTheDocument();
-		expect(screen.getByText("writing-style.md")).toBeInTheDocument();
+		expect(screen.queryByText("guides")).toBeNull();
+		expect(screen.queryByText("writing-style.md")).toBeNull();
 	});
 
-	test("collapses and expands directories", () => {
+	test("starts directories collapsed", () => {
+		render(<FileTree nodes={mockTree} />);
+
+		const docsToggle = screen.getByRole("button", { name: /docs/i });
+		expect(docsToggle).toHaveAttribute("aria-expanded", "false");
+		expect(screen.queryByText("README.md")).toBeNull();
+	});
+
+	test("expands and collapses directories", () => {
 		render(<FileTree nodes={mockTree} />);
 
 		const docsToggle = screen.getByRole("button", { name: /docs/i });
 		fireEvent.click(docsToggle);
 
-		expect(screen.queryByText("guides")).toBeNull();
+		expect(screen.getByText("guides")).toBeInTheDocument();
 
 		fireEvent.click(docsToggle);
+		expect(screen.queryByText("guides")).toBeNull();
+	});
+
+	test("preserves opened directories when the tree data refreshes", () => {
+		const { rerender } = render(<FileTree nodes={mockTree} />);
+
+		const docsToggle = screen.getByRole("button", { name: /docs/i });
+		fireEvent.click(docsToggle);
+		const guidesToggle = screen.getByRole("button", { name: /guides/i });
+		fireEvent.click(guidesToggle);
+
+		expect(screen.getByText("writing-style.md")).toBeInTheDocument();
+
+		rerender(<FileTree nodes={mockTreeWithExternalFile} />);
+
 		expect(screen.getByText("guides")).toBeInTheDocument();
+		expect(screen.getByText("external.md")).toBeInTheDocument();
 	});
 
 	test("preserves collapsed directories when the tree data refreshes", () => {
 		const { rerender } = render(<FileTree nodes={mockTree} />);
 
-		fireEvent.click(screen.getByRole("button", { name: /docs/i }));
 		expect(screen.queryByText("guides")).toBeNull();
 
 		rerender(<FileTree nodes={mockTreeWithExternalFile} />);
@@ -60,6 +83,7 @@ describe("FileTree", () => {
 
 	test("keeps focus styling on file tree rows instead of filename labels", () => {
 		render(<FileTree nodes={mockTree} />);
+		fireEvent.click(screen.getByRole("button", { name: /docs/i }));
 
 		const fileRow = screen.getByRole("button", { name: /README.md/i });
 		const fileName = screen.getByText("README.md");

--- a/src/extensions/files/file-tree.tsx
+++ b/src/extensions/files/file-tree.tsx
@@ -55,29 +55,9 @@ export function FileTree({
 	isPanelFocused = false,
 	onSelectItem,
 }: FileTreeProps) {
-	const directoryPaths = useMemo(() => collectDirectoryPaths(nodes), [nodes]);
 	const [openDirectories, setOpenDirectories] = useState(
-		() => new Set(directoryPaths),
+		() => new Set<string>(),
 	);
-	const knownDirectoryPathsRef = useRef(new Set(directoryPaths));
-
-	useEffect(() => {
-		const knownDirectoryPaths = knownDirectoryPathsRef.current;
-		const nextDirectoryPaths = new Set(directoryPaths);
-		const newDirectoryPaths = directoryPaths.filter(
-			(path) => !knownDirectoryPaths.has(path),
-		);
-		knownDirectoryPathsRef.current = nextDirectoryPaths;
-		if (newDirectoryPaths.length === 0) return;
-		setOpenDirectories((prev) => {
-			const next = new Set(prev);
-			for (const path of newDirectoryPaths) {
-				next.add(path);
-			}
-			return next;
-		});
-	}, [directoryPaths]);
-
 	const sortedNodes = useMemo(() => sortNodes(nodes), [nodes]);
 
 	const toggleDirectory = useCallback((path: string) => {
@@ -347,17 +327,6 @@ function sortNodes(nodes: FilesystemTreeNode[]): FilesystemTreeNode[] {
 		}
 		return a.type === "directory" ? -1 : 1;
 	});
-}
-
-function collectDirectoryPaths(nodes: FilesystemTreeNode[]): string[] {
-	const paths: string[] = [];
-	for (const node of nodes) {
-		if (node.type === "directory") {
-			paths.push(node.path);
-			paths.push(...collectDirectoryPaths(node.children));
-		}
-	}
-	return paths;
 }
 
 function formatDisplayName(name: string): string {


### PR DESCRIPTION
## Summary
- Start file tree directories collapsed by default.
- Stop auto-opening newly discovered directories during tree refreshes.
- Update file tree tests for collapsed defaults and refresh behavior.

## Validation
- `pnpm vitest run src/extensions/files/file-tree.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to file tree expand/collapse defaults with no auth, data, or API impact.
> 
> **Overview**
> **File tree directories now start collapsed** instead of expanding every folder on load. User toggles still control open/closed state, and that state is kept across tree data refreshes.
> 
> **Removed auto-expand on refresh**: newly discovered directory paths are no longer added to `openDirectories` when the filesystem tree updates—only paths the user explicitly opened stay open.
> 
> Tests were updated for collapsed defaults, expand/collapse, and refresh behavior (opened vs collapsed preservation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2203a66cb3fcffe54385bfbebeb8e0435d1b27b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->