### PR TITLE
Exclude .lix from workspace size limit

### DIFF
--- a/NEXT_RELEASE.md
+++ b/NEXT_RELEASE.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+- Exclude FlashType's `.lix` workspace data from the folder size limit.

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -296,6 +296,9 @@ async function directorySizeBytes(directoryPath, stopAfterBytes) {
 			continue;
 		}
 		for await (const entry of directory) {
+			if (entry.isDirectory() && entry.name === ".lix") {
+				continue;
+			}
 			const entryPath = path.join(currentDirectory, entry.name);
 			let stats;
 			try {

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -74,6 +74,34 @@ describe("workspace resolution", () => {
 		});
 	});
 
+	test("excludes .lix directories from the workspace size limit", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		await mkdir(path.join(directory, ".lix", ".internal"), {
+			recursive: true,
+		});
+		await writeFile(path.join(directory, "small.md"), Buffer.alloc(10));
+		await writeFile(
+			path.join(directory, ".lix", ".internal", "db.sqlite"),
+			Buffer.alloc(11),
+		);
+
+		await expect(
+			resolveWorkspaceTarget(directory, { maxWorkspaceSizeBytes: 10 }),
+		).resolves.toEqual({
+			workspace: {
+				ephemeral: false,
+				path: directory,
+				name: "workspace",
+			},
+			pendingOpenFilePaths: [],
+		});
+	});
+
 	test("resolves a file inside a Lix workspace to the workspace root", async () => {
 		const directory = path.join(
 			tmpdir(),


### PR DESCRIPTION
## Summary
- skip .lix directories when counting workspace size for the 100 MB open-folder limit
- add a regression test for small user content plus oversized .lix data
- add NEXT_RELEASE.md patch note

## Verification
- node scripts/validate-next-release.mjs
- pnpm vitest run electron/workspace.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to size-limit traversal with a targeted test; workspaces could theoretically exceed the intended cap if non-`.lix` content is huge, which is the desired tradeoff.
> 
> **Overview**
> Folders with small user content but large FlashType **`.lix`** metadata (e.g. `db.sqlite`) were incorrectly blocked by the ~100 MB open-folder cap because the size walk counted everything under `.lix`.
> 
> **`directorySizeBytes`** in `electron/workspace.mjs` now skips any child directory named **`.lix`** during traversal, so only non-`.lix` files contribute to the limit. A regression test covers “10 B user file + 11 B under `.lix`” at a 10 B cap, and **NEXT_RELEASE.md** records a patch note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1456fc6068ea45e76c20c34d901b71707174775b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->