### PR TITLE
[codex] add folder loading screen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Example:
 type: minor
 ---
 
-- Warn before opening folders larger than 100 MB.
+- Warn before opening folders larger than 500 MB.
 - Fix Markdown list editing with Tab, Shift+Tab, Backspace, and nested bullets.
 ```
 

--- a/NEXT_RELEASE.md
+++ b/NEXT_RELEASE.md
@@ -1,3 +1,6 @@
 ---
 type: patch
 ---
+
+- Raise the folder size warning limit to 500 MB.
+- Add a branded loading screen while folders open.

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -5,7 +5,7 @@ import { lstat, opendir, readFile, stat } from "node:fs/promises";
 const LIX_DATABASE_FILE = path.join(".lix", ".internal", "db.sqlite");
 const LEGACY_LIX_DATABASE_FILE = path.join(".lix", "db.sqlite");
 const LIX_DATABASE_FILES = [LIX_DATABASE_FILE, LEGACY_LIX_DATABASE_FILE];
-export const MAX_WORKSPACE_SIZE_BYTES = 100 * 1024 * 1024;
+export const MAX_WORKSPACE_SIZE_BYTES = 500 * 1024 * 1024;
 export const WORKSPACE_TOO_LARGE_ERROR_CODE =
 	"ERR_FLASHTYPE_WORKSPACE_TOO_LARGE";
 

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import {
+	MAX_WORKSPACE_SIZE_BYTES,
 	WORKSPACE_TOO_LARGE_ERROR_CODE,
 	resolveDirectLaunchWorkspaceTargets,
 	resolveWorkspace,
@@ -17,6 +18,10 @@ vi.mock("electron", () => ({
 }));
 
 describe("workspace resolution", () => {
+	test("defaults to a 500 MB workspace size limit", () => {
+		expect(MAX_WORKSPACE_SIZE_BYTES).toBe(500 * 1024 * 1024);
+	});
+
 	test("uses a directory path as the workspace", async () => {
 		const directory = path.join(
 			tmpdir(),

--- a/src/components/animated-zap.tsx
+++ b/src/components/animated-zap.tsx
@@ -1,0 +1,99 @@
+import type { CSSProperties, JSX } from "react";
+
+type AnimatedZapProps = {
+	readonly className?: string;
+	readonly size?: number | string;
+	readonly label?: string;
+	readonly tone?: "inherit" | "brand" | "muted";
+	readonly variant?: "solid" | "outline";
+	readonly strokeWidth?: number;
+	readonly fill?: string;
+};
+
+export function AnimatedZap({
+	className = "",
+	size = 72,
+	label,
+	tone = "inherit",
+	variant = "solid",
+	strokeWidth = 7,
+	fill = "var(--color-bg-panel)",
+}: AnimatedZapProps): JSX.Element {
+	const toneColor =
+		tone === "brand"
+			? "var(--color-icon-brand)"
+			: tone === "muted"
+				? "var(--color-text-tertiary)"
+				: undefined;
+	const style = {
+		"--flashtype-zap-width": typeof size === "number" ? `${size}px` : size,
+		"--flashtype-zap-fill": fill,
+		...(toneColor ? { "--flashtype-zap-color": toneColor } : {}),
+	} as CSSProperties;
+	const accessibilityProps = {
+		role: label ? "img" : undefined,
+		"aria-label": label,
+		"aria-hidden": label ? undefined : true,
+	};
+
+	if (variant === "outline") {
+		return (
+			<svg
+				{...accessibilityProps}
+				className={`flashtype-zap-build flashtype-zap-build--outline ${className}`}
+				style={style}
+				viewBox="-7 -7 89 114"
+				fill="none"
+				focusable="false"
+			>
+				<path
+					className="flashtype-zap-build__outline-fill"
+					d={BOLT_PATH}
+					fill="var(--flashtype-zap-fill, var(--color-bg-app))"
+				/>
+				<path
+					className="flashtype-zap-build__outline-base"
+					d={BOLT_PATH}
+					pathLength={100}
+					stroke="currentColor"
+					strokeWidth={strokeWidth}
+					strokeLinejoin="round"
+					strokeLinecap="round"
+					vectorEffect="non-scaling-stroke"
+				/>
+				<path
+					className="flashtype-zap-build__outline-draw"
+					d={BOLT_PATH}
+					pathLength={100}
+					stroke="currentColor"
+					strokeWidth={strokeWidth}
+					strokeLinejoin="round"
+					strokeLinecap="round"
+					vectorEffect="non-scaling-stroke"
+				/>
+			</svg>
+		);
+	}
+
+	return (
+		<div
+			className={`flashtype-zap-build ${className}`}
+			style={style}
+			{...accessibilityProps}
+		>
+			<div className="flashtype-zap-build__base" />
+			<div className="flashtype-zap-build__segment flashtype-zap-build__segment--top">
+				<div className="flashtype-zap-build__wipe flashtype-zap-build__wipe--top" />
+			</div>
+			<div className="flashtype-zap-build__segment flashtype-zap-build__segment--middle">
+				<div className="flashtype-zap-build__wipe flashtype-zap-build__wipe--middle" />
+			</div>
+			<div className="flashtype-zap-build__segment flashtype-zap-build__segment--bottom">
+				<div className="flashtype-zap-build__wipe flashtype-zap-build__wipe--bottom" />
+			</div>
+		</div>
+	);
+}
+
+const BOLT_PATH =
+	"M42.525 0 L0 57.5 H32.475 L24.975 100 L75 37.5 H39.975 L42.525 0 Z";

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -25,6 +25,7 @@ import {
 	EXTERNAL_WRITE_REVIEW_LAUNCH_ARG,
 	type ExternalWriteReview,
 } from "@/extension-runtime/external-write-review";
+import { AnimatedZap } from "@/components/animated-zap";
 
 type MarkdownViewProps = {
 	readonly fileId: string;
@@ -516,7 +517,7 @@ function MarkdownLoadingSpinner(): ReactNode {
 	return (
 		<div className="flex h-full items-center justify-center px-3 py-2 text-muted-foreground">
 			<div className="flex items-center gap-2 text-sm">
-				<Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+				<AnimatedZap size={13} tone="muted" className="shrink-0" />
 				<span>Loading editor…</span>
 			</div>
 		</div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,225 @@
 
 /* App-specific globals can go here later. */
 
+@keyframes flashtype-zap-wipe-top {
+	0% {
+		transform: scaleY(0);
+	}
+	30% {
+		transform: scaleY(1);
+	}
+	97.5% {
+		transform: scaleY(1);
+	}
+	98% {
+		transform: scaleY(0);
+	}
+	100% {
+		transform: scaleY(0);
+	}
+}
+
+@keyframes flashtype-zap-wipe-middle {
+	0%,
+	24% {
+		transform: translateX(-62%);
+	}
+	52% {
+		transform: translateX(0);
+	}
+	97.5% {
+		transform: translateX(0);
+	}
+	98% {
+		transform: translateX(-62%);
+	}
+	100% {
+		transform: translateX(-62%);
+	}
+}
+
+@keyframes flashtype-zap-wipe-bottom {
+	0%,
+	44% {
+		transform: scaleY(0);
+	}
+	78% {
+		transform: scaleY(1);
+	}
+	97.5% {
+		transform: scaleY(1);
+	}
+	98% {
+		transform: scaleY(0);
+	}
+	100% {
+		transform: scaleY(0);
+	}
+}
+
+@keyframes flashtype-zap-fade {
+	0%,
+	82% {
+		opacity: 1;
+	}
+	96%,
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes flashtype-zap-base-fade {
+	0%,
+	74% {
+		opacity: 0;
+	}
+	84% {
+		opacity: 1;
+	}
+	96% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes flashtype-zap-outline-draw {
+	0% {
+		stroke-dashoffset: 100;
+	}
+	74% {
+		stroke-dashoffset: 0;
+	}
+	100% {
+		stroke-dashoffset: 0;
+	}
+}
+
+.flashtype-zap-build {
+	position: relative;
+	width: var(--flashtype-zap-width, 72px);
+	aspect-ratio: 3 / 4;
+	color: var(--flashtype-zap-color, currentColor);
+	--flashtype-zap-duration: 1.45s;
+	--flashtype-zap-draw-ease: cubic-bezier(0.45, 0, 0.18, 1);
+	clip-path: polygon(
+		56.7% 0%,
+		0% 57.5%,
+		43.3% 57.5%,
+		33.3% 100%,
+		100% 37.5%,
+		53.3% 37.5%
+	);
+	animation: flashtype-zap-fade var(--flashtype-zap-duration) ease-out infinite;
+	will-change: opacity;
+}
+
+.flashtype-zap-build--outline {
+	display: block;
+	overflow: visible;
+	clip-path: none;
+}
+
+.flashtype-zap-build__base,
+.flashtype-zap-build__segment,
+.flashtype-zap-build__wipe {
+	position: absolute;
+}
+
+.flashtype-zap-build__base,
+.flashtype-zap-build__segment {
+	inset: 0;
+}
+
+.flashtype-zap-build__base,
+.flashtype-zap-build__wipe {
+	background: currentColor;
+	backface-visibility: hidden;
+}
+
+.flashtype-zap-build__base {
+	opacity: 0;
+	animation: flashtype-zap-base-fade var(--flashtype-zap-duration) linear
+		infinite;
+}
+
+.flashtype-zap-build__segment--top {
+	clip-path: polygon(56.7% 0%, 0% 57.5%, 43.3% 57.5%, 53.3% 37.5%);
+}
+
+.flashtype-zap-build__segment--middle {
+	clip-path: polygon(43.3% 57.5%, 100% 37.5%, 53.3% 37.5%);
+}
+
+.flashtype-zap-build__segment--bottom {
+	clip-path: polygon(43.3% 57.5%, 33.3% 100%, 100% 37.5%);
+}
+
+.flashtype-zap-build__wipe--top {
+	top: 0;
+	right: 0;
+	left: 0;
+	height: 57.5%;
+	transform: scaleY(0);
+	transform-origin: 50% 0%;
+	animation: flashtype-zap-wipe-top var(--flashtype-zap-duration)
+		var(--flashtype-zap-draw-ease) infinite;
+	will-change: transform;
+}
+
+.flashtype-zap-build__wipe--middle {
+	inset: 0;
+	transform: translateX(-62%);
+	animation: flashtype-zap-wipe-middle var(--flashtype-zap-duration)
+		var(--flashtype-zap-draw-ease) infinite;
+	will-change: transform;
+}
+
+.flashtype-zap-build__wipe--bottom {
+	top: 37.5%;
+	right: 0;
+	left: 0;
+	height: 62.5%;
+	transform: scaleY(0);
+	transform-origin: 50% 0%;
+	animation: flashtype-zap-wipe-bottom var(--flashtype-zap-duration)
+		var(--flashtype-zap-draw-ease) infinite;
+	will-change: transform;
+}
+
+.flashtype-zap-build__outline-base {
+	opacity: 0;
+	animation: flashtype-zap-base-fade var(--flashtype-zap-duration) linear
+		infinite;
+}
+
+.flashtype-zap-build__outline-draw {
+	stroke-dasharray: 100;
+	stroke-dashoffset: 100;
+	animation: flashtype-zap-outline-draw var(--flashtype-zap-duration)
+		var(--flashtype-zap-draw-ease) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.flashtype-zap-build,
+	.flashtype-zap-build__base,
+	.flashtype-zap-build__wipe,
+	.flashtype-zap-build__outline-base,
+	.flashtype-zap-build__outline-draw {
+		animation: none;
+	}
+
+	.flashtype-zap-build__base,
+	.flashtype-zap-build__outline-base {
+		opacity: 1;
+	}
+
+	.flashtype-zap-build__outline-draw {
+		stroke-dashoffset: 0;
+	}
+}
+
 @theme inline {
 	--radius-sm: calc(var(--radius) - 4px);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import { KEY_VALUE_DEFINITIONS } from "./hooks/key-value/schema";
 import { ErrorFallback } from "./main.error";
 import { V2LayoutShell } from "./shell/layout-shell";
 import { FirstRunScreen } from "./shell/first-run-screen";
+import { WorkspaceLoadingScreen } from "./shell/workspace-loading-screen";
 import { openDesktopLix } from "./lib/lix-client";
 import { captureTelemetry } from "./lib/telemetry";
 import {
@@ -46,6 +47,9 @@ export const AppRoot = () => {
 	const [workspaceOpenWarning, setWorkspaceOpenWarning] = useState<
 		string | null
 	>(null);
+	const [openingWorkspaceName, setOpeningWorkspaceName] = useState<
+		string | null | undefined
+	>(undefined);
 	const [isUpdateReady, setIsUpdateReady] = useState(false);
 
 	useEffect(() => {
@@ -105,6 +109,10 @@ export const AppRoot = () => {
 			const desktop = window.flashtypeDesktop;
 			if (!desktop || openFolderInFlightRef.current) return;
 			openFolderInFlightRef.current = true;
+			if (!workspace) {
+				setOpeningWorkspaceName(path ? workspaceNameFromPath(path) : null);
+			}
+			let keepLoadingScreen = false;
 			try {
 				const openPayload = path ? { path } : undefined;
 				const opened = await (workspace
@@ -113,6 +121,8 @@ export const AppRoot = () => {
 				// null = picker canceled; keep the current state.
 				if (!opened || opened.path === workspace?.path) return;
 				if (workspace) return;
+				setOpeningWorkspaceName(opened.name);
+				keepLoadingScreen = true;
 				// When switching, close the running lix before the workspace state
 				// flips: close() lags its IPC, so an unawaited close could race the
 				// new open and kill the fresh instance.
@@ -122,6 +132,7 @@ export const AppRoot = () => {
 				}
 				setWorkspace(opened);
 			} catch (error) {
+				setOpeningWorkspaceName(undefined);
 				if (isWorkspaceTooLargeError(error)) {
 					setWorkspaceOpenWarning(formatWorkspaceOpenWarning(error));
 					return;
@@ -129,6 +140,9 @@ export const AppRoot = () => {
 				setError(error);
 			} finally {
 				openFolderInFlightRef.current = false;
+				if (!keepLoadingScreen) {
+					setOpeningWorkspaceName(undefined);
+				}
 			}
 		},
 		[lix, workspace],
@@ -207,6 +221,7 @@ export const AppRoot = () => {
 
 	useEffect(() => {
 		if (!workspace || !lix) return;
+		setOpeningWorkspaceName(undefined);
 		void captureWorkspaceProfile({
 			lix,
 			isEphemeralWorkspace: workspace.ephemeral,
@@ -275,6 +290,9 @@ export const AppRoot = () => {
 	if (error) return <ErrorFallback error={error} />;
 	if (workspace === undefined) return <BootPlaceholder />;
 	if (workspace === null) {
+		if (openingWorkspaceName !== undefined) {
+			return <WorkspaceLoadingScreen workspaceName={openingWorkspaceName} />;
+		}
 		return (
 			<>
 				<WorkspaceOpenWarningDialog
@@ -289,7 +307,13 @@ export const AppRoot = () => {
 			</>
 		);
 	}
-	if (!lix) return <BootPlaceholder />;
+	if (!lix) {
+		return (
+			<WorkspaceLoadingScreen
+				workspaceName={openingWorkspaceName ?? workspace.name}
+			/>
+		);
+	}
 
 	return (
 		<>
@@ -318,6 +342,15 @@ export const AppRoot = () => {
 
 function BootPlaceholder() {
 	return <div className="h-dvh w-full bg-[var(--color-bg-app)]" />;
+}
+
+function workspaceNameFromPath(path: string): string | null {
+	const name = path
+		.replace(/[\\/]+$/u, "")
+		.split(/[\\/]/u)
+		.pop()
+		?.trim();
+	return name || null;
 }
 
 function WorkspaceOpenWarningDialog({

--- a/src/shell/workspace-loading-screen.tsx
+++ b/src/shell/workspace-loading-screen.tsx
@@ -1,0 +1,34 @@
+import type { JSX } from "react";
+import { Zap } from "lucide-react";
+import { AnimatedZap } from "@/components/animated-zap";
+import { TopBar } from "./top-bar";
+
+export function WorkspaceLoadingScreen({
+	workspaceName,
+}: {
+	readonly workspaceName?: string | null;
+}): JSX.Element {
+	const name = workspaceName?.trim();
+
+	return (
+		<div className="flex h-dvh flex-col bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+			<TopBar
+				workspaceName={name || null}
+				menu={
+					<span className="flex h-7 w-7 items-center justify-center rounded-[7px]">
+						<Zap className="size-3.75 fill-[var(--color-icon-brand)] text-[var(--color-icon-brand)]" />
+					</span>
+				}
+			/>
+			<main className="flex min-h-0 flex-1 flex-col items-center justify-center px-8 pb-9 text-center">
+				<AnimatedZap size={96} label="Flashtype loading" tone="brand" />
+				<h1 className="mt-6 text-[18px] font-bold tracking-normal text-[var(--color-text-primary)]">
+					{name ? `Opening ${name}` : "Opening folder"}
+				</h1>
+				<p className="mt-2 max-w-72 text-[13px] leading-relaxed text-[var(--color-text-secondary)] text-pretty">
+					Teaching the zap where the files live.
+				</p>
+			</main>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- raise the folder size warning limit to 500 MB
- add a branded folder-opening loading screen with the shared animated zap
- reuse the animated zap as a muted inline Markdown editor loading indicator

## Validation
- pnpm exec tsc -p . --pretty false
- pnpm vitest run electron/workspace.test.ts
- pnpm exec oxlint --tsconfig ./tsconfig.json --format stylish src/components/animated-zap.tsx src/extensions/markdown/index.tsx src/shell/workspace-loading-screen.tsx src/main.tsx electron/workspace.mjs electron/workspace.test.ts
- pnpm exec prettier --check CONTRIBUTING.md NEXT_RELEASE.md electron/workspace.mjs electron/workspace.test.ts src/components/animated-zap.tsx src/extensions/markdown/index.tsx src/index.css src/main.tsx src/shell/workspace-loading-screen.tsx
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI and a documented size-limit constant; no changes to auth, data persistence, or workspace resolution logic beyond the threshold.
> 
> **Overview**
> Raises the **folder size warning** from 100 MB to **500 MB** in the Electron workspace layer, with a matching unit test and release notes.
> 
> Adds a reusable **`AnimatedZap`** component (solid and outline variants, tone/size props, CSS keyframe animations with reduced-motion support) and a **`WorkspaceLoadingScreen`** that shows it while a folder is opening. **`main.tsx`** tracks `openingWorkspaceName` during open-folder flows and swaps the blank boot placeholder for that screen on first run and while Lix is still loading after a workspace is set.
> 
> The Markdown editor’s Suspense fallback now uses a small muted **`AnimatedZap`** instead of a generic spinner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe56337c75ec9ebcb103ee185e33577c9051f854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->