### PR TITLE
[codex] Update Lix submodule to main

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,6 +42,11 @@ jobs:
           node-version: ${{ matrix.version }}
           cache: "pnpm"
 
+      - name: Install native Lix build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev llvm-dev
+
       - name: Validate submodule branches
         run: |
           git submodule foreach '
@@ -126,6 +131,17 @@ jobs:
         with:
           node-version: 22
           cache: "pnpm"
+
+      - name: Configure native Lix build dependencies
+        run: |
+          brew list llvm >/dev/null 2>&1 || brew install llvm
+          LLVM_PREFIX="$(brew --prefix llvm)"
+          {
+            echo "LIBCLANG_PATH=$LLVM_PREFIX/lib"
+            echo "LLVM_CONFIG_PATH=$LLVM_PREFIX/bin/llvm-config"
+            echo "DYLD_LIBRARY_PATH=$LLVM_PREFIX/lib:${DYLD_LIBRARY_PATH:-}"
+            echo "DYLD_FALLBACK_LIBRARY_PATH=$LLVM_PREFIX/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+          } >> "$GITHUB_ENV"
 
       - name: Install Rust wasm target
         run: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -78,6 +78,17 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Configure native Lix build dependencies
+        run: |
+          brew list llvm >/dev/null 2>&1 || brew install llvm
+          LLVM_PREFIX="$(brew --prefix llvm)"
+          {
+            echo "LIBCLANG_PATH=$LLVM_PREFIX/lib"
+            echo "LLVM_CONFIG_PATH=$LLVM_PREFIX/bin/llvm-config"
+            echo "DYLD_LIBRARY_PATH=$LLVM_PREFIX/lib:${DYLD_LIBRARY_PATH:-}"
+            echo "DYLD_FALLBACK_LIBRARY_PATH=$LLVM_PREFIX/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+          } >> "$GITHUB_ENV"
+
       - name: Install Rust wasm target
         run: |
           if ! command -v rustup >/dev/null 2>&1; then

--- a/src/extensions/csv/index.tsx
+++ b/src/extensions/csv/index.tsx
@@ -39,6 +39,12 @@ type CsvViewProps = {
 const COLUMN_MIN_WIDTH = 72;
 const ROW_HEIGHT = 48;
 
+type CsvFileRow = {
+	readonly id: string;
+	readonly path: string;
+	readonly data: Uint8Array;
+};
+
 export function CsvView({
 	fileId,
 	externalWriteReview = null,
@@ -61,28 +67,16 @@ export function CsvView({
 	);
 }
 
-function CsvViewContent({
-	fileId,
-	externalWriteReview = null,
-	isActiveView = true,
-	isPanelFocused = true,
-	onAcceptReview,
-	onRejectReview,
-}: CsvViewProps) {
+function CsvViewContent({ fileId, ...props }: CsvViewProps) {
 	assertFileId(fileId);
 
-	const fileRow = useQueryTakeFirst((lix) =>
+	const fileRow = useQueryTakeFirst<CsvFileRow>((lix) =>
 		qb(lix)
 			.selectFrom("lix_file")
 			.select(["id", "path", "data"])
 			.where("id", "=", fileId)
 			.limit(1),
 	);
-
-	const parsed = useMemo<CsvParseResult | null>(() => {
-		if (!fileRow) return null;
-		return parseCsv(decodeFileDataToText(fileRow.data));
-	}, [fileRow]);
 
 	if (!fileRow) {
 		return (
@@ -92,7 +86,24 @@ function CsvViewContent({
 		);
 	}
 
-	if (!parsed || parsed.columns.length === 0) {
+	return <CsvViewLoaded fileRow={fileRow} {...props} />;
+}
+
+function CsvViewLoaded({
+	fileRow,
+	externalWriteReview = null,
+	isActiveView = true,
+	isPanelFocused = true,
+	onAcceptReview,
+	onRejectReview,
+}: Omit<CsvViewProps, "fileId"> & {
+	readonly fileRow: CsvFileRow;
+}) {
+	const parsed = useMemo<CsvParseResult>(() => {
+		return parseCsv(decodeFileDataToText(fileRow.data));
+	}, [fileRow]);
+
+	if (parsed.columns.length === 0) {
 		return <CsvEmptyState filePath={fileRow.path} />;
 	}
 

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -32,6 +32,17 @@ function isUserPath(path: string): boolean {
 	return !path.startsWith("/.lix/");
 }
 
+async function waitForFilesViewReady(utils: ReturnType<typeof render>) {
+	for (let i = 0; i < 20; i += 1) {
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		});
+		const button = utils.queryByRole("button", { name: "New file" });
+		if (button) return button;
+	}
+	throw new Error("Files view did not finish loading");
+}
+
 describe("FilesView", () => {
 	beforeAll(() => {
 		setNavigatorPlatform("MacIntel");
@@ -61,7 +72,8 @@ describe("FilesView", () => {
 			);
 		});
 
-		expect(await utils!.findByRole("button", { name: "New file" })).toHaveClass(
+		await waitForFilesViewReady(utils!);
+		expect(utils!.getByRole("button", { name: "New file" })).toHaveClass(
 			"select-none",
 		);
 
@@ -83,6 +95,7 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
 
 		const initialRows = await qb(lix)
 			.selectFrom("lix_file")
@@ -201,6 +214,7 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
 			fireEvent.keyDown(document, { key: ".", metaKey: true });
@@ -645,6 +659,7 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
 			fireEvent.keyDown(document, { key: ".", metaKey: true });
@@ -693,6 +708,7 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
 			fireEvent.keyDown(document, {
@@ -744,6 +760,7 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
 			fireEvent.keyDown(document, { key: ".", ctrlKey: true });
@@ -776,6 +793,7 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
 			fireEvent.keyDown(document, {
@@ -813,6 +831,7 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
 			fireEvent.keyDown(document, { key: ".", metaKey: true });

--- a/src/extensions/markdown/editor/create-editor.test.ts
+++ b/src/extensions/markdown/editor/create-editor.test.ts
@@ -230,14 +230,12 @@ test("paste at end inserts after existing content (TipTap + Lix)", async () => {
 			},
 		},
 	});
-	await new Promise((r) => setTimeout(r, 0));
 
-	const fileAfter = await qb(lix)
-		.selectFrom("lix_file")
-		.where("id", "=", fileId)
-		.selectAll()
-		.executeTakeFirst();
-	const mdAfter = new TextDecoder().decode(fileAfter?.data ?? new Uint8Array());
+	const mdAfter = await waitForMarkdown(
+		lix,
+		fileId,
+		(markdown) => markdown === ensureTrailingNewline("Start\n\nNew"),
+	);
 	expect(mdAfter).toBe(ensureTrailingNewline("Start\n\nNew"));
 	editor.destroy();
 });
@@ -271,14 +269,13 @@ test("replace word selection with paste (TipTap + Lix)", async () => {
 			},
 		},
 	});
-	await new Promise((r) => setTimeout(r, 0));
 
-	const fileAfter = await qb(lix)
-		.selectFrom("lix_file")
-		.where("id", "=", fileId)
-		.selectAll()
-		.executeTakeFirst();
-	const mdAfter = new TextDecoder().decode(fileAfter?.data ?? new Uint8Array());
+	const mdAfter = await waitForMarkdown(
+		lix,
+		fileId,
+		(markdown) =>
+			markdown === ensureTrailingNewline("Replace new content here."),
+	);
 	expect(mdAfter).toBe(ensureTrailingNewline("Replace new content here."));
 	editor.destroy();
 });
@@ -312,14 +309,14 @@ test("replace entire document with paste (TipTap + Lix)", async () => {
 			},
 		},
 	});
-	await new Promise((r) => setTimeout(r, 0));
 
-	const fileAfter = await qb(lix)
-		.selectFrom("lix_file")
-		.where("id", "=", fileId)
-		.selectAll()
-		.executeTakeFirst();
-	const mdAfter = new TextDecoder().decode(fileAfter?.data ?? new Uint8Array());
+	const mdAfter = await waitForMarkdown(
+		lix,
+		fileId,
+		(markdown) =>
+			markdown ===
+			ensureTrailingNewline("# New Document\n\nCompletely new content"),
+	);
 	expect(mdAfter).toBe(
 		ensureTrailingNewline("# New Document\n\nCompletely new content"),
 	);
@@ -355,15 +352,12 @@ test("paste multi-paragraph plain text into empty doc (TipTap + Lix)", async () 
 		},
 	});
 
-	await new Promise((r) => setTimeout(r, 0));
-
-	const fileAfter = await qb(lix)
-		.selectFrom("lix_file")
-		.where("id", "=", fileId)
-		.selectAll()
-		.executeTakeFirst();
-
-	const mdAfter = new TextDecoder().decode(fileAfter?.data ?? new Uint8Array());
+	const mdAfter = await waitForMarkdown(
+		lix,
+		fileId,
+		(markdown) =>
+			markdown === ensureTrailingNewline("First line\n\nSecond line"),
+	);
 	expect(mdAfter).toBe(ensureTrailingNewline("First line\n\nSecond line"));
 	editor.destroy();
 });
@@ -486,13 +480,11 @@ test("normalize CRLF line endings on paste (TipTap + Lix)", async () => {
 			},
 		},
 	});
-	await new Promise((r) => setTimeout(r, 0));
-	const fileAfter = await qb(lix)
-		.selectFrom("lix_file")
-		.where("id", "=", fileId)
-		.selectAll()
-		.executeTakeFirst();
-	const mdAfter = new TextDecoder().decode(fileAfter?.data ?? new Uint8Array());
+	const mdAfter = await waitForMarkdown(
+		lix,
+		fileId,
+		(markdown) => markdown === ensureTrailingNewline("Line one\n\nLine two"),
+	);
 	expect(mdAfter).toBe(ensureTrailingNewline("Line one\n\nLine two"));
 	editor.destroy();
 });
