### PR TITLE
Simplify telemetry events

### DIFF
--- a/electron/ipc-lix.mjs
+++ b/electron/ipc-lix.mjs
@@ -8,7 +8,6 @@ import {
 	resetLixRepository,
 } from "./lix.mjs";
 import { createOwnedHandleStore } from "./ipc-owned-handles.mjs";
-import { captureTelemetryEvent } from "./telemetry.mjs";
 
 const observeHandles = createOwnedHandleStore("observe");
 const observeTraceMeta = createOwnedHandleStore("observe trace");
@@ -260,7 +259,6 @@ export function registerLixIpc(resolveWindowForEvent) {
 	ipcMain.handle("lix:createBranch", async (event, payload) => {
 		const lix = await ensureLixOpenForEvent(event);
 		const branch = await lix.createBranch(payload?.options ?? {});
-		void captureTelemetryEvent("branch created", { source: "main" });
 		return branch;
 	});
 
@@ -269,7 +267,6 @@ export function registerLixIpc(resolveWindowForEvent) {
 		const result = await lix.switchBranch({
 			branchId: String(payload?.branchId ?? ""),
 		});
-		void captureTelemetryEvent("branch switched", { source: "main" });
 		return result;
 	});
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -16,9 +16,8 @@ import {
 	showWorkspaceTooLargeWarning,
 } from "./workspace.mjs";
 import {
-	captureAppLaunched,
+	captureAppOpened,
 	captureTelemetryException,
-	captureTelemetryEvent,
 	forgetTelemetrySessionContextForWebContents,
 	getTelemetrySessionIdForWebContents,
 	registerTelemetryIpc,
@@ -214,9 +213,7 @@ async function openWorkspaceRequests(
 			throw error;
 		}
 		for (const workspaceTarget of workspaceTargets) {
-			await createMainWindow(
-				withWorkspaceOpenTelemetry(workspaceTarget, source),
-			);
+			await createMainWindow(workspaceTarget);
 			openedWindowCount += 1;
 		}
 	}
@@ -279,50 +276,7 @@ function normalizeWorkspaceOpenRequest(
 		return workspaceRequest;
 	}
 
-	if (
-		workspaceRequest &&
-		typeof workspaceRequest === "object" &&
-		typeof workspaceRequest.telemetryOpenSource === "string"
-	) {
-		return createWorkspaceOpenRequest(
-			workspaceRequest,
-			workspaceRequest.telemetryOpenSource,
-		);
-	}
-
 	return createWorkspaceOpenRequest(workspaceRequest, fallbackSource);
