### PR TITLE
[codex] Reject oversized workspace folders

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -8,10 +8,12 @@ import { fileURLToPath } from "node:url";
 import {
 	applyWorkspaceWindowChrome,
 	getWorkspace,
+	isWorkspaceTooLargeError,
 	registerWorkspaceIpc,
 	resolveDirectLaunchWorkspaceTargets,
 	resolveWorkspaceTargets,
 	setWorkspaceFromTarget,
+	showWorkspaceTooLargeWarning,
 } from "./workspace.mjs";
 import {
 	captureAppLaunched,
@@ -188,6 +190,7 @@ async function openWorkspaceRequests(
 	workspaceRequests,
 	{ requestedSource = "direct_launch" } = {},
 ) {
+	let openedWindowCount = 0;
 	const requestsBySource = new Map();
 	for (const workspaceRequest of workspaceRequests) {
 		const taggedRequest = normalizeWorkspaceOpenRequest(
@@ -200,14 +203,24 @@ async function openWorkspaceRequests(
 	}
 
 	for (const [source, requests] of requestsBySource) {
-		const workspaceTargets =
-			await resolveDirectLaunchWorkspaceTargets(requests);
+		let workspaceTargets;
+		try {
+			workspaceTargets = await resolveDirectLaunchWorkspaceTargets(requests);
+		} catch (error) {
+			if (isWorkspaceTooLargeError(error)) {
+				await showWorkspaceTooLargeWarning(null, error);
+				continue;
+			}
+			throw error;
+		}
 		for (const workspaceTarget of workspaceTargets) {
 			await createMainWindow(
 				withWorkspaceOpenTelemetry(workspaceTarget, source),
 			);
+			openedWindowCount += 1;
 		}
 	}
+	return openedWindowCount;
 }
 
 function createWorkspaceOpenRequest(request, requestedSource) {
@@ -836,7 +849,12 @@ async function startWorkspaceLifecycle() {
 	readyForWorkspaceOpens = true;
 	try {
 		if (taggedWorkspaceRequestsToOpen.length > 0) {
-			await openWorkspaceRequests(taggedWorkspaceRequestsToOpen);
+			const openedWindowCount = await openWorkspaceRequests(
+				taggedWorkspaceRequestsToOpen,
+			);
+			if (openedWindowCount === 0) {
+				await createMainWindow();
+			}
 		} else {
 			await createMainWindow();
 		}

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -1,10 +1,13 @@
 import { dialog, ipcMain } from "electron";
 import path from "node:path";
-import { readFile, stat } from "node:fs/promises";
+import { lstat, opendir, readFile, stat } from "node:fs/promises";
 
 const LIX_DATABASE_FILE = path.join(".lix", ".internal", "db.sqlite");
 const LEGACY_LIX_DATABASE_FILE = path.join(".lix", "db.sqlite");
 const LIX_DATABASE_FILES = [LIX_DATABASE_FILE, LEGACY_LIX_DATABASE_FILE];
+export const MAX_WORKSPACE_SIZE_BYTES = 100 * 1024 * 1024;
+export const WORKSPACE_TOO_LARGE_ERROR_CODE =
+	"ERR_FLASHTYPE_WORKSPACE_TOO_LARGE";
 
 /**
  * The workspace is the folder Flashtype operates on. Each window has at most
@@ -25,40 +28,45 @@ export function getWorkspace(window) {
  */
 export async function resolveWorkspaceTarget(requestedPath, options = {}) {
 	const resolved = path.resolve(requestedPath);
+	let stats = null;
 	try {
-		const stats = await stat(resolved);
-		if (stats.isFile()) {
-			if (options.openFilesAsTransient === true) {
-				const workspace = createTransientDirectoryWorkspace([resolved]);
-				return {
-					workspace,
-					pendingOpenFilePaths:
-						pendingOpenFilePathsForTransientDirectoryWorkspace(workspace),
-				};
-			}
-			const workspaceDir = await findLixWorkspaceRoot(path.dirname(resolved));
-			if (!workspaceDir) {
-				const workspace = createTransientDirectoryWorkspace([resolved]);
-				return {
-					workspace,
-					pendingOpenFilePaths:
-						pendingOpenFilePathsForTransientDirectoryWorkspace(workspace),
-				};
-			}
-			return {
-				workspace: {
-					ephemeral: false,
-					path: workspaceDir,
-					name: path.basename(workspaceDir),
-				},
-				pendingOpenFilePaths: [
-					toPortableRelativePath(path.relative(workspaceDir, resolved)),
-				],
-			};
-		}
+		stats = await stat(resolved);
 	} catch {
 		// Keep the resolved path for directories and unreadable paths; the lix
 		// backend reports unreadable workspace folders.
+	}
+	if (stats?.isFile()) {
+		if (options.openFilesAsTransient === true) {
+			const workspace = createTransientDirectoryWorkspace([resolved]);
+			return {
+				workspace,
+				pendingOpenFilePaths:
+					pendingOpenFilePathsForTransientDirectoryWorkspace(workspace),
+			};
+		}
+		const workspaceDir = await findLixWorkspaceRoot(path.dirname(resolved));
+		if (!workspaceDir) {
+			const workspace = createTransientDirectoryWorkspace([resolved]);
+			return {
+				workspace,
+				pendingOpenFilePaths:
+					pendingOpenFilePathsForTransientDirectoryWorkspace(workspace),
+			};
+		}
+		await assertWorkspaceDirectorySizeWithinLimit(workspaceDir, options);
+		return {
+			workspace: {
+				ephemeral: false,
+				path: workspaceDir,
+				name: path.basename(workspaceDir),
+			},
+			pendingOpenFilePaths: [
+				toPortableRelativePath(path.relative(workspaceDir, resolved)),
+			],
+		};
+	}
+	if (stats?.isDirectory()) {
+		await assertWorkspaceDirectorySizeWithinLimit(resolved, options);
 	}
 	return {
 		workspace: {
@@ -254,6 +262,104 @@ async function resolveWorkspaceSessionEntry(workspaceEntry) {
 		};
 	}
 	return null;
+}
+
+async function assertWorkspaceDirectorySizeWithinLimit(
+	workspaceDir,
+	options = {},
+) {
+	const maxSizeBytes =
+		options.maxWorkspaceSizeBytes ?? MAX_WORKSPACE_SIZE_BYTES;
+	if (
+		typeof maxSizeBytes !== "number" ||
+		!Number.isFinite(maxSizeBytes) ||
+		maxSizeBytes <= 0
+	) {
+		return;
+	}
+	const sizeBytes = await directorySizeBytes(workspaceDir, maxSizeBytes);
+	if (sizeBytes <= maxSizeBytes) {
+		return;
+	}
+	throw createWorkspaceTooLargeError(workspaceDir, maxSizeBytes);
+}
+
+async function directorySizeBytes(directoryPath, stopAfterBytes) {
+	let totalBytes = 0;
+	const pendingDirectories = [directoryPath];
+	while (pendingDirectories.length > 0 && totalBytes <= stopAfterBytes) {
+		const currentDirectory = pendingDirectories.pop();
+		let directory;
+		try {
+			directory = await opendir(currentDirectory);
+		} catch {
+			continue;
+		}
+		for await (const entry of directory) {
+			const entryPath = path.join(currentDirectory, entry.name);
+			let stats;
+			try {
+				stats = await lstat(entryPath);
+			} catch {
+				continue;
+			}
+			if (stats.isSymbolicLink()) {
+				continue;
+			}
+			if (stats.isDirectory()) {
+				pendingDirectories.push(entryPath);
+				continue;
+			}
+			if (stats.isFile()) {
+				totalBytes += stats.size;
+				if (totalBytes > stopAfterBytes) {
+					break;
+				}
+			}
+		}
+	}
+	return totalBytes;
+}
+
+function createWorkspaceTooLargeError(workspaceDir, maxSizeBytes) {
+	const error = new Error(
+		`The folder "${path.basename(workspaceDir) || workspaceDir}" is too large for Flashtype to open. Please open a smaller folder. Flashtype currently supports folders up to ${formatBytes(maxSizeBytes)}.`,
+	);
+	error.code = WORKSPACE_TOO_LARGE_ERROR_CODE;
+	error.workspacePath = workspaceDir;
+	error.maxSizeBytes = maxSizeBytes;
+	return error;
+}
+
+export function isWorkspaceTooLargeError(error) {
+	return error?.code === WORKSPACE_TOO_LARGE_ERROR_CODE;
+}
+
+export async function showWorkspaceTooLargeWarning(window, error) {
+	const message =
+		error instanceof Error
+			? error.message
+			: "This folder is too large for Flashtype to open. Please open a smaller folder.";
+	const options = {
+		type: "warning",
+		title: "Folder too large",
+		message: "Folder too large",
+		detail: message,
+		buttons: ["OK"],
+	};
+	if (window && !window.isDestroyed()) {
+		await dialog.showMessageBox(window, options);
+		return;
+	}
+	await dialog.showMessageBox(options);
+}
+
+function formatBytes(bytes) {
+	const mib = bytes / 1024 / 1024;
+	if (Number.isInteger(mib)) {
+		return `${mib} MB`;
+	}
+	return `${mib.toFixed(1)} MB`;
 }
 
 async function resolveStandaloneFile(resolvedPath, options = {}) {

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import {
+	WORKSPACE_TOO_LARGE_ERROR_CODE,
 	resolveDirectLaunchWorkspaceTargets,
 	resolveWorkspace,
 	resolveWorkspaceTarget,
@@ -32,6 +33,47 @@ describe("workspace resolution", () => {
 		});
 	});
 
+	test("rejects directory workspaces over the size limit", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		await mkdir(directory, { recursive: true });
+		await writeFile(path.join(directory, "large.md"), Buffer.alloc(11));
+
+		await expect(
+			resolveWorkspaceTarget(directory, { maxWorkspaceSizeBytes: 10 }),
+		).rejects.toMatchObject({
+			code: WORKSPACE_TOO_LARGE_ERROR_CODE,
+			workspacePath: directory,
+			maxSizeBytes: 10,
+		});
+	});
+
+	test("allows directory workspaces at the size limit", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		await mkdir(directory, { recursive: true });
+		await writeFile(path.join(directory, "small.md"), Buffer.alloc(10));
+
+		await expect(
+			resolveWorkspaceTarget(directory, { maxWorkspaceSizeBytes: 10 }),
+		).resolves.toEqual({
+			workspace: {
+				ephemeral: false,
+				path: directory,
+				name: "workspace",
+			},
+			pendingOpenFilePaths: [],
+		});
+	});
+
 	test("resolves a file inside a Lix workspace to the workspace root", async () => {
 		const directory = path.join(
 			tmpdir(),
@@ -48,6 +90,28 @@ describe("workspace resolution", () => {
 			ephemeral: false,
 			path: directory,
 			name: "workspace",
+		});
+	});
+
+	test("rejects files that resolve to an oversized Lix workspace root", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		const filePath = path.join(directory, "readme.md");
+		await mkdir(path.join(directory, ".lix", ".internal"), { recursive: true });
+		await writeFile(path.join(directory, ".lix", ".internal", "db.sqlite"), "");
+		await writeFile(filePath, "# Hello\n");
+		await writeFile(path.join(directory, "large.md"), Buffer.alloc(11));
+
+		await expect(
+			resolveWorkspaceTarget(filePath, { maxWorkspaceSizeBytes: 10 }),
+		).rejects.toMatchObject({
+			code: WORKSPACE_TOO_LARGE_ERROR_CODE,
+			workspacePath: directory,
+			maxSizeBytes: 10,
 		});
 	});
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import {
 	useState,
 } from "react";
 import { createRoot } from "react-dom/client";
+import { AlertTriangle } from "lucide-react";
 import "./index.css";
 import { LixProvider } from "@/lib/lix-react";
 import type { Lix } from "@/lib/lix-types";
@@ -28,6 +29,7 @@ type Workspace = Awaited<
 >;
 
 const WORKSPACE_ACTIVE_SIGNAL_THROTTLE_MS = 30 * 60 * 1000;
+const WORKSPACE_TOO_LARGE_ERROR_CODE = "ERR_FLASHTYPE_WORKSPACE_TOO_LARGE";
 
 /**
  * The workspace gates the app: without a folder, only the first-run screen
@@ -41,6 +43,9 @@ export const AppRoot = () => {
 		[],
 	);
 	const [error, setError] = useState<unknown>(null);
+	const [workspaceOpenWarning, setWorkspaceOpenWarning] = useState<
+		string | null
+	>(null);
 	const [isUpdateReady, setIsUpdateReady] = useState(false);
 
 	useEffect(() => {
@@ -116,6 +121,12 @@ export const AppRoot = () => {
 					await lix.close();
 				}
 				setWorkspace(opened);
+			} catch (error) {
+				if (isWorkspaceTooLargeError(error)) {
+					setWorkspaceOpenWarning(formatWorkspaceOpenWarning(error));
+					return;
+				}
+				setError(error);
 			} finally {
 				openFolderInFlightRef.current = false;
 			}
@@ -257,40 +268,160 @@ export const AppRoot = () => {
 			current.filter((pendingFilePath) => pendingFilePath !== filePath),
 		);
 	}, []);
+	const closeWorkspaceOpenWarning = useCallback(() => {
+		setWorkspaceOpenWarning(null);
+	}, []);
 
 	if (error) return <ErrorFallback error={error} />;
 	if (workspace === undefined) return <BootPlaceholder />;
-	if (workspace === null)
+	if (workspace === null) {
 		return (
-			<FirstRunScreen
-				onOpenFolder={handleOpenFolder}
-				isUpdateReady={isUpdateReady}
-				onInstallUpdate={handleInstallUpdate}
-			/>
+			<>
+				<WorkspaceOpenWarningDialog
+					message={workspaceOpenWarning}
+					onClose={closeWorkspaceOpenWarning}
+				/>
+				<FirstRunScreen
+					onOpenFolder={handleOpenFolder}
+					isUpdateReady={isUpdateReady}
+					onInstallUpdate={handleInstallUpdate}
+				/>
+			</>
 		);
+	}
 	if (!lix) return <BootPlaceholder />;
 
 	return (
-		<LixProvider lix={lix}>
-			<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
-				<Suspense fallback={<BootPlaceholder />}>
-					<V2LayoutShell
-						workspaceName={workspace.name}
-						onOpenWorkspace={handleOpenFolder}
-						pendingOpenFilePaths={pendingOpenFilePaths}
-						onPendingOpenFileHandled={handlePendingOpenFileHandled}
-						onError={setError}
-						isUpdateReady={isUpdateReady}
-						onInstallUpdate={handleInstallUpdate}
-					/>
-				</Suspense>
-			</KeyValueProvider>
-		</LixProvider>
+		<>
+			<WorkspaceOpenWarningDialog
+				message={workspaceOpenWarning}
+				onClose={closeWorkspaceOpenWarning}
+			/>
+			<LixProvider lix={lix}>
+				<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
+					<Suspense fallback={<BootPlaceholder />}>
+						<V2LayoutShell
+							workspaceName={workspace.name}
+							onOpenWorkspace={handleOpenFolder}
+							pendingOpenFilePaths={pendingOpenFilePaths}
+							onPendingOpenFileHandled={handlePendingOpenFileHandled}
+							onError={setError}
+							isUpdateReady={isUpdateReady}
+							onInstallUpdate={handleInstallUpdate}
+						/>
+					</Suspense>
+				</KeyValueProvider>
+			</LixProvider>
+		</>
 	);
 };
 
 function BootPlaceholder() {
 	return <div className="h-dvh w-full bg-[var(--color-bg-app)]" />;
+}
+
+function WorkspaceOpenWarningDialog({
+	message,
+	onClose,
+}: {
+	readonly message: string | null;
+	readonly onClose: () => void;
+}) {
+	const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (!message) return;
+		closeButtonRef.current?.focus();
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				onClose();
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [message, onClose]);
+
+	if (!message) return null;
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-6 backdrop-blur-[2px]"
+			role="presentation"
+			onMouseDown={(event) => {
+				if (event.target === event.currentTarget) {
+					onClose();
+				}
+			}}
+		>
+			<div
+				role="alertdialog"
+				aria-modal="true"
+				aria-labelledby="workspace-open-warning-title"
+				aria-describedby="workspace-open-warning-description"
+				className="w-full max-w-md rounded-lg border border-[var(--color-border-panel)] bg-[var(--color-bg-panel)] p-5 text-[var(--color-text-primary)] shadow-2xl"
+			>
+				<div className="flex items-start gap-3">
+					<div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--color-bg-notice-warning)] text-[var(--color-text-notice-warning)]">
+						<AlertTriangle className="size-5" strokeWidth={2} />
+					</div>
+					<div className="min-w-0">
+						<h1
+							id="workspace-open-warning-title"
+							className="text-base font-semibold leading-6"
+						>
+							Folder too large
+						</h1>
+						<p
+							id="workspace-open-warning-description"
+							className="mt-1 text-sm leading-5 text-[var(--color-text-secondary)]"
+						>
+							{message}
+						</p>
+					</div>
+				</div>
+				<div className="mt-5 flex justify-end">
+					<button
+						ref={closeButtonRef}
+						type="button"
+						className="inline-flex h-8 items-center justify-center rounded-md bg-[var(--color-bg-action-primary)] px-3 text-sm font-medium text-[var(--color-text-on-action-primary)] transition-colors hover:bg-[var(--color-bg-action-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)]"
+						onClick={onClose}
+					>
+						OK
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function isWorkspaceTooLargeError(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+	const maybeError = error as { code?: unknown; message?: unknown };
+	return (
+		maybeError.code === WORKSPACE_TOO_LARGE_ERROR_CODE ||
+		(typeof maybeError.message === "string" &&
+			(maybeError.message.includes(WORKSPACE_TOO_LARGE_ERROR_CODE) ||
+				maybeError.message.includes("too large for Flashtype to open")))
+	);
+}
+
+function formatWorkspaceOpenWarning(error: unknown): string {
+	if (
+		error &&
+		typeof error === "object" &&
+		typeof (error as { message?: unknown }).message === "string"
+	) {
+		return stripIpcErrorPrefix((error as { message: string }).message);
+	}
+	return "This folder is too large for Flashtype to open. Please open a smaller folder.";
+}
+
+function stripIpcErrorPrefix(message: string): string {
+	return message
+		.replace(/^Error invoking remote method '[^']+':\s*/u, "")
+		.replace(/^Error:\s*/u, "")
+		.trim();
 }
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary
- Reject folder workspaces over 100 MB before Flashtype opens them.
- Show a warning asking the user to choose a smaller folder for picker, launch, restored-session, and renderer-triggered opens.
- Keep the app on the first-run screen when all restored/launched folders are skipped.
- Add focused workspace resolver tests with a tiny size limit.

## Validation
- `pnpm vitest run electron/workspace.test.ts`
- `pnpm exec tsc -p . --pretty false --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workspace-open paths (launch, restore, picker) and adds filesystem traversal on every directory resolve; mis-sizing or perf on huge trees could block legitimate opens.
> 
> **Overview**
> Adds a **100 MB** cap on **persistent directory workspaces** before Flashtype opens them. `resolveWorkspaceTarget` walks the folder (skipping symlinks, stopping once over the limit) and throws `ERR_FLASHTYPE_WORKSPACE_TOO_LARGE` for oversized paths, including when a file open resolves to a Lix workspace root. **Transient** direct-launch file workspaces are unchanged.
> 
> **Electron main** catches that error during launch/restore batches, shows a native **Folder too large** dialog, skips those targets, and returns how many windows opened; if every restored/launched folder is skipped, it still opens an empty window so the user lands on first-run instead of no UI.
> 
> **Renderer** treats the same error from the folder picker IPC as a non-fatal **alert dialog** (not the global error screen) on first-run and when switching workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b850056e6cfce95808983ee95418d3dec5ee74c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->