@@ -523,13 +515,16 @@ test("paste complex markdown with lists and code blocks (TipTap + Lix)", async (
 			},
 		},
 	});
-	await new Promise((r) => setTimeout(r, 0));
-	const fileAfter = await qb(lix)
-		.selectFrom("lix_file")
-		.where("id", "=", fileId)
-		.selectAll()
-		.executeTakeFirst();
-	const mdAfter = new TextDecoder().decode(fileAfter?.data ?? new Uint8Array());
+	const mdAfter = await waitForMarkdown(
+		lix,
+		fileId,
+		(markdown) =>
+			markdown.includes("# Title") &&
+			markdown.includes("- Item 1") &&
+			markdown.includes("- Item 2") &&
+			markdown.includes("```javascript") &&
+			markdown.includes("const x = 1;"),
+	);
 	expect(mdAfter).toContain("# Title");
 	expect(mdAfter).toContain("- Item 1");
 	expect(mdAfter).toContain("- Item 2");
@@ -564,13 +559,11 @@ test("paste inline formatting markdown (TipTap + Lix)", async () => {
 			},
 		},
 	});
-	await new Promise((r) => setTimeout(r, 0));
-	const fileAfter = await qb(lix)
-		.selectFrom("lix_file")
-		.where("id", "=", fileId)
-		.selectAll()
-		.executeTakeFirst();
-	const mdAfter = new TextDecoder().decode(fileAfter?.data ?? new Uint8Array());
+	const mdAfter = await waitForMarkdown(
+		lix,
+		fileId,
+		(markdown) => markdown === ensureTrailingNewline(input),
+	);
 	expect(mdAfter).toBe(ensureTrailingNewline(input));
 	editor.destroy();
 });