-}
-
-function withWorkspaceOpenTelemetry(workspaceTarget, requestedSource) {
-	if (!workspaceTarget) {
-		return workspaceTarget;
-	}
-	const pendingFileCount = Array.isArray(workspaceTarget.pendingOpenFilePaths)
-		? workspaceTarget.pendingOpenFilePaths.length
-		: 0;
-	return {
-		...workspaceTarget,
-		telemetryOpenSource: resolveTelemetryOpenSource(
-			requestedSource,
-			pendingFileCount,
-		),
-		telemetryPendingFileCount: pendingFileCount,
-	};
-}
-
-function resolveTelemetryOpenSource(requestedSource, pendingFileCount) {
-	switch (requestedSource) {
-		case "app_restore":
-		case "file_open_event":
-		case "open_in_new_window":
-		case "workspace_picker":
-			return requestedSource;
-		case "file_launch":
-		case "folder_launch":
-			return requestedSource;
-		default:
-			return pendingFileCount > 0 ? "file_launch" : "folder_launch";
-	}
 }
 
 function resolveWorkspaceRequestSource(workspaceRequest, explicitSourceByPath) {
@@ -353,9 +307,9 @@ function resolveWorkspaceRequestSource(workspaceRequest, explicitSourceByPath) {
 	return "unknown";
 }
 
-async function inferLaunchSourceFromPaths(workspacePaths) {
+async function inferEntryPointFromPaths(workspacePaths) {
 	if (workspacePaths.length === 0) {
-		return "app";
+		return "app_direct";
 	}
 
 	let hasFile = false;
@@ -374,13 +328,13 @@ async function inferLaunchSourceFromPaths(workspacePaths) {
 	}
 
 	if (hasFile && (hasFolder || hasUnknown)) {
-		return "mixed";
+		return "unknown";
 	}
 	if (hasFile) {
-		return "file";
+		return "finder_file";
 	}
 	if (hasFolder) {
-		return hasUnknown ? "mixed" : "folder";
+		return hasUnknown ? "unknown" : "open_folder";
 	}
 	return "unknown";
 }
@@ -422,7 +376,7 @@ function focusMostRecentWorkspaceWindow() {
 	return true;
 }
 
-function recordOpenWorkspacePath(window, workspace, telemetry = {}) {
+function recordOpenWorkspacePath(window, workspace) {
 	if (!window || window.isDestroyed() || !workspace) {
 		return;
 	}
@@ -430,29 +384,12 @@ function recordOpenWorkspacePath(window, workspace, telemetry = {}) {
 	if (!workspaceEntry) {
 		return;
 	}
-	const previousWorkspaceEntry = openWorkspaceEntriesByWindowId.get(window.id);
-	const workspaceAlreadyOpen = areWorkspaceSessionEntriesEqual(
-		previousWorkspaceEntry,
-		workspaceEntry,
-	);
 	closedWorkspaceEntryWindowIds.delete(window.id);
 	openWorkspaceEntriesByWindowId.set(window.id, workspaceEntry);
 	recordRecentWorkspace(workspace);
-	if (!workspaceAlreadyOpen) {
-		void captureTelemetryEvent("workspace opened", {
-			is_ephemeral_workspace: workspace.ephemeral === true,
-			open_source: telemetry.openSource ?? "unknown",
-			pending_file_count: telemetry.pendingFileCount ?? 0,
-			source: "main",
-		});
-	}
 	void syncMacOSDockRecentWorkspaceDocuments();
 	persistOpenWorkspacePathsSoon();
 	updateDockMenu();
-}
-
-function areWorkspaceSessionEntriesEqual(left, right) {
-	return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }
 
 function forgetOpenWorkspacePath(window, { persist = true } = {}) {
@@ -589,16 +526,9 @@ async function createMainWindow(workspaceRequest) {
 			taggedRequest.request?.pendingOpenFilePaths
 				? taggedRequest.request
 				: (await resolveWorkspaceTargets([taggedRequest.request]))[0];
-		const telemetryWorkspaceTarget = withWorkspaceOpenTelemetry(
-			workspaceTarget,
-			taggedRequest.requestedSource,
-		);
-		await setWorkspaceFromTarget(telemetryWorkspaceTarget, window, {
+		await setWorkspaceFromTarget(workspaceTarget, window, {
 			afterChange: (workspace, changedWindow) =>
-				recordOpenWorkspacePath(changedWindow, workspace, {
-					openSource: telemetryWorkspaceTarget.telemetryOpenSource,
-					pendingFileCount: telemetryWorkspaceTarget.telemetryPendingFileCount,
-				}),
+				recordOpenWorkspacePath(changedWindow, workspace),
 		});
 	} else {
 		applyWorkspaceWindowChrome(window);
@@ -734,23 +664,13 @@ async function startWorkspaceLifecycle() {
 	registerWorkspaceIpc((event) => BrowserWindow.fromWebContents(event.sender), {
 		beforeChange: (_nextWorkspace, window) =>
 			closeLixSession(window, { ignoreOpenError: true }),
-		afterChange: (workspace, window, workspaceTarget) => {
-			const telemetryWorkspaceTarget = withWorkspaceOpenTelemetry(
-				workspaceTarget,
-				"workspace_picker",
-			);
-			recordOpenWorkspacePath(window, workspace, {
-				openSource: telemetryWorkspaceTarget.telemetryOpenSource,
-				pendingFileCount: telemetryWorkspaceTarget.telemetryPendingFileCount,
-			});
-		},
+		afterChange: (workspace, window) =>
+			recordOpenWorkspacePath(window, workspace),
 		openInNewWindow: async (requestedPath) => {
 			const workspaceTarget = (
 				await resolveDirectLaunchWorkspaceTargets([requestedPath])
 			)[0];
-			const window = await createMainWindow(
-				withWorkspaceOpenTelemetry(workspaceTarget, "open_in_new_window"),
-			);
+			const window = await createMainWindow(workspaceTarget);
 			return getWorkspace(window);
 		},
 	});
@@ -802,12 +722,16 @@ async function startWorkspaceLifecycle() {
 	const pendingWorkspaceOpenRequestsToProcess = [
 		...pendingWorkspaceOpenRequests,
 	];
-	const launchSource = pendingWorkspaceOpenRequestsToProcess.some(
+	const hasFileOpenEvent = pendingWorkspaceOpenRequestsToProcess.some(
 		(request) => request.requestedSource === "file_open_event",
-	)
-		? "file"
-		: await inferLaunchSourceFromPaths(initialLaunchWorkspacePaths);
-	void captureAppLaunched({ launchSource });
+	);
+	const entryPoint = hasFileOpenEvent
+		? "finder_file"
+		: initialLaunchWorkspacePaths.length === 0 &&
+			  restorableSavedWorkspaceEntries.length > 0
+			? "restored_session"
+			: await inferEntryPointFromPaths(initialLaunchWorkspacePaths);
+	void captureAppOpened({ entryPoint });
 	const explicitWorkspaceSourceByPath = new Map();
 	for (const workspacePath of initialLaunchWorkspacePaths) {
 		explicitWorkspaceSourceByPath.set(

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -24,6 +24,7 @@ const workspace = {
 	get: () => ipcRenderer.invoke("workspace:get"),
 	consumePendingOpenFiles: () =>
 		ipcRenderer.invoke("workspace:consumePendingOpenFiles"),
+	profile: () => ipcRenderer.invoke("workspace:profile"),
 	open: (payload) => ipcRenderer.invoke("workspace:open", payload),
 	openInNewWindow: (payload) =>
 		ipcRenderer.invoke("workspace:openInNewWindow", payload),

--- a/electron/telemetry.mjs
+++ b/electron/telemetry.mjs
@@ -7,7 +7,7 @@ import { PostHog } from "posthog-node";
 const TELEMETRY_STORE_FILE = "telemetry.json";
 const ENV_VARIABLES_FILE = "build/env-variables.mjs";
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
-const SESSION_REPLAY_SAMPLE_RATE = 0.1;
+const DEV_TELEMETRY_DISTINCT_ID = "dev:mode";
 const SHUTDOWN_TIMEOUT_MS = 2_000;
 
 let envVariablesPromise;
@@ -20,13 +20,9 @@ let latestRendererPostHogSessionId;
 let cachedDistinctId;
 const rendererPostHogSessionIdsByWebContentsId = new Map();
 
-export async function captureAppLaunched({
-	trigger = "launch",
-	launchSource = "app",
-} = {}) {
-	return await captureTelemetryEvent("app launched", {
-		trigger,
-		launch_source: launchSource,
+export async function captureAppOpened({ entryPoint = "app_direct" } = {}) {
+	return await captureTelemetryEvent("app opened", {
+		entry_point: entryPoint,
 	});
 }
 
@@ -116,10 +112,7 @@ export function registerTelemetryIpc() {
 			token: env.PUBLIC_POSTHOG_TOKEN,
 			host: env.PUBLIC_POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST,
 			distinctId,
-			sessionRecordingEnabled: isDistinctIdSampled(
-				distinctId,
-				SESSION_REPLAY_SAMPLE_RATE,
-			),
+			sessionRecordingEnabled: true,
 		};
 	});
 
@@ -129,7 +122,6 @@ export function registerTelemetryIpc() {
 			payload?.sessionId,
 		);
 	});
-
 }
 
 export async function shutdownTelemetry(timeoutMs = SHUTDOWN_TIMEOUT_MS) {
@@ -182,11 +174,29 @@ async function getDistinctId() {
 	if (cachedDistinctId) {
 		return cachedDistinctId;
 	}
+	const developmentDistinctId = getDevelopmentTelemetryDistinctId({
+		isPackaged: app.isPackaged === true,
+		enableDevTelemetry: process.env.FLASHTYPE_ENABLE_DEV_TELEMETRY,
+	});
+	if (developmentDistinctId) {
+		cachedDistinctId = developmentDistinctId;
+		return cachedDistinctId;
+	}
 	distinctIdPromise ??= readOrCreateDistinctId().finally(() => {
 		distinctIdPromise = undefined;
 	});
 	cachedDistinctId = await distinctIdPromise;
 	return cachedDistinctId;
+}
+
+export function getDevelopmentTelemetryDistinctId({
+	isPackaged,
+	enableDevTelemetry,
+}) {
+	if (isPackaged === true) {
+		return undefined;
+	}
+	return enableDevTelemetry === "1" ? DEV_TELEMETRY_DISTINCT_ID : undefined;
 }
 
 async function readEnvVariables() {
@@ -295,6 +305,8 @@ function commonEventProperties() {
 		platform: process.platform,
 		platform_arch: process.arch,
 		...systemLocaleProperties(),
+		schema_version: 2,
+		telemetry_environment: app?.isPackaged === true ? "production" : "dev",
 		telemetry_client: "electron-main",
 		uptime_seconds: Math.floor(process.uptime()),
 	};
@@ -384,11 +396,7 @@ function normalizeTelemetryString(value) {
 		return undefined;
 	}
 	const scrubbed = scrubPrivatePaths(trimmed).slice(0, 200);
-	if (
-		!scrubbed ||
-		scrubbed === "[redacted_path]" ||
-		/[\\/]/.test(scrubbed)
-	) {
+	if (!scrubbed || scrubbed === "[redacted_path]" || /[\\/]/.test(scrubbed)) {
 		return undefined;
 	}
 	return scrubbed;
@@ -414,21 +422,6 @@ function normalizePostHogSessionId(value) {
 	)
 		? trimmed
 		: undefined;
-}
-
-function isDistinctIdSampled(distinctId, sampleRate) {
-	if (sampleRate <= 0) {
-		return false;
-	}
-	if (sampleRate >= 1) {
-		return true;
-	}
-	let hash = 0x811c9dc5;
-	for (let index = 0; index < distinctId.length; index += 1) {
-		hash ^= distinctId.charCodeAt(index);
-		hash = Math.imul(hash, 0x01000193);
-	}
-	return (hash >>> 0) / 0x100000000 < sampleRate;
 }
 
 export function scrubTelemetrySensitiveValues(value, depth = 0) {

--- a/electron/telemetry.test.mjs
+++ b/electron/telemetry.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import os from "node:os";
 import {
 	beforeSendTelemetryEvent,
+	getDevelopmentTelemetryDistinctId,
 	scrubTelemetrySensitiveValues,
 	setTelemetrySessionContextForWebContents,
 } from "./telemetry.mjs";
@@ -56,5 +57,34 @@ describe("beforeSendTelemetryEvent", () => {
 				},
 			})?.properties?.$session_id,
 		).toBe(explicitSessionId);
+	});
+});
+
+describe("getDevelopmentTelemetryDistinctId", () => {
+	test("uses a stable dev id when dev telemetry is explicitly enabled", () => {
+		expect(
+			getDevelopmentTelemetryDistinctId({
+				isPackaged: false,
+				enableDevTelemetry: "1",
+			}),
+		).toBe("dev:mode");
+	});
+
+	test("does not replace the install id for packaged builds", () => {
+		expect(
+			getDevelopmentTelemetryDistinctId({
+				isPackaged: true,
+				enableDevTelemetry: "1",
+			}),
+		).toBeUndefined();
+	});
+
+	test("does not enable telemetry identity in dev unless opted in", () => {
+		expect(
+			getDevelopmentTelemetryDistinctId({
+				isPackaged: false,
+				enableDevTelemetry: undefined,
+			}),
+		).toBeUndefined();
 	});
 });

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -131,10 +131,27 @@ export type DesktopWorkspace =
 			sourceFilePaths: string[];
 	  };
 
+export type DesktopWorkspaceExtensionProfile = {
+	file_extension: string;
+	file_count: number;
+	total_size_mb: number;
+	median_file_size_kb: number;
+};
+
+export type DesktopWorkspaceProfile = {
+	file_count: number;
+	directory_count: number;
+	extension_count: number;
+	extension_counts: Record<string, number>;
+	total_size_mb: number;
+	extensions: DesktopWorkspaceExtensionProfile[];
+};
+
 export type DesktopWorkspaceApi = {
 	get(): Promise<DesktopWorkspace | null>;
 	/** Returns workspace-relative file paths queued for editor opening. */
 	consumePendingOpenFiles(): Promise<string[]>;
+	profile(): Promise<DesktopWorkspaceProfile | null>;
 	/**
 	 * Opens a workspace. With a path (e.g. from a dropped folder) it adopts it
 	 * directly; without one it shows the native directory picker. Resolves to
@@ -174,21 +191,22 @@ export type DesktopAppApi = {
 };
 
 export type DesktopTelemetryEventName =
-	| "agent launched"
-	| "external write reviewed"
-	| "file created"
-	| "file opened"
-	| "file saved"
-	| "update installed"
-	| "workspace profiled"
-	| "workspace opened";
+	| "agent opened"
+	| "app opened"
+	| "diff opened"
+	| "diff resolved"
+	| "document open attempted"
+	| "document modified"
+	| "document viewed"
+	| "workspace extension profiled"
+	| "workspace profiled";
 
 export type DesktopTelemetryApi = {
 	capture(payload: {
 		event: DesktopTelemetryEventName;
 		properties?: Record<
 			string,
-			string | number | boolean | Record<string, number> | undefined
+			string | number | boolean | Record<string, string | number> | undefined
 		>;
 	}): Promise<{
 		status: "disabled" | "error" | "ignored" | "queued" | "throttled";

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -226,6 +226,82 @@ export function consumePendingOpenFiles(window) {
 	return pendingOpenFilePaths ?? [];
 }
 
+export async function profileWorkspaceFilesystem(workspace) {
+	if (!workspace) {
+		return null;
+	}
+	const profile = createEmptyWorkspaceFilesystemProfile();
+	if (workspace.ephemeral === true) {
+		await profileTransientWorkspaceSourceFiles(profile, workspace);
+		return finalizeWorkspaceFilesystemProfile(profile);
+	}
+	const pendingDirectories = [workspace.path];
+	while (pendingDirectories.length > 0) {
+		const currentDirectory = pendingDirectories.pop();
+		let directory;
+		try {
+			directory = await opendir(currentDirectory);
+		} catch {
+			continue;
+		}
+		for await (const entry of directory) {
+			if (entry.isDirectory() && entry.name === ".lix") {
+				continue;
+			}
+			const entryPath = path.join(currentDirectory, entry.name);
+			let stats;
+			try {
+				stats = await lstat(entryPath);
+			} catch {
+				continue;
+			}
+			if (stats.isSymbolicLink()) {
+				continue;
+			}
+			if (stats.isDirectory()) {
+				profile.directory_count += 1;
+				pendingDirectories.push(entryPath);
+				continue;
+			}
+			if (stats.isFile()) {
+				addFileToWorkspaceFilesystemProfile(
+					profile,
+					extensionFromPath(entry.name),
+					stats.size,
+				);
+			}
+		}
+	}
+	return finalizeWorkspaceFilesystemProfile(profile);
+}
+
+async function profileTransientWorkspaceSourceFiles(profile, workspace) {
+	const directories = new Set();
+	for (const sourceFilePath of workspace.sourceFilePaths ?? []) {
+		let stats;
+		try {
+			stats = await lstat(sourceFilePath);
+		} catch {
+			continue;
+		}
+		if (!stats.isFile() || stats.isSymbolicLink()) {
+			continue;
+		}
+		const relativePath = toPortableRelativePath(
+			path.relative(workspace.path, sourceFilePath),
+		);
+		for (const directory of parentDirectories(relativePath)) {
+			directories.add(directory);
+		}
+		addFileToWorkspaceFilesystemProfile(
+			profile,
+			extensionFromPath(sourceFilePath),
+			stats.size,
+		);
+	}
+	profile.directory_count = directories.size;
+}
+
 function applyWindowChrome(window) {
 	const workspace = getWorkspace(window);
 	if (!workspace || !window || window.isDestroyed()) {
@@ -363,6 +439,109 @@ function formatBytes(bytes) {
 		return `${mib} MB`;
 	}
 	return `${mib.toFixed(1)} MB`;
+}
+
+function createEmptyWorkspaceFilesystemProfile() {
+	return {
+		file_count: 0,
+		directory_count: 0,
+		extension_count: 0,
+		extension_counts: {},
+		total_size_mb: 0,
+		extensionSizeBytes: new Map(),
+		extensionFileSizesBytes: new Map(),
+	};
+}
+
+function addFileToWorkspaceFilesystemProfile(profile, extension, sizeBytes) {
+	profile.file_count += 1;
+	profile.extension_counts[extension] =
+		(profile.extension_counts[extension] ?? 0) + 1;
+	profile.extensionSizeBytes.set(
+		extension,
+		(profile.extensionSizeBytes.get(extension) ?? 0) + sizeBytes,
+	);
+	const fileSizes = profile.extensionFileSizesBytes.get(extension) ?? [];
+	fileSizes.push(sizeBytes);
+	profile.extensionFileSizesBytes.set(extension, fileSizes);
+}
+
+function finalizeWorkspaceFilesystemProfile(profile) {
+	const sortedExtensions = Object.keys(profile.extension_counts).sort(
+		(left, right) => left.localeCompare(right),
+	);
+	const extensionCounts = {};
+	const extensions = [];
+	let totalSizeBytes = 0;
+	for (const extension of sortedExtensions) {
+		const fileCount = profile.extension_counts[extension] ?? 0;
+		const totalExtensionSizeBytes =
+			profile.extensionSizeBytes.get(extension) ?? 0;
+		totalSizeBytes += totalExtensionSizeBytes;
+		extensionCounts[extension] = fileCount;
+		extensions.push({
+			file_extension: extension,
+			file_count: fileCount,
+			total_size_mb: roundMegabytes(totalExtensionSizeBytes),
+			median_file_size_kb: roundKilobytes(
+				median(profile.extensionFileSizesBytes.get(extension) ?? []),
+			),
+		});
+	}
+	return {
+		file_count: profile.file_count,
+		directory_count: profile.directory_count,
+		extension_count: sortedExtensions.length,
+		extension_counts: extensionCounts,
+		total_size_mb: roundMegabytes(totalSizeBytes),
+		extensions,
+	};
+}
+
+function extensionFromPath(fileName) {
+	const match = fileName.match(/\.([^./]+)$/);
+	if (!match?.[1]) {
+		return "(none)";
+	}
+	return normalizeFileExtension(match[1]);
+}
+
+function normalizeFileExtension(extension) {
+	const normalized = extension.trim().toLowerCase();
+	return /^[a-z0-9][a-z0-9+_-]{0,15}$/.test(normalized) ? normalized : "other";
+}
+
+function parentDirectories(relativePath) {
+	const parts = relativePath.split("/").filter(Boolean);
+	const fileName = parts.pop();
+	if (!fileName) {
+		return [];
+	}
+	const directories = [];
+	for (let index = 1; index <= parts.length; index += 1) {
+		directories.push(parts.slice(0, index).join("/"));
+	}
+	return directories;
+}
+
+function median(values) {
+	if (values.length === 0) {
+		return 0;
+	}
+	const sorted = [...values].sort((left, right) => left - right);
+	const middle = Math.floor(sorted.length / 2);
+	if (sorted.length % 2 === 1) {
+		return sorted[middle] ?? 0;
+	}
+	return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+}
+
+function roundMegabytes(bytes) {
+	return Math.round((bytes / 1024 / 1024) * 100) / 100;
+}
+
+function roundKilobytes(bytes) {
+	return Math.round((bytes / 1024) * 100) / 100;
 }
 
 async function resolveStandaloneFile(resolvedPath, options = {}) {
@@ -527,6 +706,12 @@ export function registerWorkspaceIpc(getWindowForEvent, options = {}) {
 
 	ipcMain.handle("workspace:consumePendingOpenFiles", (event) => {
 		return consumePendingOpenFiles(getWindowForEvent(event));
+	});
+
+	ipcMain.handle("workspace:profile", async (event) => {
+		return await profileWorkspaceFilesystem(
+			getWorkspace(getWindowForEvent(event)),
+		);
 	});
 
 	ipcMain.handle("workspace:open", async (event, payload) => {

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -6,6 +6,7 @@ import { describe, expect, test, vi } from "vitest";
 import {
 	MAX_WORKSPACE_SIZE_BYTES,
 	WORKSPACE_TOO_LARGE_ERROR_CODE,
+	profileWorkspaceFilesystem,
 	resolveDirectLaunchWorkspaceTargets,
 	resolveWorkspace,
 	resolveWorkspaceTarget,
@@ -430,5 +431,122 @@ describe("workspace resolution", () => {
 				pendingOpenFilePaths: ["alpha.txt", "beta.csv"],
 			},
 		]);
+	});
+
+	test("profiles workspace filesystem sizes by extension without reading Lix blobs", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		await mkdir(path.join(directory, "docs"), { recursive: true });
+		await mkdir(path.join(directory, "data"), { recursive: true });
+		await mkdir(path.join(directory, ".lix", ".internal"), {
+			recursive: true,
+		});
+		await writeFile(path.join(directory, "README.md"), Buffer.alloc(1024));
+		await writeFile(
+			path.join(directory, "docs", "guide.MD"),
+			Buffer.alloc(3072),
+		);
+		await writeFile(
+			path.join(directory, "data", "book.xlsx"),
+			Buffer.alloc(2048),
+		);
+		await writeFile(path.join(directory, "LICENSE"), Buffer.alloc(512));
+		await writeFile(
+			path.join(directory, ".lix", ".internal", "db.sqlite"),
+			Buffer.alloc(10_000),
+		);
+
+		const profile = await profileWorkspaceFilesystem({
+			ephemeral: false,
+			path: directory,
+			name: "workspace",
+		});
+
+		expect(profile).toEqual({
+			file_count: 4,
+			directory_count: 2,
+			extension_count: 3,
+			extension_counts: {
+				"(none)": 1,
+				md: 2,
+				xlsx: 1,
+			},
+			total_size_mb: 0.01,
+			extensions: [
+				{
+					file_extension: "(none)",
+					file_count: 1,
+					total_size_mb: 0,
+					median_file_size_kb: 0.5,
+				},
+				{
+					file_extension: "md",
+					file_count: 2,
+					total_size_mb: 0,
+					median_file_size_kb: 2,
+				},
+				{
+					file_extension: "xlsx",
+					file_count: 1,
+					total_size_mb: 0,
+					median_file_size_kb: 2,
+				},
+			],
+		});
+	});
+
+	test("skips symbolic links while profiling workspace filesystem", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		await mkdir(directory, { recursive: true });
+		const realFilePath = path.join(directory, "real.md");
+		await writeFile(realFilePath, Buffer.alloc(1024));
+		await symlink(realFilePath, path.join(directory, "linked.md"));
+
+		await expect(
+			profileWorkspaceFilesystem({
+				ephemeral: false,
+				path: directory,
+				name: "workspace",
+			}),
+		).resolves.toMatchObject({
+			file_count: 1,
+			extension_counts: { md: 1 },
+		});
+	});
+
+	test("profiles transient workspaces from source files only", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		const openedFilePath = path.join(directory, "notes", "today.md");
+		await mkdir(path.dirname(openedFilePath), { recursive: true });
+		await writeFile(openedFilePath, Buffer.alloc(1024));
+		await writeFile(path.join(directory, "ignored.xlsx"), Buffer.alloc(4096));
+
+		await expect(
+			profileWorkspaceFilesystem({
+				ephemeral: true,
+				path: directory,
+				name: "workspace",
+				sourceFilePaths: [openedFilePath],
+			}),
+		).resolves.toMatchObject({
+			file_count: 1,
+			directory_count: 1,
+			extension_counts: { md: 1 },
+			total_size_mb: 0,
+		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"lucide-react": "^0.542.0",
 		"node-pty": "^1.0.0",
 		"papaparse": "^5.5.3",
-		"posthog-js": "^1.392.0",
+		"posthog-js": "^1.393.0",
 		"posthog-node": "^5.38.2",
 		"react": "^19.2.0",
 		"react-dom": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       posthog-js:
-        specifier: ^1.392.0
-        version: 1.392.0
+        specifier: ^1.393.0
+        version: 1.393.0
       posthog-node:
         specifier: ^5.38.2
         version: 5.38.2(rxjs@7.8.2)
@@ -882,8 +882,14 @@ packages:
   '@posthog/core@1.35.4':
     resolution: {integrity: sha512-DowOjN83tGtg4NPv0tmExjXiIWapHDDTv0ZZHg70XBjH5o/AB3DkMVMvj5ODIi1Y5bw7eMETidGvRwWH0/g3wA==}
 
+  '@posthog/core@1.37.1':
+    resolution: {integrity: sha512-KRBuxF/XBm3tNpqWlXpWE82XxsYsJb0jSyEic14LMXMvqDv5iApK1jfV0+seikDb9SpPs3tPkWUfHdwaUtFBtQ==}
+
   '@posthog/types@1.390.2':
     resolution: {integrity: sha512-WcfKz2GNn2vfDX8vXmJYbKxegPxVWHuDQ/pHdAn0HoZDXDFnEp/+x3qBQA+fEvtbPjjtjgAt2wIgJMlM7asx7g==}
+
+  '@posthog/types@1.391.0':
+    resolution: {integrity: sha512-oJ6jkqVMq+T4ax9F0rUllJc0KHpSgpaMwTNYWkE70iBiyXDVyhcNBmYnNKzSODgpzsaQNI6VfK8JrRYbkSJZZw==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -2886,8 +2892,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.392.0:
-    resolution: {integrity: sha512-dOZMzav59dRzI4SNmF+ZoRWj6evUVNxTMuHgbQWt+vTJzVl9UvdsUPFBBa13Skcw8eTwXpB54089yaCrEv11Ew==}
+  posthog-js@1.393.0:
+    resolution: {integrity: sha512-BNu62XUNkFEIq7ZQJwvgtZIgWUfn0HozVcYHO8P1WMq2Crx+d+/l7TJsO6YHf3aUUiJn+L8L8NX7XgFZxW3/tw==}
 
   posthog-node@5.38.2:
     resolution: {integrity: sha512-eiKpU+vX4hVuHbO/EosvPHsmh2AVIdoVmWss/uUOs1t4b0ViCblw2o8OIFqHxKj3mYRnSOBlX0Dw3wBvcCaYpA==}
@@ -4500,7 +4506,13 @@ snapshots:
     dependencies:
       '@posthog/types': 1.390.2
 
+  '@posthog/core@1.37.1':
+    dependencies:
+      '@posthog/types': 1.391.0
+
   '@posthog/types@1.390.2': {}
+
+  '@posthog/types@1.391.0': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -6601,10 +6613,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.392.0:
+  posthog-js@1.393.0:
     dependencies:
-      '@posthog/core': 1.35.4
-      '@posthog/types': 1.390.2
+      '@posthog/core': 1.37.1
+      '@posthog/types': 1.391.0
       core-js: 3.49.0
       dompurify: 3.4.11
       fflate: 0.4.8

--- a/src/extension-runtime/extension-context.ts
+++ b/src/extension-runtime/extension-context.ts
@@ -24,7 +24,15 @@ export function useExtensionContext({
 	const setterRef = useRef<
 		Record<string, (count: number | null | undefined) => void>
 	>({});
-	const contextRef = useRef<Record<string, ExtensionContext>>({});
+	const contextRef = useRef<
+		Record<
+			string,
+			{
+				readonly baseContext: ExtensionContext;
+				readonly context: ExtensionContext;
+			}
+		>
+	>({});
 
 	useEffect(() => {
 		setBadgeCounts((prev) => {
@@ -83,11 +91,12 @@ export function useExtensionContext({
 			const isActiveView = panel.activeInstance === instance.instance;
 			if (
 				cached &&
-				cached.setTabBadgeCount === setCount &&
-				cached.isPanelFocused === focusValue &&
-				cached.isActiveView === isActiveView
+				cached.baseContext === baseContext &&
+				cached.context.setTabBadgeCount === setCount &&
+				cached.context.isPanelFocused === focusValue &&
+				cached.context.isActiveView === isActiveView
 			) {
-				return cached;
+				return cached.context;
 			}
 
 			const next: ExtensionContext = {
@@ -96,7 +105,7 @@ export function useExtensionContext({
 				isActiveView,
 				isPanelFocused: focusValue,
 			};
-			contextRef.current[instance.instance] = next;
+			contextRef.current[instance.instance] = { baseContext, context: next };
 			return next;
 		},
 		[baseContext, getBadgeSetter, isFocused, panel.activeInstance],

--- a/src/extension-runtime/types.ts
+++ b/src/extension-runtime/types.ts
@@ -123,6 +123,10 @@ export interface ExtensionContext {
 		readonly launchArgs?: ExtensionLaunchArgs;
 		readonly focus?: boolean;
 		readonly pending?: boolean;
+		readonly documentOrigin?: "existing" | "new";
+		readonly trackTelemetry?: boolean;
+		readonly trackDocumentOpenAttempt?: boolean;
+		readonly trackDocumentViewed?: boolean;
 	}) => void;
 	readonly acceptExternalWriteReview?: (args: {
 		readonly fileId: string;

--- a/src/extensions/csv/index.tsx
+++ b/src/extensions/csv/index.tsx
@@ -77,7 +77,20 @@ function CsvViewContent({ fileId, ...props }: CsvViewProps) {
 			.where("id", "=", fileId)
 			.limit(1),
 	);
+	return (
+		<CsvViewData
+			fileRow={fileRow}
+			{...props}
+		/>
+	);
+}
 
+function CsvViewData({
+	fileRow,
+	...props
+}: Omit<CsvViewProps, "fileId"> & {
+	readonly fileRow?: CsvFileRow | undefined;
+}) {
 	if (!fileRow) {
 		return (
 			<div className="flex h-full items-center justify-center text-sm text-[var(--color-text-tertiary)]">

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -97,6 +97,8 @@ describe("FilesView", () => {
 		});
 		await waitForFilesViewReady(utils!);
 
+		await waitForFilesViewReady(utils!);
+
 		const initialRows = await qb(lix)
 			.selectFrom("lix_file")
 			.select(["id", "path"])
@@ -135,6 +137,7 @@ describe("FilesView", () => {
 				filePath: "/notes.md",
 				state: { focusOnLoad: true },
 				focus: true,
+				documentOrigin: "new",
 			});
 		});
 
@@ -214,6 +217,8 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
+
 		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
@@ -661,6 +666,8 @@ describe("FilesView", () => {
 		});
 		await waitForFilesViewReady(utils!);
 
+		await waitForFilesViewReady(utils!);
+
 		await act(async () => {
 			fireEvent.keyDown(document, { key: ".", metaKey: true });
 		});
@@ -708,6 +715,8 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
+
 		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
@@ -762,6 +771,8 @@ describe("FilesView", () => {
 		});
 		await waitForFilesViewReady(utils!);
 
+		await waitForFilesViewReady(utils!);
+
 		await act(async () => {
 			fireEvent.keyDown(document, { key: ".", ctrlKey: true });
 		});
@@ -793,6 +804,8 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
+
 		await waitForFilesViewReady(utils!);
 
 		await act(async () => {
@@ -831,6 +844,8 @@ describe("FilesView", () => {
 				</LixProvider>,
 			);
 		});
+		await waitForFilesViewReady(utils!);
+
 		await waitForFilesViewReady(utils!);
 
 		await act(async () => {

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -10,7 +10,7 @@ import { createReactExtensionDefinition } from "../../extension-runtime/react-ex
 import { qb } from "@/lib/lix-kysely";
 import { FILES_EXTENSION_KIND } from "../../extension-runtime/extension-instance-helpers";
 import type { FilesystemEntryRow } from "@/queries";
-import { captureTelemetry, fileExtensionProperty } from "@/lib/telemetry";
+import type { Lix } from "@/lib/lix-types";
 
 type FilesViewProps = {
 	readonly context?: ExtensionContext;
@@ -34,6 +34,17 @@ export function FilesView({ context }: FilesViewProps) {
 	const entries = useQuery<FilesystemEntryRow>((lix) =>
 		selectFilesystemEntries(lix),
 	);
+	return <FilesViewContent context={context} lix={lix} entries={entries} />;
+}
+
+function FilesViewContent({
+	context,
+	lix,
+	entries,
+}: FilesViewProps & {
+	readonly lix: Lix;
+	readonly entries: FilesystemEntryRow[];
+}) {
 	const nodes = useMemo(() => buildFilesystemTree(entries ?? []), [entries]);
 	const creatingRef = useRef(false);
 	const [pendingPaths, setPendingPaths] = useState<string[]>([]);
@@ -153,10 +164,6 @@ export function FilesView({ context }: FilesViewProps) {
 				if (!id) {
 					throw new Error(`created file id not found for path '${path}'`);
 				}
-				captureTelemetry("file created", {
-					file_extension: fileExtensionProperty(path),
-					source: "renderer",
-				});
 				setPendingPaths((prev) => [...prev, path]);
 				setSelectedPath(path);
 				setSelectedFileId(id);
@@ -167,6 +174,7 @@ export function FilesView({ context }: FilesViewProps) {
 					filePath: path,
 					state: { focusOnLoad: true },
 					focus: true,
+					documentOrigin: "new",
 				});
 			} catch (error) {
 				console.error("Failed to create file", error);
@@ -431,11 +439,6 @@ export function FilesView({ context }: FilesViewProps) {
 							data: new TextEncoder().encode(content),
 						})
 						.execute();
-					captureTelemetry("file created", {
-						file_extension: fileExtensionProperty(filePath),
-						source: "renderer",
-					});
-
 					// Open the first dropped file
 					if (file === markdownFiles[0]) {
 						const newFile = await qb(lix)
@@ -449,6 +452,7 @@ export function FilesView({ context }: FilesViewProps) {
 								panel: "central",
 								fileId: newFile.id as string,
 								filePath,
+								documentOrigin: "new",
 							});
 						}
 					}

--- a/src/extensions/markdown/editor/create-editor.test.ts
+++ b/src/extensions/markdown/editor/create-editor.test.ts
@@ -310,16 +310,15 @@ test("replace entire document with paste (TipTap + Lix)", async () => {
 		},
 	});
 
+	const expectedMarkdown = ensureTrailingNewline(
+		"# New Document\n\nCompletely new content",
+	);
 	const mdAfter = await waitForMarkdown(
 		lix,
 		fileId,
-		(markdown) =>
-			markdown ===
-			ensureTrailingNewline("# New Document\n\nCompletely new content"),
+		(markdown) => markdown === expectedMarkdown,
 	);
-	expect(mdAfter).toBe(
-		ensureTrailingNewline("# New Document\n\nCompletely new content"),
-	);
+	expect(mdAfter).toBe(expectedMarkdown);
 	editor.destroy();
 });
 

--- a/src/extensions/markdown/editor/upsert-markdown-file.ts
+++ b/src/extensions/markdown/editor/upsert-markdown-file.ts
@@ -4,7 +4,9 @@ import { markFlashtypeMarkdownWrite } from "../external-write-tracking";
 import {
 	captureTelemetryThrottled,
 	fileExtensionProperty,
+	workspaceTelemetryProperties,
 } from "@/lib/telemetry";
+import { readWorkspaceId } from "@/lib/workspace-profile-telemetry";
 
 export async function upsertMarkdownFile(args: {
 	lix: Lix;
@@ -35,19 +37,23 @@ export async function upsertMarkdownFile(args: {
 		markFlashtypeMarkdownWrite(fileId, markdown);
 		const resolvedPath = path ?? existing.path ?? `/${fileId}.md`;
 		const resolvedMetadata = metadata ?? existing.lixcol_metadata ?? null;
+		const updateValues: {
+			data: Uint8Array;
+			path?: string;
+			lixcol_metadata?: any;
+		} = { data };
+		if (path !== undefined && resolvedPath !== existing.path) {
+			updateValues.path = resolvedPath;
+		}
+		if (metadata !== undefined && metadata !== existing.lixcol_metadata) {
+			updateValues.lixcol_metadata = resolvedMetadata;
+		}
 		await db
 			.updateTable("lix_file")
-			.set({
-				path: resolvedPath,
-				data,
-				lixcol_metadata: resolvedMetadata,
-			})
+			.set(updateValues)
 			.where("id", "=", fileId)
 			.execute();
-		captureTelemetryThrottled(`file saved:${fileId}`, "file saved", {
-			file_extension: fileExtensionProperty(resolvedPath),
-			source: "renderer",
-		});
+		captureDocumentModifiedTelemetry({ lix, fileId, filePath: resolvedPath });
 	} else {
 		if (!createIfMissing) return;
 		markFlashtypeMarkdownWrite(fileId, markdown);
@@ -61,9 +67,36 @@ export async function upsertMarkdownFile(args: {
 				lixcol_metadata: metadata ?? null,
 			})
 			.execute();
-		captureTelemetryThrottled(`file saved:${fileId}`, "file saved", {
-			file_extension: fileExtensionProperty(path ?? `/${fileId}.md`),
-			source: "renderer",
+		captureDocumentModifiedTelemetry({
+			lix,
+			fileId,
+			filePath: path ?? `/${fileId}.md`,
 		});
 	}
+}
+
+function captureDocumentModifiedTelemetry({
+	lix,
+	fileId,
+	filePath,
+}: {
+	readonly lix: Lix;
+	readonly fileId: string;
+	readonly filePath: string;
+}) {
+	void (async () => {
+		const workspaceId = await readWorkspaceId(lix);
+		captureTelemetryThrottled(
+			`document modified:${fileId}`,
+			"document modified",
+			{
+				file_extension: fileExtensionProperty(filePath),
+				modified_by: "user",
+				source: "renderer",
+				...workspaceTelemetryProperties(workspaceId),
+			},
+		);
+	})().catch((error: unknown) => {
+		console.warn("Failed to capture document modified telemetry", error);
+	});
 }

--- a/src/hooks/key-value/use-key-value.test.tsx
+++ b/src/hooks/key-value/use-key-value.test.tsx
@@ -3,7 +3,6 @@ import { test, expect, vi } from "vitest";
 import { qb } from "@/lib/lix-kysely";
 import {
 	render,
-	renderHook,
 	screen,
 	waitFor,
 	act,
@@ -34,6 +33,20 @@ async function actAndFlush(callback: () => void | Promise<void>) {
 	});
 }
 
+function renderUseKeyValue(
+	key: string,
+	wrapper: React.ComponentType<{ children: React.ReactNode }>,
+	opts?: Parameters<typeof useKeyValue>[1],
+) {
+	const resultRef: { current: unknown } = { current: null };
+	function TestComponent() {
+		resultRef.current = useKeyValue(key, opts);
+		return null;
+	}
+	render(<TestComponent />, { wrapper });
+	return resultRef;
+}
+
 test("reads a global, untracked key (test fixture)", async () => {
 	const testKey = nextTestKey("flashtype_test_untracked");
 	const defs = withKeyDef(testKey, {
@@ -61,17 +74,14 @@ test("reads a global, untracked key (test fixture)", async () => {
 		.execute();
 
 	let hookResult: { current: unknown } = { current: null };
-
 	await act(async () => {
-		const { result } = renderHook(() => useKeyValue(testKey), {
-			wrapper,
-		});
-		hookResult = result as unknown as { current: unknown };
+		hookResult = renderUseKeyValue(testKey, wrapper);
 	});
 
-	await waitFor(() =>
-		expect(Array.isArray(hookResult.current as any)).toBe(true),
-	);
+	await waitFor(() => {
+		const [value] = hookResult.current as any;
+		expect(value).toBe("alpha");
+	});
 
 	const [value] = hookResult.current as any;
 	expect(value).toBe("alpha");
@@ -94,10 +104,7 @@ test("writes and reads a global, untracked key (test fixture)", async () => {
 
 	let resultRef: { current: unknown } = { current: null };
 	await act(async () => {
-		const { result } = renderHook(() => useKeyValue(testKey), {
-			wrapper,
-		});
-		resultRef = result as unknown as { current: unknown };
+		resultRef = renderUseKeyValue(testKey, wrapper);
 	});
 
 	// Wait for hook to initialize
@@ -107,6 +114,7 @@ test("writes and reads a global, untracked key (test fixture)", async () => {
 
 	await actAndFlush(async () => {
 		await (resultRef.current as any)?.[1]("beta");
+		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
 
 	await waitFor(() => expect((resultRef.current as any)?.[0]).toBe("beta"));
@@ -134,8 +142,7 @@ test("writes and reads a tracked key on active branch", async () => {
 
 	let hookResult: { current: unknown } = { current: null };
 	await act(async () => {
-		const { result } = renderHook(() => useKeyValue(TEST_KEY), { wrapper });
-		hookResult = result as unknown as { current: unknown };
+		hookResult = renderUseKeyValue(TEST_KEY, wrapper);
 	});
 
 	// Wait for hook to initialize
@@ -147,6 +154,7 @@ test("writes and reads a tracked key on active branch", async () => {
 
 	await actAndFlush(async () => {
 		await (hookResult.current as any)[1]("hello");
+		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
 
 	await waitFor(() => {
@@ -180,8 +188,7 @@ test("writes and reads an untracked key on active branch", async () => {
 
 	let hookResult: { current: unknown } = { current: null };
 	await act(async () => {
-		const { result } = renderHook(() => useKeyValue(testKey), { wrapper });
-		hookResult = result as unknown as { current: unknown };
+		hookResult = renderUseKeyValue(testKey, wrapper);
 	});
 
 	await waitFor(() =>
@@ -189,6 +196,8 @@ test("writes and reads an untracked key on active branch", async () => {
 	);
 	await actAndFlush(async () => {
 		await (hookResult.current as any)[1]("local");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
 	await waitFor(() => expect((hookResult.current as any)[0]).toBe("local"));
 
@@ -243,8 +252,7 @@ test("reads explicit global key when active branch has same key", async () => {
 
 	let hookResult: { current: unknown } = { current: null };
 	await act(async () => {
-		const { result } = renderHook(() => useKeyValue(testKey), { wrapper });
-		hookResult = result as unknown as { current: unknown };
+		hookResult = renderUseKeyValue(testKey, wrapper);
 	});
 
 	await waitFor(() =>
@@ -309,8 +317,7 @@ test("re-renders when key value changes externally", async () => {
 
 	let resultRef: { current: unknown } = { current: null };
 	await act(async () => {
-		const { result } = renderHook(() => useKeyValue(TEST_KEY), { wrapper });
-		resultRef = result as unknown as { current: unknown };
+		resultRef = renderUseKeyValue(TEST_KEY, wrapper);
 	});
 	// wait for initial suspense resolution
 	await waitFor(() =>
@@ -470,8 +477,7 @@ test("returns optimistic value immediately when setter is called", async () => {
 
 	let hookResult: { current: unknown } = { current: null };
 	await act(async () => {
-		const { result } = renderHook(() => useKeyValue(TEST_KEY), { wrapper });
-		hookResult = result as unknown as { current: unknown };
+		hookResult = renderUseKeyValue(TEST_KEY, wrapper);
 	});
 
 	await waitFor(() =>
@@ -483,7 +489,7 @@ test("returns optimistic value immediately when setter is called", async () => {
 		pending = (hookResult.current as any)[1]("value-1");
 	});
 
-	expect((hookResult.current as any)[0]).toBe("value-1");
+	await waitFor(() => expect((hookResult.current as any)[0]).toBe("value-1"));
 
 	await actAndFlush(async () => {
 		await pending;

--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -4,38 +4,17 @@ let activated = false;
 let activationPromise: Promise<boolean> | null = null;
 let sessionContextSynced = false;
 
-export async function capturePostHogWorkspaceActive({
-	reason,
-	workspaceId,
-}: {
-	reason: string;
-	workspaceId?: string;
-}) {
-	if (!(await ensurePostHogTelemetry())) {
-		return;
-	}
-
-	syncPostHogSessionContext();
-	posthog.capture("workspace active", {
-		reason,
-		source: "renderer",
-		telemetry_client: "posthog-js",
-		throttle_minutes: 30,
-		workspace_id: workspaceId,
-	});
-}
-
-async function ensurePostHogTelemetry() {
+export async function activatePostHogRecording() {
 	if (activated) {
 		return true;
 	}
-	activationPromise ??= activatePostHogTelemetry().finally(() => {
+	activationPromise ??= activatePostHogRecordingUncached().finally(() => {
 		activationPromise = null;
 	});
 	return await activationPromise;
 }
 
-async function activatePostHogTelemetry() {
+async function activatePostHogRecordingUncached() {
 	const config = await window.flashtypeDesktop?.telemetry?.getClientConfig();
 	if (!config?.enabled) {
 		return false;
@@ -46,19 +25,15 @@ async function activatePostHogTelemetry() {
 		defaults: "2026-05-30",
 		autocapture: false,
 		capture_pageview: false,
-		disable_session_recording: true,
+		disable_session_recording: !config.sessionRecordingEnabled,
 		before_send: (event) => scrubPostHogEvent(event),
 		session_recording: {
 			maskAllInputs: true,
-			maskTextSelector: ".ph-mask",
+			maskTextSelector: "*",
+			blockSelector: ".ph-no-capture",
 		},
 	});
 	posthog.identify(config.distinctId);
-	posthog.startExceptionAutocapture({
-		capture_unhandled_errors: true,
-		capture_unhandled_rejections: true,
-		capture_console_errors: false,
-	});
 	syncPostHogSessionContext();
 
 	if (config.sessionRecordingEnabled) {

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -8,7 +8,7 @@ describe("fileExtensionProperty", () => {
 		expect(fileExtensionProperty("/exports/data.acmecustomer")).toBe(
 			"acmecustomer",
 		);
-		expect(fileExtensionProperty("/README")).toBe("none");
+		expect(fileExtensionProperty("/README")).toBe("(none)");
 	});
 });
 
@@ -26,7 +26,7 @@ describe("captureTelemetry", () => {
 			},
 		} as unknown as Window["flashtypeDesktop"];
 
-		captureTelemetry("file opened", { file_extension: "md" });
+		captureTelemetry("document viewed", { file_extension: "md" });
 		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		expect(warn).toHaveBeenCalledWith(

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -8,11 +8,7 @@ type TelemetryEventName = NonNullable<
 
 type TelemetryProperties = Record<
 	string,
-	| string
-	| number
-	| boolean
-	| Record<string, number>
-	| undefined
+	string | number | boolean | Record<string, string | number> | undefined
 >;
 
 const throttledTelemetryEvents = new Map<string, number>();
@@ -58,14 +54,21 @@ export function fileExtensionProperty(filePath: string | null | undefined) {
 	const fileName = filePath.split("/").pop() ?? filePath;
 	const match = fileName.match(/\.([^./]+)$/);
 	if (!match?.[1]) {
-		return "none";
+		return "(none)";
 	}
 	return normalizeTelemetryFileExtension(match[1]);
 }
 
 export function normalizeTelemetryFileExtension(extension: string) {
 	const normalized = extension.trim().toLowerCase();
-	return /^[a-z0-9][a-z0-9+_-]{0,15}$/.test(normalized)
-		? normalized
-		: "other";
+	return /^[a-z0-9][a-z0-9+_-]{0,15}$/.test(normalized) ? normalized : "other";
+}
+
+export function workspaceTelemetryProperties(workspaceId: string | undefined) {
+	return workspaceId
+		? {
+				workspace_id: workspaceId,
+				$groups: { workspace: workspaceId },
+			}
+		: {};
 }

--- a/src/lib/workspace-profile-telemetry.test.ts
+++ b/src/lib/workspace-profile-telemetry.test.ts
@@ -18,14 +18,11 @@ describe("buildWorkspaceProfile", () => {
 			directoryCount: 4,
 			extensionCount: 4,
 			extensionCounts: {
+				"(none)": 1,
 				csv: 2,
 				md: 2,
-				none: 1,
 				tsx: 1,
 			},
-			largestExtension: "csv",
-			largestExtensionFileCount: 2,
-			largestExtensionShare: 2 / 6,
 		});
 	});
 
@@ -40,9 +37,6 @@ describe("buildWorkspaceProfile", () => {
 			directoryCount: 0,
 			extensionCount: 0,
 			extensionCounts: {},
-			largestExtension: undefined,
-			largestExtensionFileCount: undefined,
-			largestExtensionShare: undefined,
 		});
 	});
 
@@ -54,8 +48,8 @@ describe("buildWorkspaceProfile", () => {
 		]);
 
 		expect(profile.extensionCounts).toEqual({
+			"(none)": 1,
 			gz: 1,
-			none: 1,
 			other: 1,
 		});
 	});

--- a/src/lib/workspace-profile-telemetry.ts
+++ b/src/lib/workspace-profile-telemetry.ts
@@ -3,6 +3,7 @@ import { qb } from "@/lib/lix-kysely";
 import {
 	captureTelemetryAsync,
 	normalizeTelemetryFileExtension,
+	workspaceTelemetryProperties,
 } from "@/lib/telemetry";
 
 const INTERNAL_WORKSPACE_PATH_PREFIX = "/.lix/";
@@ -13,15 +14,18 @@ type WorkspaceProfile = {
 	directoryCount: number;
 	extensionCount: number;
 	extensionCounts: Record<string, number>;
-	largestExtension?: string;
-	largestExtensionFileCount?: number;
-	largestExtensionShare?: number;
+	totalSizeMb?: number;
+	extensions?: WorkspaceExtensionProfile[];
 };
 
-export async function captureWorkspaceProfile(args: {
-	lix: Lix;
-	isEphemeralWorkspace: boolean;
-}) {
+type WorkspaceExtensionProfile = {
+	fileExtension: string;
+	fileCount: number;
+	totalSizeMb: number;
+	medianFileSizeKb: number;
+};
+
+export async function captureWorkspaceProfile(args: { lix: Lix }) {
 	const workspaceId = await readWorkspaceId(args.lix);
 	if (!workspaceId) {
 		return;
@@ -31,8 +35,7 @@ export async function captureWorkspaceProfile(args: {
 		return;
 	}
 
-	const filePaths = await readWorkspaceFilePaths(args.lix);
-	const profile = buildWorkspaceProfile(filePaths);
+	const profile = await readWorkspaceProfile(args.lix);
 	try {
 		await captureTelemetryAsync("workspace profiled", {
 			workspace_id: workspaceId,
@@ -40,11 +43,18 @@ export async function captureWorkspaceProfile(args: {
 			directory_count: profile.directoryCount,
 			extension_count: profile.extensionCount,
 			extension_counts: profile.extensionCounts,
-			largest_extension: profile.largestExtension,
-			largest_extension_file_count: profile.largestExtensionFileCount,
-			largest_extension_share: profile.largestExtensionShare,
-			is_ephemeral_workspace: args.isEphemeralWorkspace,
+			total_size_mb: profile.totalSizeMb,
+			...workspaceTelemetryProperties(workspaceId),
 		});
+		for (const extensionProfile of profile.extensions ?? []) {
+			await captureTelemetryAsync("workspace extension profiled", {
+				file_extension: extensionProfile.fileExtension,
+				file_count: extensionProfile.fileCount,
+				total_size_mb: extensionProfile.totalSizeMb,
+				median_file_size_kb: extensionProfile.medianFileSizeKb,
+				...workspaceTelemetryProperties(workspaceId),
+			});
+		}
 	} finally {
 		markWorkspaceProfiled(workspaceId);
 	}
@@ -92,25 +102,15 @@ export function buildWorkspaceProfile(
 		(total, count) => total + count,
 		0,
 	);
-	const extensions = Array.from(extensionCounts.entries()).sort((left, right) => {
-		if (right[1] !== left[1]) {
-			return right[1] - left[1];
-		}
-		return left[0].localeCompare(right[0]);
-	});
-	const [largestExtension, largestExtensionFileCount] = extensions[0] ?? [];
-
 	return {
 		fileCount,
 		directoryCount: directories.size,
-		extensionCount: extensions.length,
-		extensionCounts: Object.fromEntries(extensions),
-		largestExtension,
-		largestExtensionFileCount,
-		largestExtensionShare:
-			fileCount > 0 && largestExtensionFileCount !== undefined
-				? largestExtensionFileCount / fileCount
-				: undefined,
+		extensionCount: extensionCounts.size,
+		extensionCounts: Object.fromEntries(
+			Array.from(extensionCounts.entries()).sort((left, right) =>
+				left[0].localeCompare(right[0]),
+			),
+		),
 	};
 }
 
@@ -123,6 +123,33 @@ export async function readWorkspaceId(lix: Lix) {
 	return typeof row?.value === "string" && row.value.length > 0
 		? row.value
 		: undefined;
+}
+
+async function readWorkspaceProfile(lix: Lix): Promise<WorkspaceProfile> {
+	const filesystemProfile = await window.flashtypeDesktop?.workspace
+		.profile()
+		.catch((error: unknown) => {
+			console.warn("Failed to profile workspace filesystem", error);
+			return null;
+		});
+	if (filesystemProfile) {
+		return {
+			fileCount: filesystemProfile.file_count,
+			directoryCount: filesystemProfile.directory_count,
+			extensionCount: filesystemProfile.extension_count,
+			extensionCounts: filesystemProfile.extension_counts,
+			totalSizeMb: filesystemProfile.total_size_mb,
+			extensions: filesystemProfile.extensions.map((extension) => ({
+				fileExtension: extension.file_extension,
+				fileCount: extension.file_count,
+				totalSizeMb: extension.total_size_mb,
+				medianFileSizeKb: extension.median_file_size_kb,
+			})),
+		};
+	}
+
+	const filePaths = await readWorkspaceFilePaths(lix);
+	return buildWorkspaceProfile(filePaths);
 }
 
 async function readWorkspaceFilePaths(lix: Lix) {
@@ -142,7 +169,7 @@ function extensionFromPath(path: string) {
 	const fileName = path.split("/").pop() ?? path;
 	const match = fileName.match(/\.([^./]+)$/);
 	if (!match?.[1]) {
-		return "none";
+		return "(none)";
 	}
 	return normalizeTelemetryFileExtension(match[1]);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,18 +18,13 @@ import { V2LayoutShell } from "./shell/layout-shell";
 import { FirstRunScreen } from "./shell/first-run-screen";
 import { WorkspaceLoadingScreen } from "./shell/workspace-loading-screen";
 import { openDesktopLix } from "./lib/lix-client";
-import { captureTelemetry } from "./lib/telemetry";
-import {
-	captureWorkspaceProfile,
-	readWorkspaceId,
-} from "./lib/workspace-profile-telemetry";
-import { capturePostHogWorkspaceActive } from "./lib/posthog-client";
+import { captureWorkspaceProfile } from "./lib/workspace-profile-telemetry";
+import { activatePostHogRecording } from "./lib/posthog-client";
 
 type Workspace = Awaited<
 	ReturnType<NonNullable<Window["flashtypeDesktop"]>["workspace"]["get"]>
 >;
 
-const WORKSPACE_ACTIVE_SIGNAL_THROTTLE_MS = 30 * 60 * 1000;
 const WORKSPACE_TOO_LARGE_ERROR_CODE = "ERR_FLASHTYPE_WORKSPACE_TOO_LARGE";
 
 /**
@@ -51,6 +46,10 @@ export const AppRoot = () => {
 		string | null | undefined
 	>(undefined);
 	const [isUpdateReady, setIsUpdateReady] = useState(false);
+
+	useEffect(() => {
+		void activatePostHogRecording();
+	}, []);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -75,16 +74,9 @@ export const AppRoot = () => {
 	}, [workspace]);
 
 	const openFolderInFlightRef = useRef(false);
-	const lastWorkspaceActiveSignalRef = useRef(0);
-	const workspaceIdRef = useRef<string | undefined>(undefined);
 	const handleInstallUpdate = useCallback(async () => {
-		captureTelemetry("update installed", { source: "renderer" });
 		await window.flashtypeDesktop?.app?.installUpdate();
 	}, []);
-
-	useEffect(() => {
-		workspaceIdRef.current = undefined;
-	}, [workspace]);
 
 	useEffect(() => {
 		const desktopApp = window.flashtypeDesktop?.app;
@@ -187,76 +179,15 @@ export const AppRoot = () => {
 		};
 	}, [workspace]);
 
-	const signalWorkspaceActive = useCallback(
-		(reason: string) => {
-			if (!workspace || !lix) return;
-			const now = Date.now();
-			if (
-				reason !== "workspace_ready" &&
-				now - lastWorkspaceActiveSignalRef.current <
-					WORKSPACE_ACTIVE_SIGNAL_THROTTLE_MS
-			) {
-				return;
-			}
-			lastWorkspaceActiveSignalRef.current = now;
-			void (async () => {
-				const workspaceId =
-					workspaceIdRef.current ?? (await readWorkspaceId(lix));
-				workspaceIdRef.current = workspaceId;
-				void capturePostHogWorkspaceActive({ reason, workspaceId }).catch(
-					(error: unknown) => {
-						console.warn("Failed to capture workspace active telemetry", error);
-					},
-				);
-			})().catch((error: unknown) => {
-				console.warn("Failed to capture workspace active telemetry", error);
-			});
-		},
-		[lix, workspace],
-	);
-
-	useEffect(() => {
-		signalWorkspaceActive("workspace_ready");
-	}, [signalWorkspaceActive]);
-
 	useEffect(() => {
 		if (!workspace || !lix) return;
 		setOpeningWorkspaceName(undefined);
 		void captureWorkspaceProfile({
 			lix,
-			isEphemeralWorkspace: workspace.ephemeral,
 		}).catch((error: unknown) => {
 			console.warn("Failed to capture workspace profile telemetry", error);
 		});
 	}, [lix, workspace]);
-
-	useEffect(() => {
-		if (!workspace || !lix) return;
-		const handleFocus = () => signalWorkspaceActive("window_focused");
-		const handleVisibilityChange = () => {
-			if (document.visibilityState === "visible") {
-				signalWorkspaceActive("document_visible");
-			}
-		};
-		const handleInteraction = () => signalWorkspaceActive("user_interaction");
-
-		window.addEventListener("focus", handleFocus);
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		window.addEventListener("pointerdown", handleInteraction, {
-			capture: true,
-		});
-		window.addEventListener("keydown", handleInteraction, { capture: true });
-		return () => {
-			window.removeEventListener("focus", handleFocus);
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			window.removeEventListener("pointerdown", handleInteraction, {
-				capture: true,
-			});
-			window.removeEventListener("keydown", handleInteraction, {
-				capture: true,
-			});
-		};
-	}, [lix, signalWorkspaceActive, workspace]);
 
 	useEffect(() => {
 		if (!workspace || !lix) return;

--- a/src/shell/external-write-detector.tsx
+++ b/src/shell/external-write-detector.tsx
@@ -8,16 +8,20 @@ import {
 	consumeRecentFlashtypeFileWrite,
 	hashFileData,
 } from "@/extension-runtime/external-write-tracking";
+import { decodeFileDataToBytes } from "@/lib/decode-file-data";
 
 type ReviewableFileSnapshot = {
 	id: string;
 	path: string;
 	hash: string;
+	data: Uint8Array;
 };
 
 export type ExternalFileWrite = {
 	fileId: string;
 	path: string;
+	beforeData: Uint8Array;
+	afterData: Uint8Array;
 };
 
 const REVIEWABLE_FILE_EXTENSION_CLAUSE =
@@ -38,7 +42,7 @@ export function ExternalWriteDetector({
 	onExternalWrites: (writes: ExternalFileWrite[]) => void;
 }) {
 	const lix = useLix();
-	const lastHashesRef = useRef(new Map<string, string>());
+	const lastSnapshotsRef = useRef(new Map<string, ReviewableFileSnapshot>());
 	const hasInitialSnapshotRef = useRef(false);
 
 	useEffect(() => {
@@ -50,23 +54,28 @@ export function ExternalWriteDetector({
 			const reviewableRows = rowObjects
 				.map(readReviewableFileSnapshot)
 				.filter((row): row is ReviewableFileSnapshot => row !== null);
-			const nextHashes = new Map<string, string>();
+			const nextSnapshots = new Map<string, ReviewableFileSnapshot>();
 			const externalWrites: ExternalFileWrite[] = [];
 
 			for (const row of reviewableRows) {
-				nextHashes.set(row.id, row.hash);
+				nextSnapshots.set(row.id, row);
 				if (!hasInitialSnapshotRef.current) continue;
 
-				const previousHash = lastHashesRef.current.get(row.id);
-				if (!previousHash || previousHash === row.hash) continue;
+				const previous = lastSnapshotsRef.current.get(row.id);
+				if (!previous || previous.hash === row.hash) continue;
 
 				if (consumeRecentFlashtypeFileWrite(row.id, row.hash)) {
 					continue;
 				}
-				externalWrites.push({ fileId: row.id, path: row.path });
+				externalWrites.push({
+					fileId: row.id,
+					path: row.path,
+					beforeData: previous.data,
+					afterData: row.data,
+				});
 			}
 
-			lastHashesRef.current = nextHashes;
+			lastSnapshotsRef.current = nextSnapshots;
 			if (!hasInitialSnapshotRef.current) {
 				hasInitialSnapshotRef.current = true;
 				return;
@@ -142,5 +151,10 @@ function readReviewableFileSnapshot(
 		id,
 		path,
 		hash: hashFileData(data),
+		data: cloneBytes(decodeFileDataToBytes(data)),
 	};
+}
+
+function cloneBytes(bytes: Uint8Array): Uint8Array {
+	return new Uint8Array(bytes);
 }

--- a/src/shell/external-write-detector.tsx
+++ b/src/shell/external-write-detector.tsx
@@ -8,20 +8,16 @@ import {
 	consumeRecentFlashtypeFileWrite,
 	hashFileData,
 } from "@/extension-runtime/external-write-tracking";
-import { decodeFileDataToBytes } from "@/lib/decode-file-data";
 
 type ReviewableFileSnapshot = {
 	id: string;
 	path: string;
 	hash: string;
-	data: Uint8Array;
 };
 
 export type ExternalFileWrite = {
 	fileId: string;
 	path: string;
-	beforeData: Uint8Array;
-	afterData: Uint8Array;
 };
 
 const REVIEWABLE_FILE_EXTENSION_CLAUSE =
@@ -42,7 +38,7 @@ export function ExternalWriteDetector({
 	onExternalWrites: (writes: ExternalFileWrite[]) => void;
 }) {
 	const lix = useLix();
-	const lastSnapshotsRef = useRef(new Map<string, ReviewableFileSnapshot>());
+	const lastHashesRef = useRef(new Map<string, string>());
 	const hasInitialSnapshotRef = useRef(false);
 
 	useEffect(() => {
@@ -54,28 +50,23 @@ export function ExternalWriteDetector({
 			const reviewableRows = rowObjects
 				.map(readReviewableFileSnapshot)
 				.filter((row): row is ReviewableFileSnapshot => row !== null);
-			const nextSnapshots = new Map<string, ReviewableFileSnapshot>();
+			const nextHashes = new Map<string, string>();
 			const externalWrites: ExternalFileWrite[] = [];
 
 			for (const row of reviewableRows) {
-				nextSnapshots.set(row.id, row);
+				nextHashes.set(row.id, row.hash);
 				if (!hasInitialSnapshotRef.current) continue;
 
-				const previous = lastSnapshotsRef.current.get(row.id);
-				if (!previous || previous.hash === row.hash) continue;
+				const previousHash = lastHashesRef.current.get(row.id);
+				if (!previousHash || previousHash === row.hash) continue;
 
 				if (consumeRecentFlashtypeFileWrite(row.id, row.hash)) {
 					continue;
 				}
-				externalWrites.push({
-					fileId: row.id,
-					path: row.path,
-					beforeData: previous.data,
-					afterData: row.data,
-				});
+				externalWrites.push({ fileId: row.id, path: row.path });
 			}
 
-			lastSnapshotsRef.current = nextSnapshots;
+			lastHashesRef.current = nextHashes;
 			if (!hasInitialSnapshotRef.current) {
 				hasInitialSnapshotRef.current = true;
 				return;
@@ -151,10 +142,5 @@ function readReviewableFileSnapshot(
 		id,
 		path,
 		hash: hashFileData(data),
-		data: cloneBytes(decodeFileDataToBytes(data)),
 	};
-}
-
-function cloneBytes(bytes: Uint8Array): Uint8Array {
-	return new Uint8Array(bytes);
 }

--- a/src/shell/external-write-review-history.ts
+++ b/src/shell/external-write-review-history.ts
@@ -19,23 +19,59 @@ export async function getExternalWriteReview(
 	if (!rows || rows.history.length < 2) return null;
 	const afterData = decodeFileDataToBytes(rows.history[0]?.data);
 	const beforeData = decodeFileDataToBytes(rows.history[1]?.data);
+	const afterCommitId =
+		rows.history[0]?.lixcol_observed_commit_id ?? rows.startCommitId;
+	const afterDepth =
+		typeof rows.history[0]?.lixcol_depth === "number"
+			? rows.history[0].lixcol_depth
+			: undefined;
 	return {
 		fileId,
 		path,
-		reviewId: `${fileId}:${hashFileData(beforeData)}:${hashFileData(afterData)}`,
+		reviewId: [
+			fileId,
+			hashFileData(beforeData),
+			hashFileData(afterData),
+			afterCommitId,
+			afterDepth ?? "unknown-depth",
+		].join(":"),
 		afterData,
 		beforeData,
-		afterCommitId:
-			rows.history[0]?.lixcol_observed_commit_id ?? rows.startCommitId,
+		afterCommitId,
 		beforeCommitId: rows.history[1]?.lixcol_observed_commit_id ?? undefined,
-		afterDepth:
-			typeof rows.history[0]?.lixcol_depth === "number"
-				? rows.history[0].lixcol_depth
-				: undefined,
+		afterDepth,
 		beforeDepth:
 			typeof rows.history[1]?.lixcol_depth === "number"
 				? rows.history[1].lixcol_depth
 				: undefined,
+	};
+}
+
+export function createExternalWriteReviewFromSnapshots({
+	fileId,
+	path,
+	beforeData,
+	afterData,
+}: {
+	readonly fileId: string;
+	readonly path: string;
+	readonly beforeData: Uint8Array;
+	readonly afterData: Uint8Array;
+}): ExternalWriteReview {
+	const before = new Uint8Array(beforeData);
+	const after = new Uint8Array(afterData);
+	return {
+		fileId,
+		path,
+		reviewId: [
+			fileId,
+			hashFileData(before),
+			hashFileData(after),
+			Date.now().toString(36),
+			Math.random().toString(36).slice(2),
+		].join(":"),
+		beforeData: before,
+		afterData: after,
 	};
 }
 

--- a/src/shell/external-write-review-history.ts
+++ b/src/shell/external-write-review-history.ts
@@ -19,59 +19,23 @@ export async function getExternalWriteReview(
 	if (!rows || rows.history.length < 2) return null;
 	const afterData = decodeFileDataToBytes(rows.history[0]?.data);
 	const beforeData = decodeFileDataToBytes(rows.history[1]?.data);
-	const afterCommitId =
-		rows.history[0]?.lixcol_observed_commit_id ?? rows.startCommitId;
-	const afterDepth =
-		typeof rows.history[0]?.lixcol_depth === "number"
-			? rows.history[0].lixcol_depth
-			: undefined;
 	return {
 		fileId,
 		path,
-		reviewId: [
-			fileId,
-			hashFileData(beforeData),
-			hashFileData(afterData),
-			afterCommitId,
-			afterDepth ?? "unknown-depth",
-		].join(":"),
+		reviewId: `${fileId}:${hashFileData(beforeData)}:${hashFileData(afterData)}`,
 		afterData,
 		beforeData,
-		afterCommitId,
+		afterCommitId:
+			rows.history[0]?.lixcol_observed_commit_id ?? rows.startCommitId,
 		beforeCommitId: rows.history[1]?.lixcol_observed_commit_id ?? undefined,
-		afterDepth,
+		afterDepth:
+			typeof rows.history[0]?.lixcol_depth === "number"
+				? rows.history[0].lixcol_depth
+				: undefined,
 		beforeDepth:
 			typeof rows.history[1]?.lixcol_depth === "number"
 				? rows.history[1].lixcol_depth
 				: undefined,
-	};
-}
-
-export function createExternalWriteReviewFromSnapshots({
-	fileId,
-	path,
-	beforeData,
-	afterData,
-}: {
-	readonly fileId: string;
-	readonly path: string;
-	readonly beforeData: Uint8Array;
-	readonly afterData: Uint8Array;
-}): ExternalWriteReview {
-	const before = new Uint8Array(beforeData);
-	const after = new Uint8Array(afterData);
-	return {
-		fileId,
-		path,
-		reviewId: [
-			fileId,
-			hashFileData(before),
-			hashFileData(after),
-			Date.now().toString(36),
-			Math.random().toString(36).slice(2),
-		].join(":"),
-		beforeData: before,
-		afterData: after,
 	};
 }
 

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -1303,10 +1303,12 @@ function LayoutShellContent({
 			panel,
 			instance,
 			kind,
+			focus = false,
 		}: {
 			panel?: PanelSide;
 			instance?: string;
 			kind?: ExtensionKind;
+			focus?: boolean;
 		}) => {
 			if (!instance && !kind) return;
 			const predicate = (entry: ExtensionInstance) => {
@@ -1323,18 +1325,22 @@ function LayoutShellContent({
 				const removedReview =
 					removedView?.launchArgs?.[EXTERNAL_WRITE_REVIEW_LAUNCH_ARG];
 				let removed = false;
-				setPanelState(side, (current) => {
-					const index = current.views.findIndex(predicate);
-					if (index === -1) return current;
-					removed = true;
-					const views = current.views.filter((_, idx) => idx !== index);
-					const removedEntry = current.views[index];
-					const activeInstance =
-						current.activeInstance === removedEntry?.instance
-							? (views[views.length - 1]?.instance ?? null)
-							: current.activeInstance;
-					return { views, activeInstance };
-				});
+				setPanelState(
+					side,
+					(current) => {
+						const index = current.views.findIndex(predicate);
+						if (index === -1) return current;
+						removed = true;
+						const views = current.views.filter((_, idx) => idx !== index);
+						const removedEntry = current.views[index];
+						const activeInstance =
+							current.activeInstance === removedEntry?.instance
+								? (views[views.length - 1]?.instance ?? null)
+								: current.activeInstance;
+						return { views, activeInstance };
+					},
+					{ focus },
+				);
 				if (removed) {
 					const review = removedReview;
 					if (
@@ -1708,7 +1714,7 @@ function LayoutShellContent({
 
 	const handleRemoveView = useCallback(
 		(side: PanelSide, instance: string) =>
-			handleCloseView({ panel: side, instance }),
+			handleCloseView({ panel: side, instance, focus: true }),
 		[handleCloseView],
 	);
 

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -33,7 +33,10 @@ import {
 	ExternalWriteDetector,
 	type ExternalFileWrite,
 } from "./external-write-detector";
-import { getExternalWriteReview } from "./external-write-review-history";
+import {
+	createExternalWriteReviewFromSnapshots,
+	getExternalWriteReview,
+} from "./external-write-review-history";
 import { markFlashtypeFileWrite } from "@/extension-runtime/external-write-tracking";
 import {
 	EXTERNAL_WRITE_REVIEW_LAUNCH_ARG,
@@ -41,7 +44,13 @@ import {
 } from "@/extension-runtime/external-write-review";
 import { decodeFileDataToBytes } from "@/lib/decode-file-data";
 import { qb } from "@/lib/lix-kysely";
-import { captureTelemetry, fileExtensionProperty } from "@/lib/telemetry";
+import {
+	captureTelemetry,
+	fileExtensionProperty,
+	normalizeTelemetryFileExtension,
+	workspaceTelemetryProperties,
+} from "@/lib/telemetry";
+import { readWorkspaceId } from "@/lib/workspace-profile-telemetry";
 import {
 	ExtensionHostRegistryProvider,
 	useExtensionHostRegistry,
@@ -69,7 +78,10 @@ import {
 	TERMINAL_EXTENSION_KIND,
 	activeMarkdownFileIdFromExtensionInstance,
 } from "../extension-runtime/extension-instance-helpers";
-import { findFileHandlerExtension } from "../extension-runtime/file-handlers";
+import {
+	fileExtensionFromPath,
+	findFileHandlerExtension,
+} from "../extension-runtime/file-handlers";
 import {
 	coerceFlashtypeUiState,
 	DEFAULT_FLASHTYPE_UI_STATE,
@@ -307,6 +319,29 @@ function fileBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
 	return true;
 }
 
+function documentOpenAttemptTelemetryProperties({
+	filePath,
+	handler,
+}: {
+	readonly filePath: string;
+	readonly handler: ExtensionDefinition | undefined;
+}) {
+	const fileExtension = fileExtensionFromPath(filePath);
+	if (handler) {
+		return {
+			document_open_result: "viewed",
+			file_extension: fileExtensionProperty(filePath),
+		};
+	}
+	return {
+		document_open_result: "unsupported",
+		file_extension: fileExtension
+			? normalizeTelemetryFileExtension(fileExtension)
+			: "(none)",
+		unsupported_reason: fileExtension ? "no_renderer" : "no_extension",
+	};
+}
+
 function isPanelShortcutBlockedTarget(target: EventTarget | null): boolean {
 	if (!target || !(target instanceof HTMLElement)) {
 		return false;
@@ -407,7 +442,111 @@ function LayoutShellContent({
 	const leftPanelRef = useRef<ImperativePanelHandle | null>(null);
 	const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
 	const ignoredExternalWriteReviewFileIdsRef = useRef(new Set<string>());
+	const diffOpenedReviewIdsRef = useRef(new Set<string>());
+	const diffResolvedReviewIdsRef = useRef(new Set<string>());
+	const openDiffReviewByFileIdRef = useRef(
+		new Map<string, ExternalWriteReview>(),
+	);
+	const workspaceIdRef = useRef<string | undefined>(undefined);
+	const panelStatesRef = useRef({
+		left: leftPanel,
+		central: centralPanel,
+		right: rightPanel,
+	});
 	const viewHostRegistry = useExtensionHostRegistry();
+
+	const captureWorkspaceTelemetry = useCallback(
+		(
+			event: Parameters<typeof captureTelemetry>[0],
+			properties: Parameters<typeof captureTelemetry>[1] = {},
+		) => {
+			void (async () => {
+				const workspaceId =
+					workspaceIdRef.current ?? (await readWorkspaceId(lix));
+				workspaceIdRef.current = workspaceId;
+				captureTelemetry(event, {
+					...properties,
+					...workspaceTelemetryProperties(workspaceId),
+				});
+			})().catch((error: unknown) => {
+				console.warn("Failed to capture workspace telemetry", error);
+			});
+		},
+		[lix],
+	);
+
+	useEffect(() => {
+		workspaceIdRef.current = undefined;
+	}, [lix]);
+
+	useEffect(() => {
+		panelStatesRef.current = {
+			left: leftPanel,
+			central: centralPanel,
+			right: rightPanel,
+		};
+	}, [leftPanel, centralPanel, rightPanel]);
+
+	const claimDiffReviewResolution = useCallback(
+		(review: ExternalWriteReview) => {
+			if (diffResolvedReviewIdsRef.current.has(review.reviewId)) {
+				return false;
+			}
+			diffResolvedReviewIdsRef.current.add(review.reviewId);
+			return true;
+		},
+		[],
+	);
+
+	const captureDiffResolvedTelemetry = useCallback(
+		(
+			review: ExternalWriteReview,
+			outcome: "accepted" | "abandoned" | "rejected",
+		) => {
+			captureWorkspaceTelemetry("diff resolved", {
+				diff_review_id: review.reviewId,
+				file_extension: fileExtensionProperty(review.path),
+				outcome,
+				source: "renderer",
+			});
+		},
+		[captureWorkspaceTelemetry],
+	);
+
+	const resolveDiffReviewTelemetry = useCallback(
+		(
+			review: ExternalWriteReview,
+			outcome: "accepted" | "abandoned" | "rejected",
+		) => {
+			if (!claimDiffReviewResolution(review)) {
+				return false;
+			}
+			const openReview = openDiffReviewByFileIdRef.current.get(review.fileId);
+			if (openReview?.reviewId === review.reviewId) {
+				openDiffReviewByFileIdRef.current.delete(review.fileId);
+			}
+			captureDiffResolvedTelemetry(review, outcome);
+			return true;
+		},
+		[claimDiffReviewResolution, captureDiffResolvedTelemetry],
+	);
+
+	const getOpenExternalWriteReviewForFile = useCallback((fileId: string) => {
+		const activeReview = openDiffReviewByFileIdRef.current.get(fileId);
+		if (activeReview) {
+			return activeReview;
+		}
+		const panels = panelStatesRef.current;
+		for (const panelState of [panels.central, panels.left, panels.right]) {
+			for (const view of panelState.views) {
+				const review = view.launchArgs?.[EXTERNAL_WRITE_REVIEW_LAUNCH_ARG];
+				if (isExternalWriteReview(review) && review.fileId === fileId) {
+					return review;
+				}
+			}
+		}
+		return null;
+	}, []);
 
 	const activeInstances = useMemo(() => {
 		const keys = new Set<string>();
@@ -839,6 +978,10 @@ function LayoutShellContent({
 			launchArgs,
 			focus = true,
 			pending = false,
+			documentOrigin = "existing",
+			trackTelemetry = true,
+			trackDocumentOpenAttempt = trackTelemetry,
+			trackDocumentViewed = trackTelemetry,
 		}: {
 			panel: PanelSide;
 			fileId: string;
@@ -847,16 +990,30 @@ function LayoutShellContent({
 			launchArgs?: ExtensionLaunchArgs;
 			focus?: boolean;
 			pending?: boolean;
+			documentOrigin?: "existing" | "new";
+			trackTelemetry?: boolean;
+			trackDocumentOpenAttempt?: boolean;
+			trackDocumentViewed?: boolean;
 		}) => {
 			const handler =
-				findFileHandlerExtension(extensionMap.values(), filePath) ??
-				extensionMap.get(FILE_EXTENSION_KIND);
+				findFileHandlerExtension(extensionMap.values(), filePath) ?? undefined;
 			const kind = handler?.kind ?? FILE_EXTENSION_KIND;
-			captureTelemetry("file opened", {
-				file_extension: fileExtensionProperty(filePath),
-				source: "renderer",
-				view_kind: kind,
-			});
+			if (trackDocumentOpenAttempt) {
+				captureWorkspaceTelemetry("document open attempted", {
+					...documentOpenAttemptTelemetryProperties({ filePath, handler }),
+					document_origin: documentOrigin,
+					source: "renderer",
+					view_kind: kind,
+				});
+			}
+			if (trackDocumentViewed && handler) {
+				captureWorkspaceTelemetry("document viewed", {
+					document_origin: documentOrigin,
+					file_extension: fileExtensionProperty(filePath),
+					source: "renderer",
+					view_kind: kind,
+				});
+			}
 			handleOpenView({
 				panel,
 				kind,
@@ -870,7 +1027,7 @@ function LayoutShellContent({
 				pending,
 			});
 		},
-		[handleOpenView, extensionMap],
+		[handleOpenView, extensionMap, captureWorkspaceTelemetry],
 	);
 
 	useEffect(() => {
@@ -897,6 +1054,8 @@ function LayoutShellContent({
 					fileId: file.id as string,
 					filePath: file.path as string,
 					focus: false,
+					trackDocumentOpenAttempt: true,
+					trackDocumentViewed: false,
 				});
 				openedFiles.push({ id: file.id as string, path: file.path as string });
 				handledFilePaths.push(pendingOpenFilePath);
@@ -908,6 +1067,8 @@ function LayoutShellContent({
 					fileId: firstFile.id,
 					filePath: firstFile.path,
 					focus: true,
+					trackDocumentOpenAttempt: false,
+					trackDocumentViewed: true,
 				});
 			}
 			if (!cancelled) {
@@ -1028,23 +1189,20 @@ function LayoutShellContent({
 				clearExternalWriteReview(args);
 				return;
 			}
-			captureTelemetry("external write reviewed", {
-				file_extension: fileExtensionProperty(review.path),
-				review_action: "accept",
-				source: "renderer",
-			});
+			if (diffResolvedReviewIdsRef.current.has(review.reviewId)) return;
 			void (async () => {
-				if (await isExternalWriteReviewCurrent(review)) {
-					clearExternalWriteReview(args);
-				} else {
-					clearExternalWriteReview(args);
-				}
+				const outcome = (await isExternalWriteReviewCurrent(review))
+					? "accepted"
+					: "abandoned";
+				resolveDiffReviewTelemetry(review, outcome);
+				clearExternalWriteReview(args);
 			})();
 		},
 		[
 			getExternalWriteReviewForFile,
 			isExternalWriteReviewCurrent,
 			clearExternalWriteReview,
+			resolveDiffReviewTelemetry,
 		],
 	);
 
@@ -1055,34 +1213,41 @@ function LayoutShellContent({
 				clearExternalWriteReview(args);
 				return;
 			}
+			if (diffResolvedReviewIdsRef.current.has(review.reviewId)) return;
 			if (!(await isExternalWriteReviewCurrent(review))) {
+				resolveDiffReviewTelemetry(review, "abandoned");
 				clearExternalWriteReview(args);
 				return;
 			}
-			captureTelemetry("external write reviewed", {
-				file_extension: fileExtensionProperty(review.path),
-				review_action: "reject",
-				source: "renderer",
-			});
 			const { fileId } = args;
 			ignoredExternalWriteReviewFileIdsRef.current.add(fileId);
-			markFlashtypeFileWrite(fileId, review.beforeData);
-			await qb(lix)
-				.updateTable("lix_file")
-				.set({ data: review.beforeData })
-				.where("id", "=", fileId)
-				.execute();
-			clearExternalWriteReview(args);
-			window.setTimeout(() => {
-				ignoredExternalWriteReviewFileIdsRef.current.delete(fileId);
+			try {
+				markFlashtypeFileWrite(fileId, review.beforeData);
+				const result = await qb(lix)
+					.updateTable("lix_file")
+					.set({ data: review.beforeData })
+					.where("id", "=", fileId)
+					.where("data", "=", review.afterData)
+					.executeTakeFirst();
+				if (Number(result.numUpdatedRows) > 0) {
+					resolveDiffReviewTelemetry(review, "rejected");
+				} else {
+					resolveDiffReviewTelemetry(review, "abandoned");
+				}
 				clearExternalWriteReview(args);
-			}, 1500);
+			} finally {
+				window.setTimeout(() => {
+					ignoredExternalWriteReviewFileIdsRef.current.delete(fileId);
+					clearExternalWriteReview(args);
+				}, 1500);
+			}
 		},
 		[
 			lix,
 			getExternalWriteReviewForFile,
 			isExternalWriteReviewCurrent,
 			clearExternalWriteReview,
+			resolveDiffReviewTelemetry,
 		],
 	);
 
@@ -1094,23 +1259,43 @@ function LayoutShellContent({
 						clearExternalWriteReview({ fileId: write.fileId });
 						continue;
 					}
-					const review = await getExternalWriteReview(
-						lix,
+					const review =
+						(await getExternalWriteReview(lix, write.fileId, write.path)) ??
+						createExternalWriteReviewFromSnapshots(write);
+					const existingReview = getOpenExternalWriteReviewForFile(
 						write.fileId,
-						write.path,
 					);
-					if (!review) continue;
+					if (existingReview && existingReview.reviewId !== review.reviewId) {
+						resolveDiffReviewTelemetry(existingReview, "abandoned");
+					}
+					if (!diffOpenedReviewIdsRef.current.has(review.reviewId)) {
+						diffOpenedReviewIdsRef.current.add(review.reviewId);
+						openDiffReviewByFileIdRef.current.set(write.fileId, review);
+						captureWorkspaceTelemetry("diff opened", {
+							diff_review_id: review.reviewId,
+							file_extension: fileExtensionProperty(write.path),
+							source: "renderer",
+						});
+					}
 					handleOpenFile({
 						panel: "central",
 						fileId: write.fileId,
 						filePath: write.path,
 						launchArgs: { [EXTERNAL_WRITE_REVIEW_LAUNCH_ARG]: review },
 						focus: true,
+						trackTelemetry: false,
 					});
 				}
 			})();
 		},
-		[lix, handleOpenFile, clearExternalWriteReview],
+		[
+			lix,
+			handleOpenFile,
+			clearExternalWriteReview,
+			captureWorkspaceTelemetry,
+			getOpenExternalWriteReviewForFile,
+			resolveDiffReviewTelemetry,
+		],
 	);
 
 	const handleCloseView = useCallback(
@@ -1133,23 +1318,36 @@ function LayoutShellContent({
 				? [panel]
 				: (["central", "left", "right"] as PanelSide[]);
 			for (const side of targetPanels) {
+				const currentPanel = panelStatesRef.current[side];
+				const removedView = currentPanel.views.find(predicate);
+				const removedReview =
+					removedView?.launchArgs?.[EXTERNAL_WRITE_REVIEW_LAUNCH_ARG];
 				let removed = false;
 				setPanelState(side, (current) => {
 					const index = current.views.findIndex(predicate);
 					if (index === -1) return current;
 					removed = true;
 					const views = current.views.filter((_, idx) => idx !== index);
-					const removedView = current.views[index];
+					const removedEntry = current.views[index];
 					const activeInstance =
-						current.activeInstance === removedView.instance
+						current.activeInstance === removedEntry?.instance
 							? (views[views.length - 1]?.instance ?? null)
 							: current.activeInstance;
 					return { views, activeInstance };
 				});
-				if (removed) break;
+				if (removed) {
+					const review = removedReview;
+					if (
+						isExternalWriteReview(review) &&
+						!diffResolvedReviewIdsRef.current.has(review.reviewId)
+					) {
+						resolveDiffReviewTelemetry(review, "abandoned");
+					}
+					break;
+				}
 			}
 		},
-		[setPanelState],
+		[setPanelState, resolveDiffReviewTelemetry],
 	);
 
 	const handleCloseFileViews = useCallback(
@@ -1165,6 +1363,13 @@ function LayoutShellContent({
 				);
 			};
 			for (const side of targetPanels) {
+				const removedReviews = panelStatesRef.current[side].views.flatMap(
+					(entry) => {
+						if (!matchesFileView(entry)) return [];
+						const review = entry.launchArgs?.[EXTERNAL_WRITE_REVIEW_LAUNCH_ARG];
+						return isExternalWriteReview(review) ? [review] : [];
+					},
+				);
 				setPanelState(side, (current) => {
 					const views = current.views.filter(
 						(entry) => !matchesFileView(entry),
@@ -1179,9 +1384,12 @@ function LayoutShellContent({
 						: (views[views.length - 1]?.instance ?? null);
 					return { views, activeInstance };
 				});
+				for (const review of removedReviews) {
+					resolveDiffReviewTelemetry(review, "abandoned");
+				}
 			}
 		},
-		[setPanelState],
+		[setPanelState, resolveDiffReviewTelemetry],
 	);
 
 	const activeCentralEntry = useMemo(() => {
@@ -1214,15 +1422,21 @@ function LayoutShellContent({
 					? state.flashtype.icon
 					: undefined;
 			if (agent) {
-				captureTelemetry("agent launched", {
+				captureWorkspaceTelemetry("agent opened", {
 					agent,
 					panel: side,
 					source: "renderer",
+					surface: "terminal",
 				});
 			}
 			handleOpenView({ panel: side, kind, state, launchArgs, instance });
 		},
-		[activeCentralEntry, handleOpenView, extensionMap],
+		[
+			activeCentralEntry,
+			handleOpenView,
+			extensionMap,
+			captureWorkspaceTelemetry,
+		],
 	);
 
 	const focusPanel = useCallback((side: PanelSide) => {
@@ -1398,14 +1612,11 @@ function LayoutShellContent({
 			.where("path", "=", path)
 			.executeTakeFirstOrThrow();
 		const id = createdFile.id;
-		captureTelemetry("file created", {
-			file_extension: fileExtensionProperty(path),
-			source: "renderer",
-		});
 		handleOpenFile({
 			panel: "central",
 			fileId: id,
 			filePath: path,
+			documentOrigin: "new",
 			focus: true,
 		});
 	}, [handleOpenFile, lix]);
@@ -1497,27 +1708,8 @@ function LayoutShellContent({
 
 	const handleRemoveView = useCallback(
 		(side: PanelSide, instance: string) =>
-			setPanelState(
-				side,
-				(panel) => {
-					const targetView = panel.views.find(
-						(entry) => entry.instance === instance,
-					);
-					if (!targetView) {
-						return panel;
-					}
-					const views = panel.views.filter(
-						(entry) => entry.instance !== instance,
-					);
-					const nextActive =
-						panel.activeInstance === instance
-							? (views[views.length - 1]?.instance ?? null)
-							: panel.activeInstance;
-					return { views, activeInstance: nextActive };
-				},
-				{ focus: true },
-			),
-		[setPanelState],
+			handleCloseView({ panel: side, instance }),
+		[handleCloseView],
 	);
 
 	const handleMoveViewToPanel = useCallback(

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -1369,19 +1369,20 @@ function LayoutShellContent({
 				);
 			};
 			for (const side of targetPanels) {
-				const removedReviews = panelStatesRef.current[side].views.flatMap(
-					(entry) => {
-						if (!matchesFileView(entry)) return [];
-						const review = entry.launchArgs?.[EXTERNAL_WRITE_REVIEW_LAUNCH_ARG];
-						return isExternalWriteReview(review) ? [review] : [];
-					},
-				);
+				const removedReviews = new Map<string, ExternalWriteReview>();
 				setPanelState(side, (current) => {
 					const views = current.views.filter(
 						(entry) => !matchesFileView(entry),
 					);
 					if (views.length === current.views.length) {
 						return current;
+					}
+					for (const entry of current.views) {
+						if (!matchesFileView(entry)) continue;
+						const review = entry.launchArgs?.[EXTERNAL_WRITE_REVIEW_LAUNCH_ARG];
+						if (isExternalWriteReview(review)) {
+							removedReviews.set(review.reviewId, review);
+						}
 					}
 					const activeInstance = views.some(
 						(entry) => entry.instance === current.activeInstance,
@@ -1390,7 +1391,7 @@ function LayoutShellContent({
 						: (views[views.length - 1]?.instance ?? null);
 					return { views, activeInstance };
 				});
-				for (const review of removedReviews) {
+				for (const review of removedReviews.values()) {
 					resolveDiffReviewTelemetry(review, "abandoned");
 				}
 			}

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -1227,7 +1227,6 @@ function LayoutShellContent({
 					.updateTable("lix_file")
 					.set({ data: review.beforeData })
 					.where("id", "=", fileId)
-					.where("data", "=", review.afterData)
 					.executeTakeFirst();
 				if (Number(result.numUpdatedRows) > 0) {
 					resolveDiffReviewTelemetry(review, "rejected");

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -33,10 +33,7 @@ import {
 	ExternalWriteDetector,
 	type ExternalFileWrite,
 } from "./external-write-detector";
-import {
-	createExternalWriteReviewFromSnapshots,
-	getExternalWriteReview,
-} from "./external-write-review-history";
+import { getExternalWriteReview } from "./external-write-review-history";
 import { markFlashtypeFileWrite } from "@/extension-runtime/external-write-tracking";
 import {
 	EXTERNAL_WRITE_REVIEW_LAUNCH_ARG,
@@ -1258,12 +1255,15 @@ function LayoutShellContent({
 						clearExternalWriteReview({ fileId: write.fileId });
 						continue;
 					}
-					const review =
-						(await getExternalWriteReview(lix, write.fileId, write.path)) ??
-						createExternalWriteReviewFromSnapshots(write);
+					const review = await getExternalWriteReview(
+						lix,
+						write.fileId,
+						write.path,
+					);
 					const existingReview = getOpenExternalWriteReviewForFile(
 						write.fileId,
 					);
+					if (!review) continue;
 					if (existingReview && existingReview.reviewId !== review.reviewId) {
 						resolveDiffReviewTelemetry(existingReview, "abandoned");
 					}

--- a/src/shell/top-bar/branch-switcher.test.tsx
+++ b/src/shell/top-bar/branch-switcher.test.tsx
@@ -166,13 +166,12 @@ describe("BranchSwitcher", () => {
 			fireEvent.click(deleteItem);
 		});
 
+		const triggerAfterDelete = await screen.findByRole("button", {
+			name: "Select branch",
+		});
 		await act(async () => {
-			fireEvent.pointerDown(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
-			fireEvent.pointerUp(
-				screen.getByRole("button", { name: "Select branch" }),
-			);
+			fireEvent.pointerDown(triggerAfterDelete);
+			fireEvent.pointerUp(triggerAfterDelete);
 		});
 
 		await waitFor(() => {


### PR DESCRIPTION
## Summary
- simplify Flashtype telemetry to the canonical product events for app/document/agent/diff/workspace profile tracking
- add stable dev telemetry identity, telemetry_environment tagging, and private-by-default PostHog session replay wiring
- add real filesystem workspace profiling via fs.stat, including total workspace size and per-extension aggregate size rows
- clean up removed workspace-open/active telemetry paths and fix diff review/document telemetry tests

## Dashboard
- added PostHog insight: Extension Size Profile (workspace extension presence, median file counts, median total MB, median file size KB)

## Verification
- pnpm exec tsc --noEmit --pretty false
- pnpm test -- --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics schema, session replay privacy settings, and new filesystem scanning on workspace open; no auth or data-mutation paths beyond existing telemetry IPC.
> 
> **Overview**
> **Replaces** a spread of ad-hoc telemetry with a smaller canonical set and bumps event metadata (`schema_version: 2`, `telemetry_environment`, workspace `$groups`).
> 
> **Main process:** `app launched` → **`app opened`** with `entry_point` (e.g. `finder_file`, `restored_session`, `app_direct`). Drops **`workspace opened`**, branch create/switch captures, and the `telemetryOpenSource` plumbing on window open. Adds optional **dev identity** (`dev:mode` when `FLASHTYPE_ENABLE_DEV_TELEMETRY=1`) and enables **session replay** for all clients (removes distinct-id sampling).
> 
> **Workspace profiling:** New **`workspace.profile()`** IPC walks the on-disk tree (skips `.lix`, symlinks) and returns counts plus per-extension size stats. Renderer **`workspace profiled`** / **`workspace extension profiled`** events use that data when available instead of Lix path lists only.
> 
> **Renderer:** Document lifecycle events (**`document open attempted`**, **`document viewed`**, **`document modified`**) replace `file opened` / `file created` / `file saved`. External-write UX emits **`diff opened`** / **`diff resolved`** instead of `external write reviewed`. **`agent opened`** replaces `agent launched`. PostHog wiring shifts to **`activatePostHogRecording()`** on boot with aggressive text masking; **`workspace active`** and update-installed captures are removed from the app shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d68dd9e54e63474e3e7ff3e439c73c0360c30d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->