### PR TITLE
Add on-demand file tree for ephemeral workspaces

### DIFF
--- a/e2e/workspace-windows.spec.ts
+++ b/e2e/workspace-windows.spec.ts
@@ -307,6 +307,10 @@ test("Track Changes menu toggles workspace .lix storage", async ({
 		await expect(page.getByText("marker.md")).toBeVisible();
 		await expectTrackChangesMenuChecked(electronApp, false);
 		await expectPathMissing(path.join(workspaceDir, ".lix"));
+		await page.getByTestId("file-tree-item-marker-md").click();
+		await expect(
+			page.getByRole("heading", { name: "marker.md" }),
+		).toBeVisible();
 
 		await page.evaluate(async () => {
 			await window.flashtypeDesktop?.lix.execute({
@@ -324,14 +328,14 @@ test("Track Changes menu toggles workspace .lix storage", async ({
 
 		await clickTrackChangesMenuItemAndWaitForReload(electronApp, page);
 		await expect(page).toHaveTitle(path.basename(workspaceDir));
-		await expect(page.getByText("marker.md")).toBeVisible();
+		await expect(page.getByTestId("file-tree-item-marker-md")).toBeVisible();
 		await expectTrackChangesMenuChecked(electronApp, true);
 		await expectPathExists(path.join(workspaceDir, ".lix"));
 		await expectInstalledPluginArchives(workspaceDir);
 
 		await clickTrackChangesMenuItemAndWaitForReload(electronApp, page);
 		await expect(page).toHaveTitle(path.basename(workspaceDir));
-		await expect(page.getByText("marker.md")).toBeVisible();
+		await expect(page.getByTestId("file-tree-item-marker-md")).toBeVisible();
 		await expectTrackChangesMenuChecked(electronApp, false);
 		await expectPathMissing(path.join(workspaceDir, ".lix"));
 	} finally {
@@ -421,7 +425,7 @@ test("macOS open-file events open standalone files as transient workspaces", asy
 				.first(),
 		).toBeVisible();
 		await expect(filePage.getByRole("heading", { name: "Solo" })).toBeVisible();
-		await expect(filePage.getByText("sibling.md")).toHaveCount(0);
+		await expect(filePage.getByText("sibling.md")).toBeVisible();
 		await expectPathMissing(path.join(directory, ".lix"));
 		await expectPathMissing(path.join(directory, ".lix_system"));
 
@@ -503,7 +507,7 @@ test("launching with multiple standalone markdown files creates one grouped tran
 				"file-tree-item-standalone-markdown-alpha-alpha-md",
 			),
 		).toBeVisible();
-		await expect(groupedPage.getByText("sibling.md")).toHaveCount(0);
+		await expect(groupedPage.getByText("sibling.md")).toBeVisible();
 		await groupedPage
 			.getByTestId("file-tree-directory-standalone-markdown-beta")
 			.click();

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -24,6 +24,17 @@ const workspace = {
 	get: () => ipcRenderer.invoke("workspace:get"),
 	consumePendingOpenFiles: () =>
 		ipcRenderer.invoke("workspace:consumePendingOpenFiles"),
+	setEphemeralWatchedDirectories: (payload) =>
+		ipcRenderer.invoke("workspace:setEphemeralWatchedDirectories", payload),
+	onEphemeralWatchedFileTreeChanged: (listener) => {
+		const wrapped = (_event, payload) => listener(payload);
+		ipcRenderer.on("workspace:ephemeralWatchedFileTreeChanged", wrapped);
+		return () => {
+			ipcRenderer.off("workspace:ephemeralWatchedFileTreeChanged", wrapped);
+		};
+	},
+	readEphemeralFile: (payload) =>
+		ipcRenderer.invoke("workspace:readEphemeralFile", payload),
 	profile: () => ipcRenderer.invoke("workspace:profile"),
 	onNewFile: (listener) => {
 		const wrapped = () => listener();

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -147,10 +147,27 @@ export type DesktopWorkspaceProfile = {
 	extensions: DesktopWorkspaceExtensionProfile[];
 };
 
+export type DesktopWatchedFilesystemEntry = {
+	id: string;
+	parent_id: string | null;
+	path: string;
+	display_name: string;
+	kind: "directory" | "file";
+	source: "watched";
+};
+
 export type DesktopWorkspaceApi = {
 	get(): Promise<DesktopWorkspace | null>;
 	/** Returns workspace-relative file paths queued for editor opening. */
 	consumePendingOpenFiles(): Promise<string[]>;
+	setEphemeralWatchedDirectories(payload: {
+		ownerId: string;
+		paths: string[];
+	}): Promise<DesktopWatchedFilesystemEntry[]>;
+	onEphemeralWatchedFileTreeChanged(
+		listener: (entries: DesktopWatchedFilesystemEntry[]) => void,
+	): () => void;
+	readEphemeralFile(payload: { path: string }): Promise<Uint8Array>;
 	profile(): Promise<DesktopWorkspaceProfile | null>;
 	/** Fired when the native menu asks the workspace UI to start a new file. */
 	onNewFile(listener: () => void): () => void;

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -1,6 +1,7 @@
 import { dialog, ipcMain } from "electron";
 import os from "node:os";
 import path from "node:path";
+import { watch } from "node:fs";
 import {
 	cp,
 	lstat,
@@ -21,6 +22,8 @@ const LIX_DATABASE_FILE = path.join(".lix", ".internal", "db.sqlite");
 const LIX_ROCKSDB_DATABASE_DIR = path.join(".lix", ".internal", "rocksdb");
 const LEGACY_LIX_DATABASE_FILE = path.join(".lix", "db.sqlite");
 const LIX_DATABASE_FILES = [LIX_DATABASE_FILE, LEGACY_LIX_DATABASE_FILE];
+const EPHEMERAL_FILE_TREE_CHANGED_CHANNEL =
+	"workspace:ephemeralWatchedFileTreeChanged";
 
 /**
  * The workspace is the folder Flashtype operates on. Each window has at most
@@ -73,9 +76,8 @@ export async function resolveWorkspaceTarget(requestedPath) {
 				pendingOpenFilePaths: [],
 			};
 		}
-		const includePaths = await collectWorkspaceIncludePaths(resolved);
 		return {
-			workspace: createEphemeralWorkspace(resolved, includePaths),
+			workspace: createEphemeralWorkspace(resolved),
 			pendingOpenFilePaths: [],
 		};
 	}
@@ -149,6 +151,7 @@ export async function setWorkspaceFromTarget(target, window, options = {}) {
 			return state.workspace;
 		}
 		await options.beforeChange?.(nextWorkspace, window);
+		disposeEphemeralFileTreeState(state);
 		await disposeExternalLixState(state);
 		state.workspace = nextWorkspace;
 		state.pendingOpenFilePaths = target.pendingOpenFilePaths;
@@ -215,6 +218,47 @@ export function consumePendingOpenFiles(window) {
 	const pendingOpenFilePaths = state.pendingOpenFilePaths;
 	state.pendingOpenFilePaths = [];
 	return pendingOpenFilePaths ?? [];
+}
+
+export async function setEphemeralWatchedDirectories(window, payload) {
+	const state = getOrCreateWindowState(window);
+	const workspace = state.workspace;
+	const ownerId = normalizeEphemeralFileTreeOwnerId(payload?.ownerId);
+	const directoryPaths = normalizeWorkspaceDirectoryPaths(payload?.paths);
+	if (!workspace || workspace.ephemeral !== true) {
+		removeEphemeralFileTreeOwner(state, ownerId);
+		return [];
+	}
+
+	if (directoryPaths.length > 0) {
+		state.ephemeralFileTreeOwners.set(ownerId, directoryPaths);
+	} else {
+		removeEphemeralFileTreeOwner(state, ownerId);
+	}
+	await refreshEphemeralFileTree(window, state, { emit: false });
+	return state.ephemeralWatchedEntries;
+}
+
+export async function readEphemeralWorkspaceFile(window, payload) {
+	const state = getWindowState(window);
+	const workspace = state?.workspace;
+	if (!state || !workspace || workspace.ephemeral !== true) {
+		throw new Error("No transient workspace is open.");
+	}
+	const filePath = normalizeWorkspaceFilePath(payload?.path);
+	const parentDirectory = parentDirectoryPathForFilePath(filePath);
+	const watchedDirectories = effectiveEphemeralWatchedDirectories(state);
+	if (!watchedDirectories.has(parentDirectory)) {
+		throw new Error(
+			`File is not in an opened Files view directory: ${filePath}`,
+		);
+	}
+	const localPath = workspaceLocalPathForFilePath(workspace, filePath);
+	const metadata = await lstat(localPath);
+	if (metadata.isSymbolicLink() || !metadata.isFile()) {
+		throw new Error(`Path is not a regular workspace file: ${filePath}`);
+	}
+	return await readFile(localPath);
 }
 
 export async function profileWorkspaceFilesystem(workspace) {
@@ -331,14 +375,13 @@ export async function setWorkspaceTrackChanges(window, trackChanges) {
 			return workspace;
 		}
 		if (trackChanges) {
+			disposeEphemeralFileTreeState(state);
 			await moveExternalLixBackIntoWorkspace(state);
 			state.workspace = createPersistentWorkspace(workspace.path);
 		} else {
+			disposeEphemeralFileTreeState(state);
 			await moveWorkspaceLixToExternalStorage(state);
-			state.workspace = createEphemeralWorkspace(
-				workspace.path,
-				await collectWorkspaceIncludePaths(workspace.path),
-			);
+			state.workspace = createEphemeralWorkspace(workspace.path);
 		}
 		state.pendingOpenFilePaths = [];
 		applyWindowChrome(window);
@@ -353,6 +396,7 @@ export async function disposeWorkspaceWindowState(windowOrId) {
 	}
 	const state = windowStates.get(windowId);
 	windowStates.delete(windowId);
+	disposeEphemeralFileTreeState(state);
 	await disposeExternalLixState(state);
 }
 
@@ -394,12 +438,8 @@ async function resolveWorkspaceSessionEntry(workspaceEntry) {
 			pendingOpenFilePaths: [],
 		};
 	}
-	const includePaths = uniqueWorkspaceRelativeFilePaths([
-		...pendingOpenFilePaths,
-		...(await collectWorkspaceIncludePaths(workspacePath)),
-	]);
 	return {
-		workspace: createEphemeralWorkspace(workspacePath, includePaths),
+		workspace: createEphemeralWorkspace(workspacePath, pendingOpenFilePaths),
 		pendingOpenFilePaths,
 	};
 }
@@ -487,6 +527,368 @@ function parentDirectories(relativePath) {
 	return directories;
 }
 
+function normalizeEphemeralFileTreeOwnerId(ownerId) {
+	if (typeof ownerId !== "string" || ownerId.length === 0) {
+		throw new Error("workspace ephemeral file tree ownerId is required.");
+	}
+	return ownerId;
+}
+
+function normalizeWorkspaceDirectoryPaths(paths) {
+	if (!Array.isArray(paths)) {
+		throw new Error("workspace watched directory paths must be an array.");
+	}
+	const seen = new Set();
+	const normalizedPaths = [];
+	for (const path of paths) {
+		const normalizedPath = normalizeWorkspaceDirectoryPath(path);
+		if (seen.has(normalizedPath)) {
+			continue;
+		}
+		seen.add(normalizedPath);
+		normalizedPaths.push(normalizedPath);
+	}
+	normalizedPaths.sort((left, right) => left.localeCompare(right));
+	return normalizedPaths;
+}
+
+function normalizeWorkspaceDirectoryPath(directoryPath) {
+	if (directoryPath === "/") {
+		return "/";
+	}
+	if (
+		typeof directoryPath !== "string" ||
+		!directoryPath.startsWith("/") ||
+		!directoryPath.endsWith("/")
+	) {
+		throw new Error(`Invalid workspace directory path: ${directoryPath}`);
+	}
+	const segments = directoryPath.split("/").filter(Boolean);
+	validateVisibleWorkspacePathSegments(segments, directoryPath);
+	return `/${segments.join("/")}/`;
+}
+
+function normalizeWorkspaceFilePath(filePath) {
+	if (
+		typeof filePath !== "string" ||
+		!filePath.startsWith("/") ||
+		filePath.endsWith("/")
+	) {
+		throw new Error(`Invalid workspace file path: ${filePath}`);
+	}
+	const segments = filePath.split("/").filter(Boolean);
+	validateVisibleWorkspacePathSegments(segments, filePath);
+	return `/${segments.join("/")}`;
+}
+
+function validateVisibleWorkspacePathSegments(segments, originalPath) {
+	if (segments.length === 0) {
+		throw new Error(`Invalid workspace path: ${originalPath}`);
+	}
+	for (const segment of segments) {
+		if (
+			segment.length === 0 ||
+			segment === "." ||
+			segment === ".." ||
+			segment.startsWith(".") ||
+			segment.includes("/") ||
+			path.isAbsolute(segment)
+		) {
+			throw new Error(`Invalid workspace path: ${originalPath}`);
+		}
+	}
+	if (segments[0] === LIX_DIRECTORY_NAME) {
+		throw new Error(`Invalid workspace path: ${originalPath}`);
+	}
+}
+
+function workspaceLocalPathForDirectoryPath(workspace, directoryPath) {
+	if (directoryPath === "/") {
+		return workspace.path;
+	}
+	const segments = directoryPath.split("/").filter(Boolean);
+	return path.join(workspace.path, ...segments);
+}
+
+function workspaceLocalPathForFilePath(workspace, filePath) {
+	const segments = filePath.split("/").filter(Boolean);
+	return path.join(workspace.path, ...segments);
+}
+
+function parentDirectoryPathForFilePath(filePath) {
+	const segments = filePath.split("/").filter(Boolean);
+	segments.pop();
+	return segments.length === 0 ? "/" : `/${segments.join("/")}/`;
+}
+
+function parentDirectoryPathForDirectoryPath(directoryPath) {
+	if (directoryPath === "/") {
+		return null;
+	}
+	const segments = directoryPath.split("/").filter(Boolean);
+	segments.pop();
+	return segments.length === 0 ? "/" : `/${segments.join("/")}/`;
+}
+
+function childDirectoryPath(directoryPath, name) {
+	return directoryPath === "/" ? `/${name}/` : `${directoryPath}${name}/`;
+}
+
+function displayNameFromWorkspacePath(workspacePath) {
+	const segments = workspacePath.split("/").filter(Boolean);
+	return segments[segments.length - 1] ?? workspacePath;
+}
+
+function removeEphemeralFileTreeOwner(state, ownerId) {
+	state?.ephemeralFileTreeOwners?.delete(ownerId);
+}
+
+function effectiveEphemeralWatchedDirectories(state) {
+	const paths = new Set();
+	for (const ownerPaths of state.ephemeralFileTreeOwners.values()) {
+		for (const path of ownerPaths) {
+			paths.add(path);
+		}
+	}
+	return paths;
+}
+
+async function refreshEphemeralFileTree(window, state, options = {}) {
+	const workspace = state?.workspace;
+	const watchedDirectories = state
+		? effectiveEphemeralWatchedDirectories(state)
+		: new Set();
+	if (!state || !workspace || workspace.ephemeral !== true) {
+		disposeEphemeralFileTreeState(state);
+		return [];
+	}
+	if (watchedDirectories.size === 0) {
+		closeEphemeralDirectoryWatchers(state, new Set());
+		state.ephemeralWatchedEntries = [];
+		if (options.emit) {
+			emitEphemeralFileTreeChanged(window, state);
+		}
+		return state.ephemeralWatchedEntries;
+	}
+
+	await refreshEphemeralDirectoryWatchers(
+		window,
+		state,
+		workspace,
+		watchedDirectories,
+	);
+	state.ephemeralWatchedEntries = await collectEphemeralWatchedEntries(
+		workspace,
+		watchedDirectories,
+	);
+	if (options.emit) {
+		emitEphemeralFileTreeChanged(window, state);
+	}
+	return state.ephemeralWatchedEntries;
+}
+
+async function refreshEphemeralDirectoryWatchers(
+	window,
+	state,
+	workspace,
+	watchedDirectories,
+) {
+	const watchableDirectories = new Set();
+	for (const directoryPath of watchedDirectories) {
+		const localPath = workspaceLocalPathForDirectoryPath(
+			workspace,
+			directoryPath,
+		);
+		try {
+			const metadata = await lstat(localPath);
+			if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+				continue;
+			}
+			watchableDirectories.add(directoryPath);
+			if (state.ephemeralDirectoryWatchers.has(directoryPath)) {
+				continue;
+			}
+			const watcher = watch(localPath, { persistent: false }, () => {
+				scheduleEphemeralFileTreeRefresh(window, state);
+			});
+			watcher.on("error", () => {
+				state.ephemeralDirectoryWatchers.delete(directoryPath);
+				scheduleEphemeralFileTreeRefresh(window, state);
+			});
+			state.ephemeralDirectoryWatchers.set(directoryPath, watcher);
+		} catch {
+			// Missing or unreadable directories are omitted until a future refresh.
+		}
+	}
+	closeEphemeralDirectoryWatchers(state, watchableDirectories);
+}
+
+function closeEphemeralDirectoryWatchers(state, keepPaths) {
+	for (const [directoryPath, watcher] of state.ephemeralDirectoryWatchers) {
+		if (keepPaths.has(directoryPath)) {
+			continue;
+		}
+		watcher.close();
+		state.ephemeralDirectoryWatchers.delete(directoryPath);
+	}
+}
+
+function scheduleEphemeralFileTreeRefresh(window, state) {
+	if (state.ephemeralWatchRefreshTimer) {
+		clearTimeout(state.ephemeralWatchRefreshTimer);
+	}
+	state.ephemeralWatchRefreshTimer = setTimeout(() => {
+		state.ephemeralWatchRefreshTimer = null;
+		void refreshEphemeralFileTree(window, state, { emit: true }).catch(
+			(error) => {
+				console.warn("Failed to refresh transient workspace file tree", error);
+			},
+		);
+	}, 100);
+}
+
+async function collectEphemeralWatchedEntries(workspace, watchedDirectories) {
+	const entriesByPath = new Map();
+	for (const directoryPath of [...watchedDirectories].sort((left, right) =>
+		left.localeCompare(right),
+	)) {
+		if (directoryPath !== "/") {
+			addWatchedDirectoryEntry(entriesByPath, directoryPath);
+		}
+		for (const entry of await collectEphemeralDirectoryEntries(
+			workspace,
+			directoryPath,
+		)) {
+			entriesByPath.set(entry.path, entry);
+		}
+	}
+	return [...entriesByPath.values()].sort((left, right) =>
+		left.path.localeCompare(right.path),
+	);
+}
+
+function addWatchedDirectoryEntry(entriesByPath, directoryPath) {
+	if (entriesByPath.has(directoryPath)) {
+		return;
+	}
+	const parentPath = parentDirectoryPathForDirectoryPath(directoryPath);
+	entriesByPath.set(directoryPath, {
+		id: `watched:${directoryPath}`,
+		parent_id: parentPath ? `watched:${parentPath}` : null,
+		path: directoryPath,
+		display_name: displayNameFromWorkspacePath(directoryPath),
+		kind: "directory",
+		source: "watched",
+	});
+}
+
+async function collectEphemeralDirectoryEntries(workspace, directoryPath) {
+	const localDirectoryPath = workspaceLocalPathForDirectoryPath(
+		workspace,
+		directoryPath,
+	);
+	let metadata;
+	try {
+		metadata = await lstat(localDirectoryPath);
+	} catch {
+		return [];
+	}
+	if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+		return [];
+	}
+	let directory;
+	try {
+		directory = await opendir(localDirectoryPath);
+	} catch {
+		return [];
+	}
+
+	const entries = [];
+	for await (const entry of directory) {
+		if (entry.name.startsWith(".")) {
+			continue;
+		}
+		const localEntryPath = path.join(localDirectoryPath, entry.name);
+		let entryMetadata;
+		try {
+			entryMetadata = await lstat(localEntryPath);
+		} catch {
+			continue;
+		}
+		if (entryMetadata.isSymbolicLink()) {
+			continue;
+		}
+		if (entryMetadata.isDirectory()) {
+			const entryPath = childDirectoryPath(directoryPath, entry.name);
+			try {
+				normalizeWorkspaceDirectoryPath(entryPath);
+			} catch {
+				continue;
+			}
+			entries.push({
+				id: `watched:${entryPath}`,
+				parent_id: directoryPath === "/" ? null : `watched:${directoryPath}`,
+				path: entryPath,
+				display_name: entry.name,
+				kind: "directory",
+				source: "watched",
+			});
+			continue;
+		}
+		if (!entryMetadata.isFile()) {
+			continue;
+		}
+		const relativePath = workspaceRelativeFilePath(
+			workspace.path,
+			localEntryPath,
+		);
+		if (!relativePath) {
+			continue;
+		}
+		const entryPath = `/${relativePath}`;
+		try {
+			normalizeWorkspaceFilePath(entryPath);
+		} catch {
+			continue;
+		}
+		entries.push({
+			id: `watched:${entryPath}`,
+			parent_id: directoryPath === "/" ? null : `watched:${directoryPath}`,
+			path: entryPath,
+			display_name: entry.name,
+			kind: "file",
+			source: "watched",
+		});
+	}
+	return entries;
+}
+
+function emitEphemeralFileTreeChanged(window, state) {
+	if (!window || window.isDestroyed()) {
+		return;
+	}
+	window.webContents.send(
+		EPHEMERAL_FILE_TREE_CHANGED_CHANNEL,
+		state.ephemeralWatchedEntries,
+	);
+}
+
+function disposeEphemeralFileTreeState(state) {
+	if (!state) {
+		return;
+	}
+	if (state.ephemeralWatchRefreshTimer) {
+		clearTimeout(state.ephemeralWatchRefreshTimer);
+		state.ephemeralWatchRefreshTimer = null;
+	}
+	for (const watcher of state.ephemeralDirectoryWatchers.values()) {
+		watcher.close();
+	}
+	state.ephemeralDirectoryWatchers.clear();
+	state.ephemeralFileTreeOwners.clear();
+	state.ephemeralWatchedEntries = [];
+}
+
 function median(values) {
 	if (values.length === 0) {
 		return 0;
@@ -505,57 +907,6 @@ function roundMegabytes(bytes) {
 
 function roundKilobytes(bytes) {
 	return Math.round((bytes / 1024) * 100) / 100;
-}
-
-async function collectWorkspaceIncludePaths(directoryPath) {
-	const includePaths = [];
-	const pendingDirectories = [directoryPath];
-	while (pendingDirectories.length > 0) {
-		const currentDirectory = pendingDirectories.pop();
-		let directory;
-		try {
-			directory = await opendir(currentDirectory);
-		} catch {
-			continue;
-		}
-		for await (const entry of directory) {
-			if (entry.name === LIX_DIRECTORY_NAME && entry.isDirectory()) {
-				continue;
-			}
-			const entryPath = path.join(currentDirectory, entry.name);
-			let stats;
-			try {
-				stats = await lstat(entryPath);
-			} catch {
-				continue;
-			}
-			if (stats.isSymbolicLink()) {
-				continue;
-			}
-			if (stats.isDirectory()) {
-				if (entry.name !== LIX_DIRECTORY_NAME) {
-					pendingDirectories.push(entryPath);
-				}
-				continue;
-			}
-			if (stats.isFile() && isIncludedWorkspaceFileName(entry.name)) {
-				const includePath = workspaceRelativeFilePath(directoryPath, entryPath);
-				if (includePath) {
-					includePaths.push(includePath);
-				}
-			}
-		}
-	}
-	includePaths.sort();
-	return includePaths;
-}
-
-function isIncludedWorkspaceFileName(fileName) {
-	return (
-		fileName.endsWith(".md") ||
-		fileName.endsWith(".markdown") ||
-		fileName.endsWith(".csv")
-	);
 }
 
 async function resolveStandaloneFile(resolvedPath) {
@@ -835,6 +1186,20 @@ export function registerWorkspaceIpc(getWindowForEvent, options = {}) {
 		return consumePendingOpenFiles(getWindowForEvent(event));
 	});
 
+	ipcMain.handle(
+		"workspace:setEphemeralWatchedDirectories",
+		async (event, payload) => {
+			return await setEphemeralWatchedDirectories(
+				getWindowForEvent(event),
+				payload,
+			);
+		},
+	);
+
+	ipcMain.handle("workspace:readEphemeralFile", async (event, payload) => {
+		return await readEphemeralWorkspaceFile(getWindowForEvent(event), payload);
+	});
+
 	ipcMain.handle("workspace:profile", async (event) => {
 		return await profileWorkspaceFilesystem(
 			getWorkspace(getWindowForEvent(event)),
@@ -889,6 +1254,10 @@ function getOrCreateWindowState(window) {
 		pendingOpenFilePaths: [],
 		externalLixParent: null,
 		externalLixDir: null,
+		ephemeralFileTreeOwners: new Map(),
+		ephemeralDirectoryWatchers: new Map(),
+		ephemeralWatchedEntries: [],
+		ephemeralWatchRefreshTimer: null,
 		workspaceChangeQueue: Promise.resolve(),
 	};
 	windowStates.set(window.id, state);

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -5,15 +5,29 @@ import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import {
 	profileWorkspaceFilesystem,
+	disposeWorkspaceWindowState,
+	readEphemeralWorkspaceFile,
 	resolveWorkspace,
 	resolveWorkspaceTarget,
 	resolveWorkspaceTargets,
+	setEphemeralWatchedDirectories,
+	setWorkspaceFromPath,
 } from "./workspace.mjs";
 
 vi.mock("electron", () => ({
 	dialog: { showOpenDialog: vi.fn() },
 	ipcMain: { handle: vi.fn() },
 }));
+
+function createTestWindow() {
+	return {
+		id: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
+		isDestroyed: () => false,
+		setTitle: vi.fn(),
+		setRepresentedFilename: vi.fn(),
+		webContents: { send: vi.fn() },
+	};
+}
 
 describe("workspace resolution", () => {
 	test("opens directory paths as ephemeral workspaces by default", async () => {
@@ -33,7 +47,7 @@ describe("workspace resolution", () => {
 		});
 	});
 
-	test("opens directory workspaces without a size limit", async () => {
+	test("opens directory workspaces without recursively seeding include paths", async () => {
 		const directory = path.join(
 			tmpdir(),
 			"flashtype-workspace-test",
@@ -47,14 +61,14 @@ describe("workspace resolution", () => {
 			workspace: {
 				ephemeral: true,
 				path: directory,
-				includePaths: ["large.md"],
+				includePaths: [],
 				name: "workspace",
 			},
 			pendingOpenFilePaths: [],
 		});
 	});
 
-	test("opens non-Lix directories with recursive exact supported include paths", async () => {
+	test("opens non-Lix directories without extension-filtered include scans", async () => {
 		const directory = path.join(
 			tmpdir(),
 			"flashtype-workspace-test",
@@ -83,14 +97,7 @@ describe("workspace resolution", () => {
 			workspace: {
 				ephemeral: true,
 				path: directory,
-				includePaths: [
-					"alpha.markdown",
-					"data.csv",
-					"docs/nested/guide.markdown",
-					"docs/readme.md",
-					"docs/table.csv",
-					"z.md",
-				],
+				includePaths: [],
 				name: "workspace",
 			},
 			pendingOpenFilePaths: [],
@@ -460,6 +467,96 @@ describe("workspace resolution", () => {
 		]);
 	});
 
+	test("lists transient workspace directories shallowly without extension filtering", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		const childDirectory = path.join(directory, "docs");
+		const targetPath = path.join(directory, "notes.txt");
+		const symlinkPath = path.join(directory, "linked.md");
+		await mkdir(childDirectory, { recursive: true });
+		await mkdir(path.join(directory, ".lix"), { recursive: true });
+		await writeFile(path.join(directory, "alpha.md"), "# Alpha\n");
+		await writeFile(path.join(directory, "data.csv"), "name,value\nA,1\n");
+		await writeFile(targetPath, "Notes\n");
+		await writeFile(path.join(childDirectory, "nested.txt"), "Nested\n");
+		await writeFile(path.join(directory, ".hidden.md"), "# Hidden\n");
+		await writeFile(path.join(directory, ".lix", "ignored.md"), "# Ignored\n");
+		await symlink(targetPath, symlinkPath);
+
+		const window = createTestWindow();
+		try {
+			await setWorkspaceFromPath(directory, window);
+			const rootEntries = await setEphemeralWatchedDirectories(window, {
+				ownerId: "files",
+				paths: ["/"],
+			});
+			expect(rootEntries.map((entry) => entry.path).sort()).toEqual([
+				"/alpha.md",
+				"/data.csv",
+				"/docs/",
+				"/notes.txt",
+			]);
+
+			await expect(
+				readEphemeralWorkspaceFile(window, { path: "/docs/nested.txt" }),
+			).rejects.toThrow("opened Files view directory");
+
+			const nestedEntries = await setEphemeralWatchedDirectories(window, {
+				ownerId: "files",
+				paths: ["/", "/docs/"],
+			});
+			expect(nestedEntries.map((entry) => entry.path).sort()).toEqual([
+				"/alpha.md",
+				"/data.csv",
+				"/docs/",
+				"/docs/nested.txt",
+				"/notes.txt",
+			]);
+			await expect(
+				readEphemeralWorkspaceFile(window, { path: "/docs/nested.txt" }),
+			).resolves.toEqual(Buffer.from("Nested\n"));
+		} finally {
+			await disposeWorkspaceWindowState(window);
+		}
+	});
+
+	test("clears transient watched tree owners", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		await mkdir(directory, { recursive: true });
+		await writeFile(path.join(directory, "notes.txt"), "Notes\n");
+
+		const window = createTestWindow();
+		try {
+			await setWorkspaceFromPath(directory, window);
+			await expect(
+				setEphemeralWatchedDirectories(window, {
+					ownerId: "files",
+					paths: ["/"],
+				}),
+			).resolves.toHaveLength(1);
+			await expect(
+				setEphemeralWatchedDirectories(window, {
+					ownerId: "files",
+					paths: [],
+				}),
+			).resolves.toEqual([]);
+			await expect(
+				readEphemeralWorkspaceFile(window, { path: "/notes.txt" }),
+			).rejects.toThrow("opened Files view directory");
+		} finally {
+			await disposeWorkspaceWindowState(window);
+		}
+	});
+
 	test("profiles workspace filesystem sizes by extension without reading Lix blobs", async () => {
 		const directory = path.join(
 			tmpdir(),
@@ -627,7 +724,7 @@ describe("workspace resolution", () => {
 				workspace: {
 					ephemeral: true,
 					path: directory,
-					includePaths: ["docs/readme.md", "overview.md"],
+					includePaths: ["docs/readme.md"],
 					name: "workspace",
 				},
 				pendingOpenFilePaths: ["docs/readme.md"],
@@ -635,7 +732,7 @@ describe("workspace resolution", () => {
 		]);
 	});
 
-	test("restores saved non-Lix directory session entries with all supported files", async () => {
+	test("restores saved non-Lix directory session entries without include scans", async () => {
 		const directory = path.join(
 			tmpdir(),
 			"flashtype-workspace-test",
@@ -658,7 +755,7 @@ describe("workspace resolution", () => {
 				workspace: {
 					ephemeral: true,
 					path: directory,
-					includePaths: ["data.csv", "docs/notes.markdown", "marker.md"],
+					includePaths: [],
 					name: "workspace",
 				},
 				pendingOpenFilePaths: [],

--- a/src/extension-runtime/types.ts
+++ b/src/extension-runtime/types.ts
@@ -140,7 +140,7 @@ export interface ExtensionContext {
 		readonly trackTelemetry?: boolean;
 		readonly trackDocumentOpenAttempt?: boolean;
 		readonly trackDocumentViewed?: boolean;
-	}) => void;
+	}) => void | Promise<void>;
 	readonly acceptExternalWriteReview?: (args: {
 		readonly fileId: string;
 		readonly reviewId: string;

--- a/src/extension-runtime/types.ts
+++ b/src/extension-runtime/types.ts
@@ -27,6 +27,19 @@ export type ExtensionState = {
 	readonly [key: string]: unknown;
 };
 
+export type WorkspaceContext =
+	| {
+			readonly ephemeral: false;
+			readonly path: string;
+			readonly name: string;
+	  }
+	| {
+			readonly ephemeral: true;
+			readonly path: string;
+			readonly name: string;
+			readonly includePaths: readonly string[];
+	  };
+
 /**
  * One-shot launch-time arguments that must not be persisted.
  *
@@ -162,6 +175,7 @@ export interface ExtensionContext {
 		readonly isActiveView: boolean;
 		readonly handler: () => void;
 	}) => () => void;
+	readonly workspace?: WorkspaceContext;
 	readonly lix: Lix;
 }
 

--- a/src/extensions/files/build-filesystem-tree.test.ts
+++ b/src/extensions/files/build-filesystem-tree.test.ts
@@ -132,6 +132,82 @@ describe("buildFilesystemTree", () => {
 			"/visible.md",
 		]);
 	});
+
+	test("parents watched rows by path when parent ids do not match Lix ids", () => {
+		const tree = buildFilesystemTree([
+			{
+				id: "dir_docs",
+				parent_id: null,
+				path: "/docs/",
+				display_name: "docs",
+				kind: "directory",
+				source: "lix",
+			},
+			{
+				id: "watched:/docs/notes.txt",
+				parent_id: "watched:/docs/",
+				path: "/docs/notes.txt",
+				display_name: "notes.txt",
+				kind: "file",
+				source: "watched",
+			},
+		]);
+
+		expect(collectPaths(tree)).toEqual(["/docs/", "/docs/notes.txt"]);
+	});
+
+	test("dedupes by normalized path with Lix rows winning", () => {
+		const tree = buildFilesystemTree([
+			{
+				id: "watched:/docs/",
+				parent_id: null,
+				path: "/docs/",
+				display_name: "docs",
+				kind: "directory",
+				source: "watched",
+			},
+			{
+				id: "watched:/docs/notes.txt",
+				parent_id: "watched:/docs/",
+				path: "/docs/notes.txt",
+				display_name: "notes.txt",
+				kind: "file",
+				source: "watched",
+			},
+			{
+				id: "dir_docs",
+				parent_id: null,
+				path: "/docs",
+				display_name: "docs",
+				kind: "directory",
+				source: "lix",
+			},
+			{
+				id: "file_notes",
+				parent_id: "dir_docs",
+				path: "/docs/notes.txt",
+				display_name: "notes.txt",
+				kind: "file",
+				source: "lix",
+			},
+		]);
+
+		const [docs] = tree;
+		expect(docs).toMatchObject({
+			type: "directory",
+			id: "dir_docs",
+			path: "/docs/",
+			source: "lix",
+		});
+		if (docs?.type !== "directory") throw new Error("expected docs directory");
+		expect(docs.children).toHaveLength(1);
+		expect(docs.children[0]).toMatchObject({
+			type: "file",
+			id: "file_notes",
+			path: "/docs/notes.txt",
+			source: "lix",
+		});
+	});
 });
 
 function collectPaths(nodes: readonly FilesystemTreeNode[]): string[] {

--- a/src/extensions/files/build-filesystem-tree.ts
+++ b/src/extensions/files/build-filesystem-tree.ts
@@ -5,6 +5,7 @@ export type FilesystemTreeFile = {
 	id: string;
 	name: string;
 	path: string;
+	source?: "lix" | "watched";
 };
 
 export type FilesystemTreeDirectory = {
@@ -12,6 +13,7 @@ export type FilesystemTreeDirectory = {
 	id: string;
 	name: string;
 	path: string;
+	source?: "lix" | "watched";
 	children: FilesystemTreeNode[];
 };
 
@@ -35,6 +37,60 @@ function hasDotPrefixedSegment(path: string): boolean {
 	return path.split("/").some((segment) => segment.startsWith("."));
 }
 
+function normalizeDirectoryPath(path: string): string {
+	if (path === "/") return "/";
+	return path.endsWith("/") ? path : `${path}/`;
+}
+
+function normalizeFilePath(path: string): string {
+	return path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+function parentDirectoryPath(path: string, kind: "directory" | "file") {
+	const normalized =
+		kind === "directory"
+			? normalizeDirectoryPath(path)
+			: normalizeFilePath(path);
+	const segments = normalized.split("/").filter(Boolean);
+	segments.pop();
+	if (segments.length === 0) return null;
+	return `/${segments.join("/")}/`;
+}
+
+function normalizeEntryPath(entry: FilesystemEntryRow): string {
+	return entry.kind === "directory"
+		? normalizeDirectoryPath(entry.path)
+		: normalizeFilePath(entry.path);
+}
+
+function preferLixEntry(
+	existing: FilesystemEntryRow | undefined,
+	next: FilesystemEntryRow,
+): boolean {
+	if (!existing) return true;
+	return existing.source === "watched" && next.source !== "watched";
+}
+
+function normalizeAndDedupeEntries(
+	entries: readonly FilesystemEntryRow[],
+): FilesystemEntryRow[] {
+	const entriesByPath = new Map<string, FilesystemEntryRow>();
+	for (const entry of entries) {
+		const path = normalizeEntryPath(entry);
+		if (hasDotPrefixedSegment(path)) continue;
+		const normalizedEntry = {
+			...entry,
+			path,
+			source: entry.source ?? "lix",
+		} satisfies FilesystemEntryRow;
+		const existing = entriesByPath.get(path);
+		if (preferLixEntry(existing, normalizedEntry)) {
+			entriesByPath.set(path, normalizedEntry);
+		}
+	}
+	return [...entriesByPath.values()];
+}
+
 /**
  * Builds a nested tree from flat filesystem entries.
  *
@@ -44,45 +100,50 @@ function hasDotPrefixedSegment(path: string): boolean {
 export function buildFilesystemTree(
 	entries: readonly FilesystemEntryRow[],
 ): FilesystemTreeNode[] {
+	const normalizedEntries = normalizeAndDedupeEntries(entries);
 	const directories = new Map<string, FilesystemTreeDirectory>();
 	const roots: FilesystemTreeNode[] = [];
 
-	for (const entry of entries) {
+	for (const entry of normalizedEntries) {
 		if (entry.kind !== "directory") continue;
-		if (hasDotPrefixedSegment(entry.path)) continue;
-		directories.set(entry.id, {
+		const path = entry.path;
+		directories.set(path, {
 			type: "directory",
 			id: entry.id,
 			name: entry.display_name,
-			path: entry.path,
+			path,
+			source: entry.source,
 			children: [],
 		});
 	}
 
-	for (const entry of entries) {
+	for (const entry of normalizedEntries) {
 		if (entry.kind !== "directory") continue;
-		if (hasDotPrefixedSegment(entry.path)) continue;
-		const node = directories.get(entry.id);
+		const path = entry.path;
+		const node = directories.get(path);
 		if (!node) continue;
-		if (entry.parent_id && directories.has(entry.parent_id)) {
-			const parent = directories.get(entry.parent_id)!;
+		const parentPath = parentDirectoryPath(path, "directory");
+		if (parentPath && directories.has(parentPath)) {
+			const parent = directories.get(parentPath)!;
 			parent.children.push(node);
 		} else {
 			roots.push(node);
 		}
 	}
 
-	for (const entry of entries) {
+	for (const entry of normalizedEntries) {
 		if (entry.kind !== "file") continue;
-		if (hasDotPrefixedSegment(entry.path)) continue;
+		const path = entry.path;
 		const fileNode: FilesystemTreeFile = {
 			type: "file",
 			id: entry.id,
 			name: entry.display_name,
-			path: entry.path,
+			path,
+			source: entry.source,
 		};
-		if (entry.parent_id && directories.has(entry.parent_id)) {
-			const parent = directories.get(entry.parent_id)!;
+		const parentPath = parentDirectoryPath(path, "file");
+		if (parentPath && directories.has(parentPath)) {
+			const parent = directories.get(parentPath)!;
 			parent.children.push(fileNode);
 		} else {
 			roots.push(fileNode);

--- a/src/extensions/files/file-tree.test.tsx
+++ b/src/extensions/files/file-tree.test.tsx
@@ -32,6 +32,33 @@ describe("FileTree", () => {
 		expect(screen.queryByText("guides")).toBeNull();
 	});
 
+	test("supports controlled opened directories", () => {
+		const handleOpenDirectoriesChange = vi.fn();
+		const { rerender } = render(
+			<FileTree
+				nodes={mockTree}
+				openDirectories={new Set<string>()}
+				onOpenDirectoriesChange={handleOpenDirectoriesChange}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /docs/i }));
+
+		expect(handleOpenDirectoriesChange).toHaveBeenCalledWith(
+			new Set(["/docs"]),
+		);
+		expect(screen.queryByText("guides")).toBeNull();
+
+		rerender(
+			<FileTree
+				nodes={mockTree}
+				openDirectories={new Set(["/docs"])}
+				onOpenDirectoriesChange={handleOpenDirectoriesChange}
+			/>,
+		);
+		expect(screen.getByText("guides")).toBeInTheDocument();
+	});
+
 	test("preserves opened directories when the tree data refreshes", () => {
 		const { rerender } = render(<FileTree nodes={mockTree} />);
 
@@ -61,6 +88,34 @@ describe("FileTree", () => {
 			"aria-expanded",
 			"false",
 		);
+	});
+
+	test("reports controlled open directory changes", () => {
+		const handleOpenDirectoriesChange = vi.fn();
+		const { rerender } = render(
+			<FileTree
+				nodes={mockTree}
+				openDirectories={new Set()}
+				onOpenDirectoriesChange={handleOpenDirectoriesChange}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /docs/i }));
+		expect([...handleOpenDirectoriesChange.mock.calls.at(-1)![0]]).toEqual([
+			"/docs",
+		]);
+
+		rerender(
+			<FileTree
+				nodes={mockTree}
+				openDirectories={new Set(["/docs", "/docs/guides"])}
+				onOpenDirectoriesChange={handleOpenDirectoriesChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /docs/i }));
+		expect([...handleOpenDirectoriesChange.mock.calls.at(-1)![0]]).toEqual([
+			"/docs/guides",
+		]);
 	});
 
 	test("invokes openFileView when a file is selected", () => {

--- a/src/extensions/files/file-tree.tsx
+++ b/src/extensions/files/file-tree.tsx
@@ -30,6 +30,8 @@ export type FileTreeProps = {
 	readonly selectedPath?: string;
 	readonly isPanelFocused?: boolean;
 	readonly onSelectItem?: (path: string, kind: "file" | "directory") => void;
+	readonly openDirectories?: ReadonlySet<string>;
+	readonly onOpenDirectoriesChange?: (paths: ReadonlySet<string>) => void;
 };
 
 const sanitizeForTestId = (value: string): string =>
@@ -54,23 +56,34 @@ export function FileTree({
 	selectedPath,
 	isPanelFocused = false,
 	onSelectItem,
+	openDirectories,
+	onOpenDirectoriesChange,
 }: FileTreeProps) {
-	const [openDirectories, setOpenDirectories] = useState(
+	const [internalOpenDirectories, setInternalOpenDirectories] = useState(
 		() => new Set<string>(),
 	);
+	const resolvedOpenDirectories = openDirectories ?? internalOpenDirectories;
 	const sortedNodes = useMemo(() => sortNodes(nodes), [nodes]);
 
-	const toggleDirectory = useCallback((path: string) => {
-		setOpenDirectories((prev) => {
-			const next = new Set(prev);
-			if (next.has(path)) {
-				next.delete(path);
-			} else {
-				next.add(path);
+	const toggleDirectory = useCallback(
+		(path: string) => {
+			const update = (prev: ReadonlySet<string>) => {
+				const next = new Set(prev);
+				if (next.has(path)) {
+					next.delete(path);
+				} else {
+					next.add(path);
+				}
+				return next;
+			};
+			if (openDirectories && onOpenDirectoriesChange) {
+				onOpenDirectoriesChange(update(openDirectories));
+				return;
 			}
-			return next;
-		});
-	}, []);
+			setInternalOpenDirectories(update);
+		},
+		[onOpenDirectoriesChange, openDirectories],
+	);
 
 	const isEmpty = sortedNodes.length === 0 && !draft;
 
@@ -95,7 +108,7 @@ export function FileTree({
 					node={node}
 					depth={0}
 					onToggleDirectory={toggleDirectory}
-					openDirectories={openDirectories}
+					openDirectories={resolvedOpenDirectories}
 					openFileView={openFileView}
 					draft={draft}
 					selectedPath={selectedPath}
@@ -121,7 +134,7 @@ function FileTreeNode({
 	readonly node: FilesystemTreeNode;
 	readonly depth: number;
 	readonly onToggleDirectory: (path: string) => void;
-	readonly openDirectories: Set<string>;
+	readonly openDirectories: ReadonlySet<string>;
 	readonly openFileView?: (
 		fileId: string,
 		path: string,

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -582,7 +582,7 @@ describe("FilesView", () => {
 		await lix.close();
 	});
 
-	test("watches transient directories on demand and imports watched-only files before opening", async () => {
+	test("watches transient directories on demand and delegates watched-only file opens", async () => {
 		const lix = await openLix();
 		const originalDesktop = window.flashtypeDesktop;
 		const openFile = vi.fn();
@@ -619,13 +619,9 @@ describe("FilesView", () => {
 			async ({ paths }: { paths: string[] }) =>
 				paths.includes("/docs/") ? nestedEntries : rootEntries,
 		);
-		const readEphemeralFile = vi.fn(async () =>
-			new TextEncoder().encode("Nested text"),
-		);
 		window.flashtypeDesktop = {
 			workspace: {
 				setEphemeralWatchedDirectories,
-				readEphemeralFile,
 				onEphemeralWatchedFileTreeChanged: vi.fn(() => () => {}),
 			},
 		} as unknown as Window["flashtypeDesktop"];
@@ -680,21 +676,15 @@ describe("FilesView", () => {
 			});
 
 			await waitFor(async () => {
-				expect(readEphemeralFile).toHaveBeenCalledWith({
-					path: "/docs/nested.txt",
-				});
 				const file = await qb(lix)
 					.selectFrom("lix_file")
 					.select(["id", "path", "data"])
 					.where("path", "=", "/docs/nested.txt")
 					.executeTakeFirst();
-				expect(file?.path).toBe("/docs/nested.txt");
-				expect(new TextDecoder().decode(file?.data as Uint8Array)).toBe(
-					"Nested text",
-				);
+				expect(file).toBeUndefined();
 				expect(openFile).toHaveBeenCalledWith({
 					panel: "central",
-					fileId: file?.id,
+					fileId: "watched:/docs/nested.txt",
 					filePath: "/docs/nested.txt",
 					focus: false,
 				});
@@ -812,7 +802,7 @@ describe("FilesView", () => {
 		await lix.close();
 	});
 
-	test("lists ephemeral watched directories and imports watched-only files on open", async () => {
+	test("lists ephemeral watched directories and delegates watched-only file opens", async () => {
 		const lix = await openLix();
 		const originalDesktop = window.flashtypeDesktop;
 		const openFile = vi.fn();
@@ -849,14 +839,10 @@ describe("FilesView", () => {
 			async ({ paths }: { paths: string[] }) =>
 				paths.includes("/docs/") ? nestedEntries : rootEntries,
 		);
-		const readEphemeralFile = vi.fn(async () =>
-			new TextEncoder().encode("Loose text\n"),
-		);
 		window.flashtypeDesktop = {
 			workspace: {
 				setEphemeralWatchedDirectories,
 				onEphemeralWatchedFileTreeChanged: vi.fn(() => () => {}),
-				readEphemeralFile,
 			},
 		} as unknown as Window["flashtypeDesktop"];
 
@@ -913,11 +899,10 @@ describe("FilesView", () => {
 					.select(["id", "path"])
 					.where("path", "=", "/loose.txt")
 					.executeTakeFirst();
-				expect(row?.path).toBe("/loose.txt");
-				expect(readEphemeralFile).toHaveBeenCalledWith({ path: "/loose.txt" });
+				expect(row).toBeUndefined();
 				expect(openFile).toHaveBeenCalledWith({
 					panel: "central",
-					fileId: row?.id,
+					fileId: "watched:/loose.txt",
 					filePath: "/loose.txt",
 					focus: false,
 				});

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -61,7 +61,7 @@ describe("FilesView", () => {
 	test("prevents text selection on the new file row", async () => {
 		const lix = await openLix();
 
-		let utils: ReturnType<typeof render>;
+		let utils: ReturnType<typeof render> | null = null;
 		await act(async () => {
 			utils = render(
 				<LixProvider lix={lix}>
@@ -85,7 +85,7 @@ describe("FilesView", () => {
 		const lix = await openLix();
 		const openFile = vi.fn();
 
-		let utils: ReturnType<typeof render>;
+		let utils: ReturnType<typeof render> | null = null;
 		await act(async () => {
 			utils = render(
 				<LixProvider lix={lix}>
@@ -582,6 +582,141 @@ describe("FilesView", () => {
 		await lix.close();
 	});
 
+	test("watches transient directories on demand and imports watched-only files before opening", async () => {
+		const lix = await openLix();
+		const originalDesktop = window.flashtypeDesktop;
+		const openFile = vi.fn();
+		const rootEntries = [
+			{
+				id: "watched:/docs/",
+				parent_id: null,
+				path: "/docs/",
+				display_name: "docs",
+				kind: "directory" as const,
+				source: "watched" as const,
+			},
+			{
+				id: "watched:/notes.txt",
+				parent_id: null,
+				path: "/notes.txt",
+				display_name: "notes.txt",
+				kind: "file" as const,
+				source: "watched" as const,
+			},
+		];
+		const nestedEntries = [
+			...rootEntries,
+			{
+				id: "watched:/docs/nested.txt",
+				parent_id: "watched:/docs/",
+				path: "/docs/nested.txt",
+				display_name: "nested.txt",
+				kind: "file" as const,
+				source: "watched" as const,
+			},
+		];
+		const setEphemeralWatchedDirectories = vi.fn(
+			async ({ paths }: { paths: string[] }) =>
+				paths.includes("/docs/") ? nestedEntries : rootEntries,
+		);
+		const readEphemeralFile = vi.fn(async () =>
+			new TextEncoder().encode("Nested text"),
+		);
+		window.flashtypeDesktop = {
+			workspace: {
+				setEphemeralWatchedDirectories,
+				readEphemeralFile,
+				onEphemeralWatchedFileTreeChanged: vi.fn(() => () => {}),
+			},
+		} as unknown as Window["flashtypeDesktop"];
+
+		let utils: ReturnType<typeof render>;
+		let cleanup: (() => void) | undefined;
+		try {
+			await act(async () => {
+				utils = render(
+					<LixProvider lix={lix}>
+						<Suspense fallback={null}>
+							<FilesView
+								context={createViewContext(lix, {
+									openFile,
+									viewInstance: "files-view-test",
+									workspace: {
+										ephemeral: true,
+										path: "/workspace",
+										name: "workspace",
+										includePaths: [],
+									},
+								})}
+							/>
+						</Suspense>
+					</LixProvider>,
+				);
+				cleanup = () => utils.unmount();
+			});
+
+			await waitFor(() => {
+				expect(utils!.getByText("docs")).toBeInTheDocument();
+				expect(utils!.getByText("notes.txt")).toBeInTheDocument();
+			});
+			expect(setEphemeralWatchedDirectories).toHaveBeenCalledWith({
+				ownerId: "files-view:files-view-test",
+				paths: ["/"],
+			});
+
+			await act(async () => {
+				fireEvent.click(utils!.getByText("docs"));
+			});
+			await waitFor(() => {
+				expect(setEphemeralWatchedDirectories).toHaveBeenCalledWith({
+					ownerId: "files-view:files-view-test",
+					paths: ["/", "/docs/"],
+				});
+				expect(utils!.getByText("nested.txt")).toBeInTheDocument();
+			});
+
+			await act(async () => {
+				fireEvent.click(utils!.getByText("nested.txt"));
+			});
+
+			await waitFor(async () => {
+				expect(readEphemeralFile).toHaveBeenCalledWith({
+					path: "/docs/nested.txt",
+				});
+				const file = await qb(lix)
+					.selectFrom("lix_file")
+					.select(["id", "path", "data"])
+					.where("path", "=", "/docs/nested.txt")
+					.executeTakeFirst();
+				expect(file?.path).toBe("/docs/nested.txt");
+				expect(new TextDecoder().decode(file?.data as Uint8Array)).toBe(
+					"Nested text",
+				);
+				expect(openFile).toHaveBeenCalledWith({
+					panel: "central",
+					fileId: file?.id,
+					filePath: "/docs/nested.txt",
+					focus: false,
+				});
+			});
+
+			await act(async () => {
+				fireEvent.click(utils!.getByText("docs"));
+			});
+			await waitFor(() => {
+				expect(setEphemeralWatchedDirectories).toHaveBeenLastCalledWith({
+					ownerId: "files-view:files-view-test",
+					paths: ["/"],
+				});
+				expect(utils!.queryByText("nested.txt")).toBeNull();
+			});
+		} finally {
+			cleanup?.();
+			window.flashtypeDesktop = originalDesktop;
+			await lix.close();
+		}
+	});
+
 	test("Cmd+Backspace deletes the selected directory", async () => {
 		const lix = await openLix();
 		await qb(lix)
@@ -675,6 +810,124 @@ describe("FilesView", () => {
 
 		utils!.unmount();
 		await lix.close();
+	});
+
+	test("lists ephemeral watched directories and imports watched-only files on open", async () => {
+		const lix = await openLix();
+		const originalDesktop = window.flashtypeDesktop;
+		const openFile = vi.fn();
+		const rootEntries = [
+			{
+				id: "watched:/docs/",
+				parent_id: null,
+				path: "/docs/",
+				display_name: "docs",
+				kind: "directory" as const,
+				source: "watched" as const,
+			},
+			{
+				id: "watched:/loose.txt",
+				parent_id: null,
+				path: "/loose.txt",
+				display_name: "loose.txt",
+				kind: "file" as const,
+				source: "watched" as const,
+			},
+		];
+		const nestedEntries = [
+			...rootEntries,
+			{
+				id: "watched:/docs/nested.txt",
+				parent_id: "watched:/docs/",
+				path: "/docs/nested.txt",
+				display_name: "nested.txt",
+				kind: "file" as const,
+				source: "watched" as const,
+			},
+		];
+		const setEphemeralWatchedDirectories = vi.fn(
+			async ({ paths }: { paths: string[] }) =>
+				paths.includes("/docs/") ? nestedEntries : rootEntries,
+		);
+		const readEphemeralFile = vi.fn(async () =>
+			new TextEncoder().encode("Loose text\n"),
+		);
+		window.flashtypeDesktop = {
+			workspace: {
+				setEphemeralWatchedDirectories,
+				onEphemeralWatchedFileTreeChanged: vi.fn(() => () => {}),
+				readEphemeralFile,
+			},
+		} as unknown as Window["flashtypeDesktop"];
+
+		let utils: ReturnType<typeof render>;
+		try {
+			await act(async () => {
+				utils = render(
+					<LixProvider lix={lix}>
+						<Suspense fallback={null}>
+							<FilesView
+								context={createViewContext(lix, {
+									openFile,
+									viewInstance: "files-test",
+									workspace: {
+										ephemeral: true,
+										path: "/tmp/workspace",
+										name: "workspace",
+										includePaths: [],
+									},
+								})}
+							/>
+						</Suspense>
+					</LixProvider>,
+				);
+			});
+
+			await waitFor(() => {
+				expect(utils!.getByText("docs")).toBeInTheDocument();
+				expect(utils!.getByText("loose.txt")).toBeInTheDocument();
+			});
+			expect(setEphemeralWatchedDirectories).toHaveBeenCalledWith({
+				ownerId: "files-view:files-test",
+				paths: ["/"],
+			});
+
+			await act(async () => {
+				fireEvent.click(utils!.getByText("docs"));
+			});
+			await waitFor(() => {
+				expect(utils!.getByText("nested.txt")).toBeInTheDocument();
+			});
+			expect(setEphemeralWatchedDirectories).toHaveBeenCalledWith({
+				ownerId: "files-view:files-test",
+				paths: ["/", "/docs/"],
+			});
+
+			await act(async () => {
+				fireEvent.click(utils!.getByText("loose.txt"));
+			});
+
+			await waitFor(async () => {
+				const row = await qb(lix)
+					.selectFrom("lix_file")
+					.select(["id", "path"])
+					.where("path", "=", "/loose.txt")
+					.executeTakeFirst();
+				expect(row?.path).toBe("/loose.txt");
+				expect(readEphemeralFile).toHaveBeenCalledWith({ path: "/loose.txt" });
+				expect(openFile).toHaveBeenCalledWith({
+					panel: "central",
+					fileId: row?.id,
+					filePath: "/loose.txt",
+					focus: false,
+				});
+			});
+
+			utils!.unmount();
+		} finally {
+			window.flashtypeDesktop = originalDesktop;
+			await lix.close();
+		}
 	});
 
 	test("renders the file tree inside a vertical scroll region", async () => {

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -94,20 +94,6 @@ function FilesViewContent({
 				.map((entry) => entry.path),
 		);
 	}, [combinedEntries]);
-	const lixFilePathSet = useMemo(() => {
-		return new Set(
-			(entries ?? [])
-				.filter((entry) => entry.kind === "file")
-				.map((entry) => entry.path),
-		);
-	}, [entries]);
-	const watchedFilePathSet = useMemo(() => {
-		return new Set(
-			(watchedEntries ?? [])
-				.filter((entry) => entry.kind === "file")
-				.map((entry) => entry.path),
-		);
-	}, [watchedEntries]);
 	const existingFilePaths = useMemo(() => {
 		const combined = new Set(entryPathSet);
 		for (const path of pendingPaths) {
@@ -336,45 +322,18 @@ function FilesViewContent({
 	}, [context, draft, existingDirectoryPaths, existingFilePaths, lix]);
 
 	const handleOpenFile = useCallback(
-		async (fileId: string, path: string) => {
-			if (
-				isEphemeralWorkspace &&
-				watchedFilePathSet.has(path) &&
-				!lixFilePathSet.has(path)
-			) {
-				const data =
-					await window.flashtypeDesktop?.workspace.readEphemeralFile?.({
-						path,
-					});
-				if (!data) {
-					throw new Error(`Unable to read transient workspace file: ${path}`);
-				}
-				await qb(lix)
-					.insertInto("lix_file")
-					.values({
-						path,
-						data,
-					})
-					.onConflict((oc) => oc.column("path").doUpdateSet({ data }))
-					.execute();
-				const importedFile = await qb(lix)
-					.selectFrom("lix_file")
-					.select("id")
-					.where("path", "=", path)
-					.executeTakeFirstOrThrow();
-				fileId = importedFile.id as string;
-			}
+		(fileId: string, path: string) => {
 			setSelectedPath(path);
 			setSelectedFileId(fileId);
 			setSelectedKind("file");
-			context?.openFile?.({
+			void context?.openFile?.({
 				panel: "central",
 				fileId,
 				filePath: path,
 				focus: false,
 			});
 		},
-		[context, isEphemeralWorkspace, lix, lixFilePathSet, watchedFilePathSet],
+		[context],
 	);
 
 	const handleOpenDirectoriesChange = useCallback(

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -45,7 +45,28 @@ function FilesViewContent({
 	readonly lix: Lix;
 	readonly entries: FilesystemEntryRow[];
 }) {
-	const nodes = useMemo(() => buildFilesystemTree(entries ?? []), [entries]);
+	const ownerIdRef = useRef(
+		`files-view:${context?.viewInstance ?? Math.random().toString(36).slice(2)}`,
+	);
+	const isEphemeralWorkspace = context?.workspace?.ephemeral === true;
+	const [watchedEntries, setWatchedEntries] = useState<FilesystemEntryRow[]>(
+		[],
+	);
+	const [openDirectoryPaths, setOpenDirectoryPaths] = useState(
+		() => new Set<string>(),
+	);
+	const combinedEntries = useMemo(
+		() =>
+			unionFilesystemEntries(
+				entries ?? [],
+				isEphemeralWorkspace ? watchedEntries : [],
+			),
+		[entries, isEphemeralWorkspace, watchedEntries],
+	);
+	const nodes = useMemo(
+		() => buildFilesystemTree(combinedEntries),
+		[combinedEntries],
+	);
 	const creatingRef = useRef(false);
 	const [pendingPaths, setPendingPaths] = useState<string[]>([]);
 	const [pendingDirectoryPaths, setPendingDirectoryPaths] = useState<string[]>(
@@ -61,18 +82,32 @@ function FilesViewContent({
 	const dragCounterRef = useRef(0);
 	const entryPathSet = useMemo(() => {
 		return new Set(
+			(combinedEntries ?? [])
+				.filter((entry) => entry.kind === "file")
+				.map((entry) => entry.path),
+		);
+	}, [combinedEntries]);
+	const entryDirectorySet = useMemo(() => {
+		return new Set(
+			(combinedEntries ?? [])
+				.filter((entry) => entry.kind === "directory")
+				.map((entry) => entry.path),
+		);
+	}, [combinedEntries]);
+	const lixFilePathSet = useMemo(() => {
+		return new Set(
 			(entries ?? [])
 				.filter((entry) => entry.kind === "file")
 				.map((entry) => entry.path),
 		);
 	}, [entries]);
-	const entryDirectorySet = useMemo(() => {
+	const watchedFilePathSet = useMemo(() => {
 		return new Set(
-			(entries ?? [])
-				.filter((entry) => entry.kind === "directory")
+			(watchedEntries ?? [])
+				.filter((entry) => entry.kind === "file")
 				.map((entry) => entry.path),
 		);
-	}, [entries]);
+	}, [watchedEntries]);
 	const existingFilePaths = useMemo(() => {
 		const combined = new Set(entryPathSet);
 		for (const path of pendingPaths) {
@@ -99,6 +134,71 @@ function FilesViewContent({
 	}, [entryDirectorySet, pendingDirectoryPaths.length]);
 	const isMacPlatform = useMemo(() => detectMacPlatform(), []);
 	const isPanelFocused = context?.isPanelFocused ?? false;
+	const registerNewFileDraftHandler = context?.registerNewFileDraftHandler;
+	const panelSide = context?.panelSide;
+	const viewInstance = context?.viewInstance;
+	const isActiveView = context?.isActiveView === true;
+	const openedEphemeralDirectoryPaths = useMemo(() => {
+		const paths = new Set(openDirectoryPaths);
+		paths.add("/");
+		return [...paths].sort((left, right) => left.localeCompare(right));
+	}, [openDirectoryPaths]);
+
+	useEffect(() => {
+		if (!isEphemeralWorkspace) {
+			setWatchedEntries([]);
+			return;
+		}
+		const workspaceApi = window.flashtypeDesktop?.workspace;
+		if (!workspaceApi?.setEphemeralWatchedDirectories) {
+			return;
+		}
+		const ownerId = ownerIdRef.current;
+		let cancelled = false;
+		void workspaceApi
+			.setEphemeralWatchedDirectories({
+				ownerId,
+				paths: openedEphemeralDirectoryPaths,
+			})
+			.then((entries) => {
+				if (!cancelled) {
+					setWatchedEntries(entries);
+				}
+			})
+			.catch((error: unknown) => {
+				if (!cancelled) {
+					console.warn("Failed to list transient workspace files", error);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [isEphemeralWorkspace, openedEphemeralDirectoryPaths]);
+
+	useEffect(() => {
+		if (!isEphemeralWorkspace) {
+			return;
+		}
+		return window.flashtypeDesktop?.workspace.onEphemeralWatchedFileTreeChanged?.(
+			(entries) => {
+				setWatchedEntries(entries);
+			},
+		);
+	}, [isEphemeralWorkspace]);
+
+	useEffect(() => {
+		if (!isEphemeralWorkspace) {
+			return;
+		}
+		const workspaceApi = window.flashtypeDesktop?.workspace;
+		const ownerId = ownerIdRef.current;
+		return () => {
+			void workspaceApi?.setEphemeralWatchedDirectories?.({
+				ownerId,
+				paths: [],
+			});
+		};
+	}, [isEphemeralWorkspace]);
 
 	const resolveDraftDirectory = useCallback(() => {
 		if (!selectedPath) return "/";
@@ -133,25 +233,21 @@ function FilesViewContent({
 	}, [resolveDraftDirectory]);
 
 	useEffect(() => {
-		if (
-			!context?.registerNewFileDraftHandler ||
-			!context.panelSide ||
-			!context.viewInstance
-		) {
+		if (!registerNewFileDraftHandler || !panelSide || !viewInstance) {
 			return;
 		}
-		return context.registerNewFileDraftHandler({
-			panelSide: context.panelSide,
-			viewInstance: context.viewInstance,
-			isActiveView: context.isActiveView === true,
+		return registerNewFileDraftHandler({
+			panelSide,
+			viewInstance,
+			isActiveView,
 			handler: handleNewFile,
 		});
 	}, [
-		context?.isActiveView,
-		context?.panelSide,
-		context?.registerNewFileDraftHandler,
-		context?.viewInstance,
 		handleNewFile,
+		isActiveView,
+		panelSide,
+		registerNewFileDraftHandler,
+		viewInstance,
 	]);
 
 	const handleDraftCommit = useCallback(async () => {
@@ -241,6 +337,33 @@ function FilesViewContent({
 
 	const handleOpenFile = useCallback(
 		async (fileId: string, path: string) => {
+			if (
+				isEphemeralWorkspace &&
+				watchedFilePathSet.has(path) &&
+				!lixFilePathSet.has(path)
+			) {
+				const data =
+					await window.flashtypeDesktop?.workspace.readEphemeralFile?.({
+						path,
+					});
+				if (!data) {
+					throw new Error(`Unable to read transient workspace file: ${path}`);
+				}
+				await qb(lix)
+					.insertInto("lix_file")
+					.values({
+						path,
+						data,
+					})
+					.onConflict((oc) => oc.column("path").doUpdateSet({ data }))
+					.execute();
+				const importedFile = await qb(lix)
+					.selectFrom("lix_file")
+					.select("id")
+					.where("path", "=", path)
+					.executeTakeFirstOrThrow();
+				fileId = importedFile.id as string;
+			}
 			setSelectedPath(path);
 			setSelectedFileId(fileId);
 			setSelectedKind("file");
@@ -251,7 +374,26 @@ function FilesViewContent({
 				focus: false,
 			});
 		},
-		[context],
+		[context, isEphemeralWorkspace, lix, lixFilePathSet, watchedFilePathSet],
+	);
+
+	const handleOpenDirectoriesChange = useCallback(
+		(next: ReadonlySet<string>) => {
+			setOpenDirectoryPaths((prev) => {
+				const nextPaths = new Set([...next].map(ensureDirectoryPath));
+				const closedPaths = [...prev].filter((path) => !nextPaths.has(path));
+				for (const closedPath of closedPaths) {
+					const closedPrefix = ensureDirectoryPath(closedPath);
+					for (const path of [...nextPaths]) {
+						if (path !== closedPrefix && path.startsWith(closedPrefix)) {
+							nextPaths.delete(path);
+						}
+					}
+				}
+				return nextPaths;
+			});
+		},
+		[],
 	);
 
 	const handleSelectItem = useCallback(
@@ -551,6 +693,8 @@ function FilesViewContent({
 					onSelectItem={handleSelectItem}
 					selectedPath={selectedPath ?? undefined}
 					isPanelFocused={isPanelFocused}
+					openDirectories={openDirectoryPaths}
+					onOpenDirectoriesChange={handleOpenDirectoriesChange}
 					draft={
 						draft
 							? {
@@ -681,4 +825,35 @@ function normalizeNameStem(stem: string): string {
 function ensureDirectoryPath(path: string): string {
 	if (path === "/") return "/";
 	return path.endsWith("/") ? path : `${path}/`;
+}
+
+function unionFilesystemEntries(
+	lixEntries: readonly FilesystemEntryRow[],
+	watchedEntries: readonly FilesystemEntryRow[],
+): FilesystemEntryRow[] {
+	const entriesByPath = new Map<string, FilesystemEntryRow>();
+	for (const entry of watchedEntries) {
+		entriesByPath.set(filesystemEntryPathKey(entry), {
+			...entry,
+			path: filesystemEntryPathKey(entry),
+			source: "watched",
+		});
+	}
+	for (const entry of lixEntries) {
+		entriesByPath.set(filesystemEntryPathKey(entry), {
+			...entry,
+			path: filesystemEntryPathKey(entry),
+			source: "lix",
+		});
+	}
+	return [...entriesByPath.values()].sort((left, right) =>
+		left.path.localeCompare(right.path),
+	);
+}
+
+function filesystemEntryPathKey(entry: FilesystemEntryRow): string {
+	if (entry.kind === "directory") {
+		return ensureDirectoryPath(entry.path);
+	}
+	return entry.path.endsWith("/") ? entry.path.slice(0, -1) : entry.path;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,6 +35,8 @@ export const AppRoot = () => {
 	const [pendingOpenFilePaths, setPendingOpenFilePaths] = useState<string[]>(
 		[],
 	);
+	const [pendingOpenFilesConsumed, setPendingOpenFilesConsumed] =
+		useState(false);
 	const [error, setError] = useState<unknown>(null);
 	const [openingWorkspaceName, setOpeningWorkspaceName] = useState<
 		string | null | undefined
@@ -180,6 +182,8 @@ export const AppRoot = () => {
 	}, [lix, workspace]);
 
 	useEffect(() => {
+		setPendingOpenFilesConsumed(false);
+		setPendingOpenFilePaths([]);
 		if (!workspace || !lix) return;
 		let cancelled = false;
 		(async () => {
@@ -187,8 +191,9 @@ export const AppRoot = () => {
 				const filePaths =
 					(await window.flashtypeDesktop?.workspace.consumePendingOpenFiles()) ??
 					[];
-				if (!cancelled && filePaths.length > 0) {
+				if (!cancelled) {
 					setPendingOpenFilePaths(filePaths);
+					setPendingOpenFilesConsumed(true);
 				}
 			} catch (e) {
 				if (!cancelled) setError(e);
@@ -236,6 +241,9 @@ export const AppRoot = () => {
 						workspaceName={workspace.name}
 						onOpenWorkspace={handleOpenFolder}
 						pendingOpenFilePaths={pendingOpenFilePaths}
+						canPersistOpenFileSession={
+							pendingOpenFilesConsumed && pendingOpenFilePaths.length === 0
+						}
 						onPendingOpenFileHandled={handlePendingOpenFileHandled}
 						onError={setError}
 						isUpdateReady={isUpdateReady}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -232,6 +232,7 @@ export const AppRoot = () => {
 			<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
 				<Suspense fallback={<BootPlaceholder />}>
 					<V2LayoutShell
+						workspace={workspace}
 						workspaceName={workspace.name}
 						onOpenWorkspace={handleOpenFolder}
 						pendingOpenFilePaths={pendingOpenFilePaths}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -7,6 +7,7 @@ export type FilesystemEntryRow = {
 	path: string;
 	display_name: string;
 	kind: "directory" | "file";
+	source?: "lix" | "watched";
 };
 
 /**
@@ -25,6 +26,7 @@ export function selectFilesystemEntries(lix: Lix) {
 			eb.ref("lix_directory.path").as("path"),
 			eb.ref("lix_directory.name").as("display_name"),
 			sql<string>`'directory'`.as("kind"),
+			sql<string>`'lix'`.as("source"),
 		])
 		.unionAll(
 			qb(lix)
@@ -35,6 +37,7 @@ export function selectFilesystemEntries(lix: Lix) {
 					eb.ref("lix_file.path").as("path"),
 					eb.ref("lix_file.name").as("display_name"),
 					sql<string>`'file'`.as("kind"),
+					sql<string>`'lix'`.as("source"),
 				]),
 		)
 		.orderBy("path", "asc")

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -7,7 +7,7 @@ import { KEY_VALUE_DEFINITIONS } from "@/hooks/key-value/schema";
 import { openLix } from "@/test-utils/node-lix-sdk";
 import { qb } from "@/lib/lix-kysely";
 import { FILES_EXTENSION_KIND } from "@/extension-runtime/extension-instance-helpers";
-import { V2LayoutShell } from "./layout-shell";
+import { resolveLixFileForOpen, V2LayoutShell } from "./layout-shell";
 import type { FlashtypeUiState } from "./ui-state";
 import type { Lix } from "@/lib/lix-types";
 
@@ -21,6 +21,123 @@ const originalDesktop = window.flashtypeDesktop;
 afterEach(() => {
 	cleanup();
 	window.flashtypeDesktop = originalDesktop;
+});
+
+describe("resolveLixFileForOpen", () => {
+	test("uses the existing Lix row for normalized file paths", async () => {
+		const lix = await openLix();
+		const readEphemeralFile = vi.fn(async () =>
+			new TextEncoder().encode("Disk content"),
+		);
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "real_file",
+				path: "/docs/readme.md",
+				data: new TextEncoder().encode("Lix content"),
+			})
+			.execute();
+
+		const resolved = await resolveLixFileForOpen({
+			lix,
+			workspace: ephemeralWorkspace(),
+			filePath: "docs/./readme.md",
+			readEphemeralFile,
+		});
+
+		expect(resolved).toEqual({ id: "real_file", path: "/docs/readme.md" });
+		expect(readEphemeralFile).not.toHaveBeenCalled();
+		await lix.close();
+	});
+
+	test("imports an ephemeral disk file and returns the inserted Lix id", async () => {
+		const lix = await openLix();
+		const readEphemeralFile = vi.fn(async () =>
+			new TextEncoder().encode("# Imported"),
+		);
+
+		const resolved = await resolveLixFileForOpen({
+			lix,
+			workspace: ephemeralWorkspace(),
+			filePath: "/notes.md",
+			readEphemeralFile,
+		});
+
+		expect(readEphemeralFile).toHaveBeenCalledWith({ path: "/notes.md" });
+		expect(resolved?.path).toBe("/notes.md");
+		expect(resolved?.id).toBeTruthy();
+		const row = await qb(lix)
+			.selectFrom("lix_file")
+			.select(["id", "path", "data"])
+			.where("path", "=", "/notes.md")
+			.executeTakeFirstOrThrow();
+		expect(row.id).toBe(resolved?.id);
+		expect(new TextDecoder().decode(row.data as Uint8Array)).toBe("# Imported");
+		await lix.close();
+	});
+
+	test("does not overwrite a Lix row created while importing", async () => {
+		const lix = await openLix();
+		const readEphemeralFile = vi.fn(async () => {
+			await qb(lix)
+				.insertInto("lix_file")
+				.values({
+					id: "raced_file",
+					path: "/race.md",
+					data: new TextEncoder().encode("Existing Lix data"),
+				})
+				.execute();
+			return new TextEncoder().encode("Disk data");
+		});
+
+		const resolved = await resolveLixFileForOpen({
+			lix,
+			workspace: ephemeralWorkspace(),
+			filePath: "/race.md",
+			readEphemeralFile,
+		});
+
+		expect(resolved).toEqual({ id: "raced_file", path: "/race.md" });
+		const row = await qb(lix)
+			.selectFrom("lix_file")
+			.select(["data"])
+			.where("path", "=", "/race.md")
+			.executeTakeFirstOrThrow();
+		expect(new TextDecoder().decode(row.data as Uint8Array)).toBe(
+			"Existing Lix data",
+		);
+		await lix.close();
+	});
+
+	test("refuses files that cannot be found or imported", async () => {
+		const lix = await openLix();
+		const readEphemeralFile = vi.fn(async () => undefined);
+
+		await expect(
+			resolveLixFileForOpen({
+				lix,
+				workspace: {
+					ephemeral: false,
+					path: "/workspace/.lix",
+					name: "workspace",
+				},
+				filePath: "/missing.md",
+				readEphemeralFile,
+			}),
+		).resolves.toBeNull();
+		expect(readEphemeralFile).not.toHaveBeenCalled();
+
+		await expect(
+			resolveLixFileForOpen({
+				lix,
+				workspace: ephemeralWorkspace(),
+				filePath: "/missing.md",
+				readEphemeralFile,
+			}),
+		).resolves.toBeNull();
+		expect(readEphemeralFile).toHaveBeenCalledWith({ path: "/missing.md" });
+		await lix.close();
+	});
 });
 
 describe("V2LayoutShell native New File", () => {
@@ -228,7 +345,10 @@ function collapsedFilesViewState(): FlashtypeUiState {
 	};
 }
 
-async function findFilePath(lix: Lix, path: string): Promise<string | undefined> {
+async function findFilePath(
+	lix: Lix,
+	path: string,
+): Promise<string | undefined> {
 	return (
 		await qb(lix)
 			.selectFrom("lix_file")
@@ -236,4 +356,13 @@ async function findFilePath(lix: Lix, path: string): Promise<string | undefined>
 			.where("path", "=", path)
 			.executeTakeFirst()
 	)?.path;
+}
+
+function ephemeralWorkspace() {
+	return {
+		ephemeral: true,
+		path: "/workspace",
+		name: "workspace",
+		includePaths: [],
+	} as const;
 }

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -90,9 +90,28 @@ describe("V2LayoutShell native New File", () => {
 			await desktop.emitNewFile();
 		});
 
-		await waitFor(async () => {
-			expect(await findFilePath(lix, "/new-file.md")).toBeDefined();
+		await expectNewFileCreatedAndOpened(lix);
+		expect(screen.queryByTestId("files-view-draft-input")).toBeNull();
+
+		utils.unmount();
+		await lix.close();
+	});
+
+	test("falls back to direct file creation when the active FilesView is collapsed", async () => {
+		const desktop = installDesktopMock();
+		const lix = await openLix({
+			keyValues: [uiStateKeyValue(collapsedFilesViewState())],
 		});
+
+		const utils = await renderShell(lix);
+		await screen.findByRole("button", { name: "New file" });
+		await waitFor(() => expect(desktop.onNewFile).toHaveBeenCalled());
+
+		await act(async () => {
+			await desktop.emitNewFile();
+		});
+
+		await expectNewFileCreatedAndOpened(lix);
 		expect(screen.queryByTestId("files-view-draft-input")).toBeNull();
 
 		utils.unmount();
@@ -114,6 +133,16 @@ async function renderShell(lix: Lix) {
 		);
 	});
 	return result!;
+}
+
+async function expectNewFileCreatedAndOpened(lix: Lix) {
+	await waitFor(async () => {
+		expect(await findFilePath(lix, "/new-file.md")).toBeDefined();
+	});
+	await screen.findByTestId("tiptap-editor");
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
 }
 
 function installDesktopMock(): DesktopMock {
@@ -181,6 +210,21 @@ function twoFilesViewsState(): FlashtypeUiState {
 			},
 		},
 		layout: { sizes: { left: 20, central: 50, right: 30 } },
+	};
+}
+
+function collapsedFilesViewState(): FlashtypeUiState {
+	return {
+		focusedPanel: "left",
+		panels: {
+			left: {
+				views: [{ instance: "files-left", kind: FILES_EXTENSION_KIND }],
+				activeInstance: "files-left",
+			},
+			central: { views: [], activeInstance: null },
+			right: { views: [], activeInstance: null },
+		},
+		layout: { sizes: { left: 0, central: 70, right: 30 } },
 	};
 }
 

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -22,6 +22,7 @@ import {
 	useSensors,
 } from "@dnd-kit/core";
 import { useLix } from "@/lib/lix-react";
+import type { Lix } from "@/lib/lix-types";
 import { useKeyValue } from "@/hooks/key-value/use-key-value";
 import { SidePanel } from "./side-panel";
 import { CentralPanel } from "./central-panel";
@@ -411,6 +412,82 @@ function fileBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
 		if (left[index] !== right[index]) return false;
 	}
 	return true;
+}
+
+type LixFileForOpen = {
+	readonly id: string;
+	readonly path: string;
+};
+
+type ReadEphemeralFile = (payload: {
+	readonly path: string;
+}) => Promise<Uint8Array | undefined>;
+
+function normalizeLixFileOpenPath(filePath: string): string | null {
+	const rawPath = filePath.replace(/\\/g, "/").trim();
+	if (!rawPath) return null;
+	const rootedPath = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+	const segments: string[] = [];
+	for (const segment of rootedPath.split("/")) {
+		if (!segment || segment === ".") continue;
+		if (segment === "..") {
+			if (segments.length === 0) return null;
+			segments.pop();
+			continue;
+		}
+		segments.push(segment);
+	}
+	if (segments.length === 0) return null;
+	return `/${segments.join("/")}`;
+}
+
+async function selectLixFileForOpen(
+	lix: Lix,
+	filePath: string,
+): Promise<LixFileForOpen | null> {
+	const row = await qb(lix)
+		.selectFrom("lix_file")
+		.select(["id", "path"])
+		.where("path", "=", filePath)
+		.executeTakeFirst();
+	if (!row) return null;
+	return { id: row.id as string, path: row.path as string };
+}
+
+export async function resolveLixFileForOpen({
+	lix,
+	workspace,
+	filePath,
+	readEphemeralFile,
+}: {
+	readonly lix: Lix;
+	readonly workspace?: WorkspaceContext;
+	readonly filePath: string;
+	readonly readEphemeralFile?: ReadEphemeralFile;
+}): Promise<LixFileForOpen | null> {
+	const normalizedPath = normalizeLixFileOpenPath(filePath);
+	if (!normalizedPath) return null;
+
+	const existingFile = await selectLixFileForOpen(lix, normalizedPath);
+	if (existingFile) return existingFile;
+
+	if (workspace?.ephemeral !== true || !readEphemeralFile) {
+		return null;
+	}
+
+	const data = await readEphemeralFile({ path: normalizedPath });
+	if (!data) return null;
+
+	await qb(lix)
+		.insertInto("lix_file")
+		.values({
+			path: normalizedPath,
+			data,
+		})
+		.onConflict((oc) => oc.column("path").doNothing())
+		.execute();
+
+	return selectLixFileForOpen(lix, normalizedPath);
 }
 
 function documentOpenAttemptTelemetryProperties({
@@ -1119,7 +1196,7 @@ function LayoutShellLoadedContent({
 		[ensurePanelExpanded, setPanelState],
 	);
 
-	const handleOpenFile = useCallback(
+	const openResolvedFileView = useCallback(
 		({
 			panel,
 			fileId,
@@ -1180,6 +1257,69 @@ function LayoutShellLoadedContent({
 		[handleOpenView, extensionMap, captureWorkspaceTelemetry],
 	);
 
+	const handleOpenFile = useCallback(
+		async ({
+			panel,
+			fileId: _requestedFileId,
+			filePath,
+			state,
+			launchArgs,
+			focus,
+			pending,
+			documentOrigin,
+			trackTelemetry,
+			trackDocumentOpenAttempt,
+			trackDocumentViewed,
+		}: {
+			panel: PanelSide;
+			fileId: string;
+			filePath: string;
+			state?: ExtensionState;
+			launchArgs?: ExtensionLaunchArgs;
+			focus?: boolean;
+			pending?: boolean;
+			documentOrigin?: "existing" | "new";
+			trackTelemetry?: boolean;
+			trackDocumentOpenAttempt?: boolean;
+			trackDocumentViewed?: boolean;
+		}) => {
+			let resolvedFile: LixFileForOpen | null = null;
+			try {
+				resolvedFile = await resolveLixFileForOpen({
+					lix,
+					workspace,
+					filePath,
+					readEphemeralFile:
+						window.flashtypeDesktop?.workspace.readEphemeralFile,
+				});
+			} catch (error) {
+				onError?.(error);
+				return;
+			}
+			if (!resolvedFile) {
+				onError?.(
+					new Error(`File not found in the opened workspace: ${filePath}`),
+				);
+				return;
+			}
+
+			openResolvedFileView({
+				panel,
+				fileId: resolvedFile.id,
+				filePath: resolvedFile.path,
+				state,
+				launchArgs,
+				focus,
+				pending,
+				documentOrigin,
+				trackTelemetry,
+				trackDocumentOpenAttempt,
+				trackDocumentViewed,
+			});
+		},
+		[lix, workspace, onError, openResolvedFileView],
+	);
+
 	useEffect(() => {
 		if (!pendingOpenFilePaths || pendingOpenFilePaths.length === 0) return;
 		let cancelled = false;
@@ -1187,19 +1327,20 @@ function LayoutShellLoadedContent({
 			const openedFiles: Array<{ id: string; path: string }> = [];
 			const handledFilePaths: string[] = [];
 			for (const pendingOpenFilePath of pendingOpenFilePaths) {
-				const lixLookupPath = `/${pendingOpenFilePath}`;
-				const file = await qb(lix)
-					.selectFrom("lix_file")
-					.select(["id", "path"])
-					.where("path", "=", lixLookupPath)
-					.executeTakeFirst();
+				const file = await resolveLixFileForOpen({
+					lix,
+					workspace,
+					filePath: `/${pendingOpenFilePath}`,
+					readEphemeralFile:
+						window.flashtypeDesktop?.workspace.readEphemeralFile,
+				});
 				if (cancelled) return;
 				if (!file) {
 					throw new Error(
 						`File not found in the opened workspace: ${pendingOpenFilePath}`,
 					);
 				}
-				handleOpenFile({
+				openResolvedFileView({
 					panel: "central",
 					fileId: file.id as string,
 					filePath: file.path as string,
@@ -1212,7 +1353,7 @@ function LayoutShellLoadedContent({
 			}
 			const firstFile = openedFiles[0];
 			if (!cancelled && firstFile) {
-				handleOpenFile({
+				openResolvedFileView({
 					panel: "central",
 					fileId: firstFile.id,
 					filePath: firstFile.path,
@@ -1235,11 +1376,12 @@ function LayoutShellLoadedContent({
 			cancelled = true;
 		};
 	}, [
-		handleOpenFile,
 		lix,
 		onError,
 		onPendingOpenFileHandled,
+		openResolvedFileView,
 		pendingOpenFilePaths,
+		workspace,
 	]);
 
 	const clearExternalWriteReview = useCallback(
@@ -1429,7 +1571,7 @@ function LayoutShellLoadedContent({
 							source: "renderer",
 						});
 					}
-					handleOpenFile({
+					await handleOpenFile({
 						panel: "central",
 						fileId: write.fileId,
 						filePath: write.path,
@@ -1784,7 +1926,7 @@ function LayoutShellLoadedContent({
 			.where("path", "=", path)
 			.executeTakeFirstOrThrow();
 		const id = createdFile.id;
-		handleOpenFile({
+		await handleOpenFile({
 			panel: "central",
 			fileId: id,
 			filePath: path,

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -1787,8 +1787,19 @@ function LayoutShellLoadedContent({
 	}, [handleOpenFile, lix]);
 
 	const handleNativeNewFile = useCallback(async () => {
+		const visibleDraftHandlers = [
+			...newFileDraftHandlersRef.current.values(),
+		].filter((registration) => {
+			if (registration.panelSide === "left") {
+				return !isLeftCollapsed;
+			}
+			if (registration.panelSide === "right") {
+				return !isRightCollapsed;
+			}
+			return true;
+		});
 		const filesViewHandler = selectNewFileDraftHandler(
-			newFileDraftHandlersRef.current.values(),
+			visibleDraftHandlers,
 			focusedPanel,
 		);
 		if (filesViewHandler) {
@@ -1805,7 +1816,14 @@ function LayoutShellLoadedContent({
 			}
 			console.error("Failed to create new file from native menu", error);
 		}
-	}, [focusPanel, focusedPanel, handleCreateNewFile, onError]);
+	}, [
+		focusPanel,
+		focusedPanel,
+		handleCreateNewFile,
+		isLeftCollapsed,
+		isRightCollapsed,
+		onError,
+	]);
 
 	useEffect(() => {
 		const unsubscribe =

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -60,6 +60,7 @@ import type {
 	ExtensionLaunchArgs,
 	ExtensionState,
 	ExtensionDefinition,
+	WorkspaceContext,
 } from "../extension-runtime/types";
 import {
 	createExtensionInstanceId,
@@ -337,6 +338,7 @@ async function resolveNextUntitledMarkdownPath(
 }
 
 export function V2LayoutShell({
+	workspace,
 	workspaceName,
 	onOpenWorkspace,
 	pendingOpenFilePaths,
@@ -345,6 +347,7 @@ export function V2LayoutShell({
 	isUpdateReady,
 	onInstallUpdate,
 }: {
+	readonly workspace?: WorkspaceContext;
 	readonly workspaceName?: string;
 	readonly onOpenWorkspace?: () => void;
 	readonly pendingOpenFilePaths?: readonly string[];
@@ -357,6 +360,7 @@ export function V2LayoutShell({
 		<ExtensionRegistryProvider>
 			<ExtensionHostRegistryProvider>
 				<LayoutShellContent
+					workspace={workspace}
 					workspaceName={workspaceName}
 					onOpenWorkspace={onOpenWorkspace}
 					pendingOpenFilePaths={pendingOpenFilePaths}
@@ -371,6 +375,7 @@ export function V2LayoutShell({
 }
 
 type LayoutShellContentProps = {
+	readonly workspace?: WorkspaceContext;
 	readonly workspaceName?: string;
 	readonly onOpenWorkspace?: () => void;
 	readonly pendingOpenFilePaths?: readonly string[];
@@ -453,6 +458,7 @@ function isPanelShortcutBlockedTarget(target: EventTarget | null): boolean {
  * <V2LayoutShell />
  */
 function LayoutShellContent({
+	workspace,
 	workspaceName,
 	onOpenWorkspace,
 	pendingOpenFilePaths,
@@ -465,6 +471,7 @@ function LayoutShellContent({
 	return (
 		<LayoutShellUiStateLoader
 			workspaceName={workspaceName}
+			workspace={workspace}
 			onOpenWorkspace={onOpenWorkspace}
 			pendingOpenFilePaths={pendingOpenFilePaths}
 			onPendingOpenFileHandled={onPendingOpenFileHandled}
@@ -511,6 +518,7 @@ function LayoutShellActiveFileLoader(
 }
 
 function LayoutShellLoadedContent({
+	workspace,
 	workspaceName,
 	onOpenWorkspace,
 	pendingOpenFilePaths,
@@ -2032,6 +2040,7 @@ function LayoutShellLoadedContent({
 			registerNewFileDraftHandler,
 			acceptExternalWriteReview: handleAcceptExternalWriteReview,
 			rejectExternalWriteReview: handleRejectExternalWriteReview,
+			workspace,
 			lix,
 		}),
 		[
@@ -2045,6 +2054,7 @@ function LayoutShellLoadedContent({
 			handleRejectExternalWriteReview,
 			focusPanel,
 			registerNewFileDraftHandler,
+			workspace,
 			lix,
 		],
 	);

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -343,6 +343,7 @@ export function V2LayoutShell({
 	workspaceName,
 	onOpenWorkspace,
 	pendingOpenFilePaths,
+	canPersistOpenFileSession = true,
 	onPendingOpenFileHandled,
 	onError,
 	isUpdateReady,
@@ -352,6 +353,7 @@ export function V2LayoutShell({
 	readonly workspaceName?: string;
 	readonly onOpenWorkspace?: () => void;
 	readonly pendingOpenFilePaths?: readonly string[];
+	readonly canPersistOpenFileSession?: boolean;
 	readonly onPendingOpenFileHandled?: (filePath: string) => void;
 	readonly onError?: (error: unknown) => void;
 	readonly isUpdateReady?: boolean;
@@ -365,6 +367,7 @@ export function V2LayoutShell({
 					workspaceName={workspaceName}
 					onOpenWorkspace={onOpenWorkspace}
 					pendingOpenFilePaths={pendingOpenFilePaths}
+					canPersistOpenFileSession={canPersistOpenFileSession}
 					onPendingOpenFileHandled={onPendingOpenFileHandled}
 					onError={onError}
 					isUpdateReady={isUpdateReady}
@@ -380,6 +383,7 @@ type LayoutShellContentProps = {
 	readonly workspaceName?: string;
 	readonly onOpenWorkspace?: () => void;
 	readonly pendingOpenFilePaths?: readonly string[];
+	readonly canPersistOpenFileSession?: boolean;
 	readonly onPendingOpenFileHandled?: (filePath: string) => void;
 	readonly onError?: (error: unknown) => void;
 	readonly isUpdateReady?: boolean;
@@ -539,6 +543,7 @@ function LayoutShellContent({
 	workspaceName,
 	onOpenWorkspace,
 	pendingOpenFilePaths,
+	canPersistOpenFileSession,
 	onPendingOpenFileHandled,
 	onError,
 	isUpdateReady,
@@ -551,6 +556,7 @@ function LayoutShellContent({
 			workspace={workspace}
 			onOpenWorkspace={onOpenWorkspace}
 			pendingOpenFilePaths={pendingOpenFilePaths}
+			canPersistOpenFileSession={canPersistOpenFileSession}
 			onPendingOpenFileHandled={onPendingOpenFileHandled}
 			onError={onError}
 			isUpdateReady={isUpdateReady}
@@ -599,6 +605,7 @@ function LayoutShellLoadedContent({
 	workspaceName,
 	onOpenWorkspace,
 	pendingOpenFilePaths,
+	canPersistOpenFileSession,
 	onPendingOpenFileHandled,
 	onError,
 	isUpdateReady,
@@ -2024,10 +2031,11 @@ function LayoutShellLoadedContent({
 	);
 
 	useEffect(() => {
+		if (!canPersistOpenFileSession) return;
 		void window.flashtypeDesktop?.workspace.setOpenFilePaths({
 			filePaths: sessionOpenFilePaths,
 		});
-	}, [sessionOpenFilePaths]);
+	}, [canPersistOpenFileSession, sessionOpenFilePaths]);
 
 	const isLeftFocused = focusedPanel === "left";
 	const isCentralFocused = focusedPanel === "central";


### PR DESCRIPTION
- Stops non-Lix folders from eagerly importing/scanning all supported files at workspace open time.
- Adds workspace IPC for ephemeral file-tree watching and ephemeral file reads.
- Makes the Files panel watch only the root and expanded directories, updating as directories open/close.
- Imports transient disk files into Lix only when they are opened.
- Centralizes file-open resolution in the layout shell so pending opens, Files panel opens, and external-write opens share the same Lix-first path.
- Fixes native New File behavior when the Files view is unavailable or collapsed by falling back to direct file creation.
- Delays open-file session persistence until pending open files have been consumed, avoiding accidental loss of restored/opened files.
- Normalizes and dedupes mixed Lix/watched file-tree entries, preferring real Lix rows and hiding dot-prefixed paths.
- Cleans up ephemeral watchers on workspace switches, Track Changes toggles, and window disposal.