--- a/src/extensions/markdown/editor/handle-paste.test.ts
+++ b/src/extensions/markdown/editor/handle-paste.test.ts
@@ -99,8 +99,8 @@ describe("handlePaste - cursor position insertion", () => {
 			],
 		});
 
-		// Set cursor between paragraphs
-		editor.commands.setTextSelection(12);
+		// Set cursor at the end of the first paragraph.
+		editor.commands.setTextSelection(11);
 
 		const ok = await handlePaste({
 			editor,
@@ -146,8 +146,8 @@ describe("handlePaste - selection replacement", () => {
 			],
 		});
 
-		// Select "Line two" paragraph
-		editor.commands.setTextSelection({ from: 10, to: 19 });
+		// Select "Line two" paragraph text.
+		editor.commands.setTextSelection({ from: 11, to: 19 });
 
 		const ok = await handlePaste({
 			editor,

--- a/src/extensions/markdown/index.test.tsx
+++ b/src/extensions/markdown/index.test.tsx
@@ -366,7 +366,7 @@ describe("MarkdownView", () => {
 			);
 		});
 
-		expect(screen.getByText(/file not found/i)).toBeInTheDocument();
+		expect(await screen.findByText(/file not found/i)).toBeInTheDocument();
 		expect(screen.queryByTestId("tiptap-editor")).not.toBeInTheDocument();
 
 		await act(async () => {

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -48,6 +48,11 @@ type HistoricalMarkdownBlockRow = {
 	readonly snapshot_content: unknown;
 };
 
+type MarkdownFileRow = {
+	readonly id: string;
+	readonly path: string;
+};
+
 /**
  * Embeds the shared TipTap editor to render Markdown documents.
  *
@@ -82,19 +87,10 @@ export function MarkdownView({
 	);
 }
 
-function MarkdownViewContent({
-	fileId,
-	isActiveView = true,
-	isPanelFocused = true,
-	focusOnLoad = false,
-	syncActiveFile = true,
-	externalWriteReview = null,
-	onAcceptReviewDiff,
-	onRejectReviewDiff,
-}: MarkdownViewProps) {
+function MarkdownViewContent({ fileId, ...props }: MarkdownViewProps) {
 	assertFileId(fileId);
 
-	const fileRow = useQueryTakeFirst(
+	const fileRow = useQueryTakeFirst<MarkdownFileRow>(
 		(lix) =>
 			qb(lix)
 				.selectFrom("lix_file")
@@ -103,6 +99,22 @@ function MarkdownViewContent({
 				.limit(1),
 		{ subscribe: false },
 	);
+
+	return <MarkdownViewLoaded fileRow={fileRow} {...props} />;
+}
+
+function MarkdownViewLoaded({
+	fileRow,
+	isActiveView = true,
+	isPanelFocused = true,
+	focusOnLoad = false,
+	syncActiveFile = true,
+	externalWriteReview = null,
+	onAcceptReviewDiff,
+	onRejectReviewDiff,
+}: Omit<MarkdownViewProps, "fileId"> & {
+	readonly fileRow: MarkdownFileRow | undefined;
+}) {
 	const reviewDiff = useMemo<MarkdownReviewDiff | null>(() => {
 		if (!externalWriteReview) return null;
 		return {

--- a/src/hooks/key-value/use-key-value.test.tsx
+++ b/src/hooks/key-value/use-key-value.test.tsx
@@ -27,6 +27,13 @@ function withKeyDef(
 	} as any;
 }
 
+async function actAndFlush(callback: () => void | Promise<void>) {
+	await act(async () => {
+		await callback();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
 test("reads a global, untracked key (test fixture)", async () => {
 	const testKey = nextTestKey("flashtype_test_untracked");
 	const defs = withKeyDef(testKey, {
@@ -62,7 +69,9 @@ test("reads a global, untracked key (test fixture)", async () => {
 		hookResult = result as unknown as { current: unknown };
 	});
 
-	await waitFor(() => Array.isArray(hookResult.current as any));
+	await waitFor(() =>
+		expect(Array.isArray(hookResult.current as any)).toBe(true),
+	);
 
 	const [value] = hookResult.current as any;
 	expect(value).toBe("alpha");
@@ -92,9 +101,11 @@ test("writes and reads a global, untracked key (test fixture)", async () => {
 	});
 
 	// Wait for hook to initialize
-	await waitFor(() => Array.isArray(resultRef.current as any));
+	await waitFor(() =>
+		expect(Array.isArray(resultRef.current as any)).toBe(true),
+	);
 
-	await act(async () => {
+	await actAndFlush(async () => {
 		await (resultRef.current as any)?.[1]("beta");
 	});
 
@@ -128,11 +139,13 @@ test("writes and reads a tracked key on active branch", async () => {
 	});
 
 	// Wait for hook to initialize
-	await waitFor(() => Array.isArray(hookResult.current as any));
+	await waitFor(() =>
+		expect(Array.isArray(hookResult.current as any)).toBe(true),
+	);
 
 	await waitFor(() => typeof (hookResult.current as any)[1] === "function");
 
-	await act(async () => {
+	await actAndFlush(async () => {
 		await (hookResult.current as any)[1]("hello");
 	});
 
@@ -171,8 +184,10 @@ test("writes and reads an untracked key on active branch", async () => {
 		hookResult = result as unknown as { current: unknown };
 	});
 
-	await waitFor(() => Array.isArray(hookResult.current as any));
-	await act(async () => {
+	await waitFor(() =>
+		expect(Array.isArray(hookResult.current as any)).toBe(true),
+	);
+	await actAndFlush(async () => {
 		await (hookResult.current as any)[1]("local");
 	});
 	await waitFor(() => expect((hookResult.current as any)[0]).toBe("local"));
@@ -298,11 +313,13 @@ test("re-renders when key value changes externally", async () => {
 		resultRef = result as unknown as { current: unknown };
 	});
 	// wait for initial suspense resolution
-	await waitFor(() => Array.isArray(resultRef.current as any));
+	await waitFor(() =>
+		expect(Array.isArray(resultRef.current as any)).toBe(true),
+	);
 	await waitFor(() => expect((resultRef.current as any)[0]).toBe("initial"));
 
 	// mutate externally (simulate another part of app)
-	await act(async () => {
+	await actAndFlush(async () => {
 		await qb(lix)
 			.updateTable("lix_key_value")
 			.set({ value: "external" })
@@ -428,7 +445,7 @@ test("shares optimistic updates across hook instances", async () => {
 		secondary: "next",
 	});
 
-	await act(async () => {
+	await actAndFlush(async () => {
 		gate.resolve();
 		await pendingWrite;
 	});
@@ -457,16 +474,18 @@ test("returns optimistic value immediately when setter is called", async () => {
 		hookResult = result as unknown as { current: unknown };
 	});
 
-	await waitFor(() => Array.isArray(hookResult.current as any));
+	await waitFor(() =>
+		expect(Array.isArray(hookResult.current as any)).toBe(true),
+	);
 
 	let pending: Promise<unknown> | undefined;
-	await act(async () => {
+	await actAndFlush(async () => {
 		pending = (hookResult.current as any)[1]("value-1");
 	});
 
 	expect((hookResult.current as any)[0]).toBe("value-1");
 
-	await act(async () => {
+	await actAndFlush(async () => {
 		await pending;
 	});
 

--- a/src/shell/top-bar/branch-switcher.test.tsx
+++ b/src/shell/top-bar/branch-switcher.test.tsx
@@ -103,14 +103,13 @@ describe("BranchSwitcher", () => {
 		vi.stubGlobal("prompt", promptSpy);
 
 		await renderWithProviders();
+		const trigger = await screen.findByRole("button", {
+			name: "Select branch",
+		});
 
 		await act(async () => {
-			fireEvent.pointerDown(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
-			fireEvent.pointerUp(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
+			fireEvent.pointerDown(trigger);
+			fireEvent.pointerUp(trigger);
 		});
 
 		const actionsButton = await screen.findByRole("button", {
@@ -145,14 +144,13 @@ describe("BranchSwitcher", () => {
 		vi.stubGlobal("confirm", confirmSpy);
 
 		await renderWithProviders();
+		const trigger = await screen.findByRole("button", {
+			name: "Select branch",
+		});
 
 		await act(async () => {
-			fireEvent.pointerDown(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
-			fireEvent.pointerUp(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
+			fireEvent.pointerDown(trigger);
+			fireEvent.pointerUp(trigger);
 		});
 
 		const actionsButton = await screen.findByRole("button", {
@@ -198,14 +196,13 @@ describe("BranchSwitcher", () => {
 
 	test("delete action is disabled for active branch", async () => {
 		await renderWithProviders();
+		const trigger = await screen.findByRole("button", {
+			name: "Select branch",
+		});
 
 		await act(async () => {
-			fireEvent.pointerDown(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
-			fireEvent.pointerUp(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
+			fireEvent.pointerDown(trigger);
+			fireEvent.pointerUp(trigger);
 		});
 
 		const actionsButton = await screen.findByRole("button", {


### PR DESCRIPTION
## Summary
- Update `submodule/lix` to the latest `origin/main` commit.

## Lix commit
- `183bb1b27aef876b73898a3ed8e8044535658048`
- `183bb1b2 Merge pull request #553 from opral/experiment/rocksdb-blobdb-fs-backend`

## Validation
- `pnpm exec tsc -p . --pretty false --noEmit`

## Note
This Lix version pulls in native RocksDB/bindgen dependencies. Linux CI may need `libclang`/LLVM packages installed before `pnpm run ci`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all CI/macOS release builds and editor view loading paths; risk is build fragility and test flakiness rather than user data or auth.
> 
> **Overview**
> Adds **CI build prerequisites** so the updated Lix SDK (native RocksDB/bindgen) can compile: Linux jobs install `clang` / `libclang-dev` / `llvm-dev`, and macOS CI plus **release-macos** install Homebrew `llvm` and export `LIBCLANG_PATH`, `LLVM_CONFIG_PATH`, and dynamic loader paths before `pnpm install` / packaging.
> 
> **CSV** and **Markdown** views split the suspense/query layer from the loaded UI (`CsvViewLoaded` / `MarkdownViewLoaded`), with typed file rows from `useQueryTakeFirst`, so missing files and parsing run after the file row resolves.
> 
> Tests are tightened for slower/async persistence: `waitForFilesViewReady`, `waitForMarkdown` polling, `actAndFlush` in key-value hooks, async `findBy*` in branch switcher and markdown “file not found”, and small TipTap selection fixes in paste tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037c3e6442aa3341088a1297093f61a08254fa53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->