### PR TITLE
[codex] Improve CSV grid rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,9 @@
 > [!INFO]
 > `pnpm install` runs a postinstall step that installs Lix dependencies, so Nx can cache Lix builds.
 
+> [!INFO]
+> `@glideapps/glide-data-grid` is used for the CSV viewer. Its published peer range has not caught up to React 19, so `package.json` intentionally allows the React 19 peer for Glide and lists Glide's peer packages explicitly.
+
 1. `git submodule update --init --recursive`
 2. `pnpm install`
 3. `pnpm run build:lix`

--- a/e2e/files-click-tour.spec.ts
+++ b/e2e/files-click-tour.spec.ts
@@ -49,10 +49,6 @@ test("left files panel survives a seeded random file click tour", async ({
 			const delayMs = Math.floor(rng() * 1001);
 			const file = fileItems.nth(fileIndex);
 			const testId = await file.getAttribute("data-testid");
-			const expectedViewKind =
-				testId === "file-tree-item-metrics-csv"
-					? "flashtype_csv"
-					: "flashtype_file";
 
 			await test.step(`click ${index + 1}/${clickCount}: file index ${fileIndex}, delay ${delayMs}ms`, async () => {
 				await file.click();
@@ -60,10 +56,13 @@ test("left files panel survives a seeded random file click tour", async ({
 				await expect(
 					page
 						.locator(
-							`[data-active="true"][data-view-key="${expectedViewKind}"]:visible`,
+							'[data-panel-side="central"][data-active="true"][data-view-key="flashtype_file"]:visible, [data-panel-side="central"][data-active="true"][data-view-key="flashtype_csv"]:visible',
 						)
 						.first(),
 				).toBeVisible();
+				if (testId === "file-tree-item-metrics-csv") {
+					await expectCsvGridCanvasToRender(page);
+				}
 				await page.waitForTimeout(delayMs);
 			});
 		}

--- a/e2e/files-click-tour.spec.ts
+++ b/e2e/files-click-tour.spec.ts
@@ -1,11 +1,9 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import type { ElectronApplication } from "playwright";
-import path from "node:path";
 import seedrandom from "seedrandom";
 import {
 	closeElectronApp,
 	ensureFilesViewOpenInLeftPanel,
-	expectPathMissing,
 	launchDevElectronApp,
 	registerRendererConsoleLogging,
 	writeStarterFiles,
@@ -30,7 +28,6 @@ test("left files panel survives a seeded random file click tour", async ({
 		registerRendererConsoleLogging(page);
 
 		await expect(page.getByTestId("central-panel-empty-state")).toBeVisible();
-		await expectPathMissing(path.join(workspaceDir, ".lix"));
 		await ensureFilesViewOpenInLeftPanel(page);
 
 		const fileItems = page.locator('[data-testid^="file-tree-item-"]');
@@ -42,10 +39,7 @@ test("left files panel survives a seeded random file click tour", async ({
 			page.locator('[data-active="true"][data-view-key="flashtype_csv"]'),
 		).toBeVisible();
 		await expect(page.getByText("/metrics.csv")).toBeVisible();
-		await expect(page.getByText("metric", { exact: true })).toBeVisible();
-		await expect(page.getByText("value", { exact: true })).toBeVisible();
-		await expect(page.getByText("signups", { exact: true })).toBeVisible();
-		await expect(page.getByText("42", { exact: true })).toBeVisible();
+		await expectCsvGridCanvasToRender(page);
 
 		for (let index = 0; index < clickCount; index += 1) {
 			const fileCount = await fileItems.count();
@@ -78,6 +72,40 @@ test("left files panel survives a seeded random file click tour", async ({
 	}
 });
 
+async function expectCsvGridCanvasToRender(
+	page: Page,
+): Promise<void> {
+	const canvas = page
+		.locator('[data-active="true"][data-view-key="flashtype_csv"] canvas')
+		.first();
+	await expect(canvas).toBeVisible();
+	await expect
+		.poll(async () => {
+			return await canvas.evaluate((element) => {
+				const canvasElement = element as HTMLCanvasElement;
+				const context = canvasElement.getContext("2d");
+				if (!context || canvasElement.width === 0 || canvasElement.height === 0) {
+					return 0;
+				}
+				const width = Math.min(canvasElement.width, 500);
+				const height = Math.min(canvasElement.height, 300);
+				const pixels = context.getImageData(0, 0, width, height).data;
+				let nonWhitePixels = 0;
+				for (let index = 0; index < pixels.length; index += 4) {
+					const red = pixels[index] ?? 255;
+					const green = pixels[index + 1] ?? 255;
+					const blue = pixels[index + 2] ?? 255;
+					const alpha = pixels[index + 3] ?? 0;
+					if (alpha > 0 && (red < 245 || green < 245 || blue < 245)) {
+						nonWhitePixels += 1;
+					}
+				}
+				return nonWhitePixels;
+			});
+		})
+		.toBeGreaterThan(100);
+}
+
 test("deleting the active file closes the central file view", async ({
 	browserName: _browserName,
 }, testInfo) => {
@@ -92,7 +120,6 @@ test("deleting the active file closes the central file view", async ({
 		registerRendererConsoleLogging(page);
 
 		await expect(page.getByTestId("central-panel-empty-state")).toBeVisible();
-		await expectPathMissing(path.join(workspaceDir, ".lix"));
 		await ensureFilesViewOpenInLeftPanel(page);
 
 		const file = page.getByTestId("file-tree-item-welcome-md");

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -989,6 +989,17 @@ function canUseAutoUpdates() {
 	return app.isPackaged && process.env.FLASHTYPE_DISABLE_AUTO_UPDATE !== "1";
 }
 
+function validateExternalUrl(value) {
+	if (typeof value !== "string") {
+		throw new Error("External URL must be a string");
+	}
+	const url = new URL(value);
+	if (!["http:", "https:", "mailto:"].includes(url.protocol)) {
+		throw new Error(`Unsupported external URL protocol: ${url.protocol}`);
+	}
+	return url.toString();
+}
+
 function registerAppIpc() {
 	ipcMain.handle("app:checkForUpdates", async () => {
 		return await checkForUpdatesFromMenu({ manual: true });
@@ -998,6 +1009,11 @@ function registerAppIpc() {
 	});
 	ipcMain.handle("app:installUpdate", async () => {
 		return installDownloadedUpdate();
+	});
+	ipcMain.handle("app:openExternal", async (_event, payload) => {
+		const url = validateExternalUrl(payload?.url);
+		await shell.openExternal(url);
+		return { status: "opened" };
 	});
 	ipcMain.handle("workspace:setActiveFilePath", (event, payload) => {
 		const window = BrowserWindow.fromWebContents(event.sender);

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -4,6 +4,7 @@ const app = {
 	checkForUpdates: () => ipcRenderer.invoke("app:checkForUpdates"),
 	getUpdateState: () => ipcRenderer.invoke("app:getUpdateState"),
 	installUpdate: () => ipcRenderer.invoke("app:installUpdate"),
+	openExternal: (payload) => ipcRenderer.invoke("app:openExternal", payload),
 	onUpdateState: (listener) => {
 		const wrapped = (_event, payload) => listener(payload);
 		ipcRenderer.on("app:updateState", wrapped);

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -190,6 +190,7 @@ export type DesktopAppApi = {
 	checkForUpdates(): Promise<{ status: DesktopUpdateCheckStatus }>;
 	getUpdateState(): Promise<DesktopUpdateState>;
 	installUpdate(): Promise<{ status: DesktopUpdateCheckStatus }>;
+	openExternal(payload: { url: string }): Promise<{ status: "opened" }>;
 	onUpdateState(listener: (state: DesktopUpdateState) => void): () => void;
 };
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
 	"type": "module",
 	"main": "electron/main.mjs",
 	"packageManager": "pnpm@10.13.1",
+	"pnpm": {
+		"peerDependencyRules": {
+			"allowedVersions": {
+				"@glideapps/glide-data-grid>react": "^19.0.0",
+				"@glideapps/glide-data-grid>react-dom": "^19.0.0"
+			}
+		}
+	},
 	"scripts": {
 		"dev": "node scripts/dev.mjs",
 		"dev:renderer": "vite --host 127.0.0.1 --port 4173 --strictPort",
@@ -45,12 +53,11 @@
 		"@dnd-kit/core": "^6.3.1",
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
+		"@glideapps/glide-data-grid": "^6.0.3",
 		"@lix-js/html-diff": "^0.1.0",
 		"@lix-js/sdk": "workspace:*",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",
 		"@radix-ui/react-tooltip": "^1.2.8",
-		"@tanstack/react-table": "^8.21.3",
-		"@tanstack/react-virtual": "^3.14.2",
 		"@tiptap/core": "^3.3.0",
 		"@tiptap/extension-history": "^3.4.4",
 		"@tiptap/extension-placeholder": "^3.4.4",
@@ -62,7 +69,9 @@
 		"clsx": "^2.1.1",
 		"electron-updater": "^6.8.9",
 		"kysely": "^0.28.7",
+		"lodash": "^4.18.1",
 		"lucide-react": "^0.542.0",
+		"marked": "^4.3.0",
 		"node-pty": "^1.0.0",
 		"papaparse": "^5.5.3",
 		"posthog-js": "^1.393.0",
@@ -70,6 +79,7 @@
 		"react": "^19.2.0",
 		"react-dom": "^19.2.0",
 		"react-resizable-panels": "^2.1.9",
+		"react-responsive-carousel": "^3.2.23",
 		"tailwind-merge": "^3.3.1"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.0)
+      '@glideapps/glide-data-grid':
+        specifier: ^6.0.3
+        version: 6.0.3(lodash@4.18.1)(marked@4.3.0)(react-dom@19.2.0(react@19.2.0))(react-responsive-carousel@3.2.23)(react@19.2.0)
       '@lix-js/html-diff':
         specifier: ^0.1.0
         version: 0.1.0
@@ -32,12 +35,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@tanstack/react-table':
-        specifier: ^8.21.3
-        version: 8.21.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@tanstack/react-virtual':
-        specifier: ^3.14.2
-        version: 3.14.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tiptap/core':
         specifier: ^3.3.0
         version: 3.14.0(@tiptap/pm@3.14.0)
@@ -71,9 +68,15 @@ importers:
       kysely:
         specifier: ^0.28.7
         version: 0.28.9
+      lodash:
+        specifier: ^4.18.1
+        version: 4.18.1
       lucide-react:
         specifier: ^0.542.0
         version: 0.542.0(react@19.2.0)
+      marked:
+        specifier: ^4.3.0
+        version: 4.3.0
       node-pty:
         specifier: ^1.0.0
         version: 1.1.0
@@ -95,6 +98,9 @@ importers:
       react-resizable-panels:
         specifier: ^2.1.9
         version: 2.1.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-responsive-carousel:
+        specifier: ^3.2.23
+        version: 3.2.23
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.4.0
@@ -239,6 +245,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.28.5':
     resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
     engines: {node: '>=6.9.0'}
@@ -251,6 +261,10 @@ packages:
     resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
@@ -259,8 +273,16 @@ packages:
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.27.1':
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.28.3':
@@ -269,16 +291,34 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-plugin-utils@7.27.1':
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -293,6 +333,34 @@ packages:
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-proposal-export-namespace-from@7.18.9':
+    resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-dynamic-import@7.8.3':
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-export-namespace-from@7.8.3':
+    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7':
+    resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
@@ -314,12 +382,24 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.28.5':
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@base-ui-components/react@1.0.0-beta.4':
@@ -450,6 +530,12 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
+
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -631,6 +717,15 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@glideapps/glide-data-grid@6.0.3':
+    resolution: {integrity: sha512-YXKggiNOaEemf0jP0jORq2EQKz+zXms+6mGzZc+q0mLMjmgzzoGLOQC1uYcynXSj1R61bd27JcPFsoH+Gj37Vg==}
+    peerDependencies:
+      lodash: ^4.17.19
+      marked: ^4.0.10
+      react: ^16.12.0 || 17.x || 18.x
+      react-dom: ^16.12.0 || 17.x || 18.x
+      react-responsive-carousel: ^3.2.7
+
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
     engines: {node: '>=14.0.0'}
@@ -677,6 +772,28 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@linaria/core@4.5.4':
+    resolution: {integrity: sha512-vMs/5iU0stxjfbBCxobIgY+wSQx4G8ukNwrhjPVD+6bF9QrTwi5rl0mKaCMxaGMjnfsLRiiM3i+hnWLIEYLdSg==}
+    engines: {node: ^12.16.0 || >=13.7.0}
+
+  '@linaria/logger@4.5.0':
+    resolution: {integrity: sha512-XdQLk242Cpcsc9a3Cz1ktOE5ysTo2TpxdeFQEPwMm8Z/+F/S6ZxBDdHYJL09srXWz3hkJr3oS2FPuMZNH1HIxw==}
+    engines: {node: ^12.16.0 || >=13.7.0}
+
+  '@linaria/react@4.5.4':
+    resolution: {integrity: sha512-/dhCVCsfdGPfQCPV0q5yy+DDlFXepvfXrw/os2fC+Xo1v9J/9gyiaBBWHzcumauvNNFj8aN6vRkj89fMujPHew==}
+    engines: {node: ^12.16.0 || >=13.7.0}
+    peerDependencies:
+      react: '>=16'
+
+  '@linaria/tags@4.5.4':
+    resolution: {integrity: sha512-HPxLB6HlJWLi6o8+8lTLegOmDnbMbuzEE+zzunaPZEGSoIIYx8HAv5VbY/sG/zNyxDElk6laiAwEVWN8h5/zxg==}
+    engines: {node: ^12.16.0 || >=13.7.0}
+
+  '@linaria/utils@4.5.3':
+    resolution: {integrity: sha512-tSpxA3Zn0DKJ2n/YBnYAgiDY+MNvkmzAHrD8R9PKrpGaZ+wz1jQEmE1vGn1cqh8dJyWK0NzPAA8sf1cqa+RmAg==}
+    engines: {node: ^12.16.0 || >=13.7.0}
 
   '@lix-js/html-diff@0.1.0':
     resolution: {integrity: sha512-4dr7+xo8UEncWGjne9PoL6KqFGcOHZXyeBTTghTW196kK5xidQ8h4hufjHXYxv6x5VAFzXcBCuFnW1GgPS5kqw==}
@@ -1400,26 +1517,6 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  '@tanstack/react-virtual@3.14.2':
-    resolution: {integrity: sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
-
-  '@tanstack/virtual-core@3.17.0':
-    resolution: {integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==}
-
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1741,6 +1838,12 @@ packages:
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
+  babel-merge@3.0.0:
+    resolution: {integrity: sha512-eBOBtHnzt9xvnjpYNI5HmaPp/b2vMveE5XggzqHnQeHJ8mFIBrBv6WZEVIj5jJ2uwTItkqKo9gWzEEcBxEq0yw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
@@ -1833,6 +1936,9 @@ packages:
   caniuse-lite@1.0.30001762:
     resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
 
+  canvas-hypertxt@1.0.3:
+    resolution: {integrity: sha512-+VsMpRr64jYgKq2IeFUNel3vCZH/IzS+iXSHxmUV3IUH5dXlC9xHz4AwtPZisDxZ5MWcuK0V+TXgPKFPiZnxzg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1862,6 +1968,9 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -1975,6 +2084,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deepmerge@2.2.1:
+    resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
+    engines: {node: '>=0.10.0'}
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -2198,6 +2311,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
@@ -2337,6 +2454,9 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  html-element-attributes@1.3.1:
+    resolution: {integrity: sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2385,6 +2505,10 @@ packages:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
+  is-extendable@1.0.1:
+    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2404,6 +2528,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2433,6 +2561,10 @@ packages:
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -2574,6 +2706,10 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
@@ -2581,12 +2717,16 @@ packages:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -2624,6 +2764,11 @@ packages:
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
     hasBin: true
 
   matcher@3.0.0:
@@ -2782,9 +2927,17 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  object.omit@3.0.0:
+    resolution: {integrity: sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2821,6 +2974,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
@@ -2836,6 +2993,10 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -2940,6 +3101,9 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -3034,8 +3198,24 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
+  react-easy-swipe@0.0.21:
+    resolution: {integrity: sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==}
+    engines: {node: '>= 6'}
+
+  react-html-attributes@1.4.6:
+    resolution: {integrity: sha512-uS3MmThNKFH2EZUQQw4k5pIcU7XIr208UE5dktrj/GOH1CMagqxDl4DCLpt3o2l9x+IB5nVYBeN3Cr4IutBXAg==}
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-number-format@5.4.5:
+    resolution: {integrity: sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==}
+    peerDependencies:
+      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -3066,6 +3246,9 @@ packages:
     peerDependencies:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  react-responsive-carousel@3.2.23:
+    resolution: {integrity: sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==}
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -3510,6 +3693,10 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  ts-invariant@0.10.3:
+    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
+    engines: {node: '>=8'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3874,6 +4061,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.28.5': {}
 
   '@babel/core@7.28.5':
@@ -3904,6 +4097,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
       '@babel/compat-data': 7.28.5
@@ -3914,10 +4115,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3930,11 +4140,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -3946,6 +4171,34 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.28.5)
+
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -3965,6 +4218,12 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -3977,10 +4236,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.28.5':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@base-ui-components/react@1.0.0-beta.4(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -4181,6 +4457,12 @@ snapshots:
       - supports-color
     optional: true
 
+  '@emotion/is-prop-valid@1.4.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
+  '@emotion/memoize@0.9.0': {}
+
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
@@ -4279,6 +4561,19 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@glideapps/glide-data-grid@6.0.3(lodash@4.18.1)(marked@4.3.0)(react-dom@19.2.0(react@19.2.0))(react-responsive-carousel@3.2.23)(react@19.2.0)':
+    dependencies:
+      '@linaria/react': 4.5.4(react@19.2.0)
+      canvas-hypertxt: 1.0.3
+      lodash: 4.18.1
+      marked: 4.3.0
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-number-format: 5.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-responsive-carousel: 3.2.23
+    transitivePeerDependencies:
+      - supports-color
+
   '@hapi/address@5.1.1':
     dependencies:
       '@hapi/hoek': 11.0.7
@@ -4333,6 +4628,59 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@linaria/core@4.5.4':
+    dependencies:
+      '@linaria/logger': 4.5.0
+      '@linaria/tags': 4.5.4
+      '@linaria/utils': 4.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@linaria/logger@4.5.0':
+    dependencies:
+      debug: 4.4.3
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@linaria/react@4.5.4(react@19.2.0)':
+    dependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      '@linaria/core': 4.5.4
+      '@linaria/tags': 4.5.4
+      '@linaria/utils': 4.5.3
+      minimatch: 9.0.5
+      react: 19.2.0
+      react-html-attributes: 1.4.6
+      ts-invariant: 0.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@linaria/tags@4.5.4':
+    dependencies:
+      '@babel/generator': 7.28.5
+      '@linaria/logger': 4.5.0
+      '@linaria/utils': 4.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@linaria/utils@4.5.3':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.28.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.28.5)
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@linaria/logger': 4.5.0
+      babel-merge: 3.0.0(@babel/core@7.28.5)
+      find-up: 5.0.0
+      minimatch: 9.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@lix-js/html-diff@0.1.0':
     dependencies:
       diff: 8.0.4
@@ -4358,7 +4706,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       fs-extra: 9.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4929,25 +5277,9 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 7.3.0(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.97.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@tanstack/table-core': 8.21.3
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-
-  '@tanstack/react-virtual@3.14.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@tanstack/virtual-core': 3.17.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-
-  '@tanstack/table-core@8.21.3': {}
-
-  '@tanstack/virtual-core@3.17.0': {}
-
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -5358,6 +5690,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  babel-merge@3.0.0(@babel/core@7.28.5):
+    dependencies:
+      '@babel/core': 7.28.5
+      deepmerge: 2.2.1
+      object.omit: 3.0.0
+
   babel-plugin-react-compiler@1.0.0:
     dependencies:
       '@babel/types': 7.28.5
@@ -5486,6 +5824,8 @@ snapshots:
 
   caniuse-lite@1.0.30001762: {}
 
+  canvas-hypertxt@1.0.3: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -5509,6 +5849,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  classnames@2.5.1: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -5615,6 +5957,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deepmerge@2.2.1: {}
 
   defaults@1.0.4:
     dependencies:
@@ -5756,7 +6100,7 @@ snapshots:
       '@electron/asar': 3.4.1
       debug: 4.4.3
       fs-extra: 7.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
@@ -5894,6 +6238,11 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
     optional: true
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
 
   follow-redirects@1.15.11: {}
 
@@ -6067,6 +6416,8 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  html-element-attributes@1.3.1: {}
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.8.0
@@ -6118,6 +6469,10 @@ snapshots:
 
   ip-address@10.1.0: {}
 
+  is-extendable@1.0.1:
+    dependencies:
+      is-plain-object: 2.0.4
+
   is-extglob@2.1.1:
     optional: true
 
@@ -6132,6 +6487,10 @@ snapshots:
 
   is-number@7.0.0:
     optional: true
+
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
 
   is-potential-custom-element-name@1.0.1:
     optional: true
@@ -6149,6 +6508,8 @@ snapshots:
   isexe@3.1.5: {}
 
   isexe@4.0.0: {}
+
+  isobject@3.0.1: {}
 
   jackspeak@3.4.3:
     dependencies:
@@ -6291,16 +6652,24 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash.escaperegexp@4.1.2: {}
 
   lodash.isequal@4.5.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lowercase-keys@2.0.0: {}
 
@@ -6351,6 +6720,8 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  marked@4.3.0: {}
 
   matcher@3.0.0:
     dependencies:
@@ -6504,8 +6875,14 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  object-assign@4.1.1: {}
+
   object-keys@1.1.1:
     optional: true
+
+  object.omit@3.0.0:
+    dependencies:
+      is-extendable: 1.0.1
 
   obug@2.1.1: {}
 
@@ -6547,6 +6924,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   p-map@7.0.4: {}
 
   package-json-from-dist@1.0.1: {}
@@ -6561,6 +6942,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
     optional: true
+
+  path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -6657,6 +7040,12 @@ snapshots:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -6794,7 +7183,22 @@ snapshots:
       react: 19.2.0
       scheduler: 0.27.0
 
+  react-easy-swipe@0.0.21:
+    dependencies:
+      prop-types: 15.8.1
+
+  react-html-attributes@1.4.6:
+    dependencies:
+      html-element-attributes: 1.3.1
+
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
+
+  react-number-format@5.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   react-refresh@0.18.0: {}
 
@@ -6821,6 +7225,12 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+
+  react-responsive-carousel@3.2.23:
+    dependencies:
+      classnames: 2.5.1
+      prop-types: 15.8.1
+      react-easy-swipe: 0.0.21
 
   react-style-singleton@2.2.3(@types/react@19.2.7)(react@19.2.0):
     dependencies:
@@ -7268,6 +7678,10 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
+  ts-invariant@0.10.3:
+    dependencies:
+      tslib: 2.8.1
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -7459,7 +7873,7 @@ snapshots:
     dependencies:
       axios: 1.13.5
       joi: 18.0.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:

--- a/src/extensions/csv/index.reactive.test.tsx
+++ b/src/extensions/csv/index.reactive.test.tsx
@@ -1,10 +1,51 @@
 import { Suspense } from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { qb } from "@/lib/lix-kysely";
 import { LixProvider } from "@/lib/lix-react";
 import { openLix } from "@/test-utils/node-lix-sdk";
 import { CsvView } from "./index";
+
+vi.mock("@glideapps/glide-data-grid", () => ({
+	DataEditor: ({
+		columns,
+		getCellContent,
+		rows,
+	}: {
+		columns: readonly { title: string }[];
+		getCellContent: (cell: readonly [number, number]) => {
+			displayData: string;
+			kind: string;
+			data?: string;
+		};
+		rows: number;
+	}) => (
+		<div data-testid="csv-data-grid">
+			{columns.map((column) => (
+				<div key={column.title}>{column.title}</div>
+			))}
+			{Array.from({ length: rows }, (_, rowIndex) =>
+				columns.map((_column, columnIndex) => {
+					const cell = getCellContent([columnIndex, rowIndex]);
+					return (
+						<div
+							data-cell-data={cell.data}
+							data-cell-kind={cell.kind}
+							data-testid={`csv-cell-${rowIndex}-${columnIndex}`}
+							key={`${rowIndex}-${columnIndex}`}
+						>
+							{cell.displayData}
+						</div>
+					);
+				}),
+			)}
+		</div>
+	),
+	GridCellKind: {
+		Text: "text",
+		Uri: "uri",
+	},
+}));
 
 test("updates when CSV file data changes in Lix", async () => {
 	const lix = await openLix();
@@ -17,7 +58,9 @@ test("updates when CSV file data changes in Lix", async () => {
 			.values({
 				id: fileId,
 				path: "/data.csv",
-				data: new TextEncoder().encode("name,value\nalpha,1"),
+				data: new TextEncoder().encode(
+					"name,value,email,url\nalpha,1,alice@example.com,https://example.com",
+				),
 			})
 			.execute();
 
@@ -32,6 +75,22 @@ test("updates when CSV file data changes in Lix", async () => {
 		});
 
 		expect(await screen.findByText("name")).toBeInTheDocument();
+		expect(screen.getByTestId("csv-cell-0-2")).toHaveAttribute(
+			"data-cell-kind",
+			"uri",
+		);
+		expect(screen.getByTestId("csv-cell-0-2")).toHaveAttribute(
+			"data-cell-data",
+			"mailto:alice@example.com",
+		);
+		expect(screen.getByTestId("csv-cell-0-3")).toHaveAttribute(
+			"data-cell-kind",
+			"uri",
+		);
+		expect(screen.getByTestId("csv-cell-0-3")).toHaveAttribute(
+			"data-cell-data",
+			"https://example.com",
+		);
 
 		await act(async () => {
 			await qb(lix)

--- a/src/extensions/csv/index.tsx
+++ b/src/extensions/csv/index.tsx
@@ -262,7 +262,7 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 	);
 
 	return (
-		<div className="ph-mask h-full min-h-0 flex-1 bg-background">
+		<div className="ph-mask ph-no-capture h-full min-h-0 flex-1 bg-background">
 			<DataEditor
 				className="csv-data-grid"
 				columns={columns}

--- a/src/extensions/csv/index.tsx
+++ b/src/extensions/csv/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { AlertTriangle, Loader2, Table2 } from "lucide-react";
 import {
 	DataEditor,
@@ -211,6 +211,9 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 	const [columnWidthOverrides, setColumnWidthOverrides] = useState<
 		Record<number, number>
 	>({});
+	useEffect(() => {
+		setColumnWidthOverrides({});
+	}, [parsed]);
 	const columns = useMemo<GridColumn[]>(() => {
 		return parsed.columns.map((title, index) => ({
 			id: String(index),
@@ -228,7 +231,7 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 					data: linkUrl,
 					displayData: value,
 					hoverEffect: true,
-					allowOverlay: true,
+					allowOverlay: false,
 					readonly: true,
 					copyData: value,
 					onClickUri: (event) => {
@@ -241,7 +244,7 @@ function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
 				kind: GridCellKind.Text,
 				data: value,
 				displayData: value,
-				allowOverlay: true,
+				allowOverlay: false,
 				readonly: true,
 				copyData: value,
 			};

--- a/src/extensions/csv/index.tsx
+++ b/src/extensions/csv/index.tsx
@@ -1,12 +1,13 @@
-import { Suspense, useMemo, useRef, type CSSProperties } from "react";
+import { Suspense, useCallback, useMemo, useState } from "react";
 import { AlertTriangle, Loader2, Table2 } from "lucide-react";
 import {
-	flexRender,
-	getCoreRowModel,
-	useReactTable,
-	type ColumnDef,
-} from "@tanstack/react-table";
-import { useVirtualizer } from "@tanstack/react-virtual";
+	DataEditor,
+	GridCellKind,
+	type GridCell,
+	type GridColumn,
+	type Item,
+} from "@glideapps/glide-data-grid";
+import "@glideapps/glide-data-grid/dist/index.css";
 import { LixProvider, useQueryTakeFirst } from "@/lib/lix-react";
 import { qb } from "@/lib/lix-kysely";
 import { decodeFileDataToText } from "@/lib/decode-file-data";
@@ -36,8 +37,25 @@ type CsvViewProps = {
 	}) => Promise<void>;
 };
 
-const COLUMN_MIN_WIDTH = 72;
+const COLUMN_MIN_WIDTH = 112;
+const COLUMN_MAX_WIDTH = 520;
+const COLUMN_SAMPLE_ROW_LIMIT = 100;
 const ROW_HEIGHT = 48;
+const HEADER_HEIGHT = 40;
+const CSV_GRID_THEME = {
+	accentColor: "rgb(194, 65, 12)",
+	accentFg: "rgb(255, 255, 255)",
+	accentLight: "rgb(251, 239, 228)",
+	bgHeader: "rgb(255, 255, 255)",
+	bgHeaderHasFocus: "rgb(255, 255, 255)",
+	bgHeaderHovered: "rgb(255, 255, 255)",
+	borderColor: "rgb(244, 241, 236)",
+	headerBottomBorderColor: "rgb(244, 241, 236)",
+	horizontalBorderColor: "rgb(244, 241, 236)",
+	linkColor: "rgb(194, 65, 12)",
+	resizeIndicatorColor: "rgb(234, 88, 12)",
+	textHeaderSelected: "rgb(124, 45, 18)",
+};
 
 type CsvFileRow = {
 	readonly id: string;
@@ -183,120 +201,94 @@ function CsvReviewOverlay({
 }
 
 function CsvTable({ parsed }: { readonly parsed: CsvParseResult }) {
-	const parentRef = useRef<HTMLDivElement | null>(null);
-	const columns = useMemo<ColumnDef<CsvRow>[]>(() => {
-		return parsed.columns.map((header, index) => ({
-			id: `column_${index}`,
-			header,
-			accessorFn: (row: CsvRow) => row.cells[index] ?? "",
+	const initialColumnWidths = useMemo(
+		() =>
+			parsed.columns.map((header, index) =>
+				measureColumnWidth(header, parsed.rows, index),
+			),
+		[parsed.columns, parsed.rows],
+	);
+	const [columnWidthOverrides, setColumnWidthOverrides] = useState<
+		Record<number, number>
+	>({});
+	const columns = useMemo<GridColumn[]>(() => {
+		return parsed.columns.map((title, index) => ({
+			id: String(index),
+			title,
+			width: columnWidthOverrides[index] ?? initialColumnWidths[index],
 		}));
-	}, [parsed.columns]);
-	const table = useReactTable({
-		data: [...parsed.rows],
-		columns,
-		getCoreRowModel: getCoreRowModel(),
-	});
-	const rows = table.getRowModel().rows;
-	const virtualizer = useVirtualizer({
-		count: rows.length,
-		getScrollElement: () => parentRef.current,
-		estimateSize: () => ROW_HEIGHT,
-		measureElement:
-			typeof window !== "undefined" && !navigator.userAgent.includes("Firefox")
-				? (element) => element?.getBoundingClientRect().height
-				: undefined,
-		overscan: 12,
-	});
-	const totalWidth = parsed.columns.length * COLUMN_MIN_WIDTH;
+	}, [columnWidthOverrides, initialColumnWidths, parsed.columns]);
+	const getCellContent = useCallback(
+		([columnIndex, rowIndex]: Item): GridCell => {
+			const value = parsed.rows[rowIndex]?.cells[columnIndex] ?? "";
+			const linkUrl = toExternalLinkUrl(value);
+			if (linkUrl) {
+				return {
+					kind: GridCellKind.Uri,
+					data: linkUrl,
+					displayData: value,
+					hoverEffect: true,
+					allowOverlay: true,
+					readonly: true,
+					copyData: value,
+					onClickUri: (event) => {
+						event.preventDefault();
+						void window.flashtypeDesktop?.app.openExternal({ url: linkUrl });
+					},
+				};
+			}
+			return {
+				kind: GridCellKind.Text,
+				data: value,
+				displayData: value,
+				allowOverlay: true,
+				readonly: true,
+				copyData: value,
+			};
+		},
+		[parsed.rows],
+	);
+	const onColumnResizeEnd = useCallback(
+		(_column: GridColumn, newSize: number, columnIndex: number) => {
+			setColumnWidthOverrides((current) => ({
+				...current,
+				[columnIndex]: clamp(newSize, COLUMN_MIN_WIDTH, COLUMN_MAX_WIDTH),
+			}));
+		},
+		[],
+	);
 
 	return (
-		<div
-			ref={parentRef}
-			className="ph-mask h-full min-h-0 flex-1 overflow-auto bg-background"
-		>
-			<div style={{ minWidth: totalWidth }} className="relative w-full">
-				<div className="sticky top-0 z-10 flex h-10 w-full border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-panel-muted)] text-[11px] font-bold uppercase tracking-[0.04em] text-[var(--color-text-secondary)]">
-					{table.getHeaderGroups()[0]?.headers.map((header) => (
-						<div
-							key={header.id}
-							className="flex h-10 items-center border-r border-[var(--color-border-table-grid)] px-4 last:border-r-0"
-							style={columnStyle()}
-						>
-							<div className="truncate">
-								{flexRender(
-									header.column.columnDef.header,
-									header.getContext(),
-								)}
-							</div>
-						</div>
-					))}
-				</div>
-				<div
-					className="relative"
-					style={{ height: virtualizer.getTotalSize() }}
-				>
-					{virtualizer.getVirtualItems().map((virtualRow) => {
-						const row = rows[virtualRow.index];
-						if (!row) return null;
-						return (
-							<div
-								key={row.id}
-								data-index={virtualRow.index}
-								ref={virtualizer.measureElement}
-								className="absolute left-0 flex w-full border-b border-[var(--color-border-table-grid)] text-[13.5px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-table-row-hover)]"
-								style={{
-									minHeight: virtualRow.size,
-									transform: `translateY(${virtualRow.start}px)`,
-								}}
-							>
-								{row.getVisibleCells().map((cell) => (
-									<div
-										key={cell.id}
-										className="border-r border-[var(--color-border-table-grid)] px-4 py-0 last:border-r-0"
-										style={columnStyle()}
-									>
-										<div
-											className={cellValueClassName(
-												String(cell.getValue() ?? ""),
-												cell.column.id === "column_0",
-											)}
-										>
-											{flexRender(
-												cell.column.columnDef.cell,
-												cell.getContext(),
-											)}
-										</div>
-									</div>
-								))}
-							</div>
-						);
-					})}
-				</div>
-			</div>
+		<div className="ph-mask h-full min-h-0 flex-1 bg-background">
+			<DataEditor
+				className="csv-data-grid"
+				columns={columns}
+				rows={parsed.rows.length}
+				getCellContent={getCellContent}
+				getCellsForSelection={true}
+				width="100%"
+				height="100%"
+				rowHeight={ROW_HEIGHT}
+				headerHeight={HEADER_HEIGHT}
+				minColumnWidth={COLUMN_MIN_WIDTH}
+				maxColumnWidth={COLUMN_MAX_WIDTH}
+				maxColumnAutoWidth={COLUMN_MAX_WIDTH}
+				onColumnResizeEnd={onColumnResizeEnd}
+				rowMarkers="number"
+				rangeSelect="multi-rect"
+				columnSelect="multi"
+				rowSelect="multi"
+				copyHeaders={true}
+				onPaste={false}
+				fillHandle={false}
+				freezeColumns={0}
+				fixedShadowX={false}
+				fixedShadowY={false}
+				smoothScrollX={true}
+				theme={CSV_GRID_THEME}
+			/>
 		</div>
 	);
-}
-
-function cellValueClassName(value: string, isFirstColumn: boolean): string {
-	const base = "flex min-h-12 items-center whitespace-normal break-words py-2";
-	if (isEmailLike(value)) {
-		return `${base} font-mono text-[12.5px] text-[var(--color-text-link-hover)]`;
-	}
-	if (isNumericValue(value)) {
-		return `${base} font-mono text-[13px] text-[var(--color-text-secondary)]`;
-	}
-	if (isFirstColumn) {
-		return `${base} font-mono text-[12.5px] text-[var(--color-icon-tertiary)]`;
-	}
-	return `${base} font-normal text-[var(--color-text-primary)]`;
-}
-
-function isEmailLike(value: string): boolean {
-	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-}
-
-function isNumericValue(value: string): boolean {
-	return value.trim() !== "" && /^-?\d+(?:\.\d+)?$/.test(value.trim());
 }
 
 function CsvEmptyState({ filePath }: { readonly filePath: string }) {
@@ -330,11 +322,55 @@ function CsvLoadingSpinner() {
 
 export { parseCsv, renderCsvReviewDiffHtml };
 
-function columnStyle(): CSSProperties {
-	return {
-		flex: "1 0 0",
-		minWidth: COLUMN_MIN_WIDTH,
-	};
+function measureColumnWidth(
+	header: string,
+	rows: readonly CsvRow[],
+	columnIndex: number,
+): number {
+	let widest = textWidthEstimate(header, true);
+	for (const row of rows.slice(0, COLUMN_SAMPLE_ROW_LIMIT)) {
+		widest = Math.max(
+			widest,
+			textWidthEstimate(row.cells[columnIndex] ?? "", false),
+		);
+	}
+	return clamp(Math.ceil(widest + 32), COLUMN_MIN_WIDTH, COLUMN_MAX_WIDTH);
+}
+
+function textWidthEstimate(value: string, isHeader: boolean): number {
+	const text = value.trim();
+	if (text.length === 0) return 0;
+
+	let width = isHeader ? 10 : 0;
+	for (const char of text) {
+		if (char === " " || char === "," || char === "." || char === ":") {
+			width += 4;
+		} else if (/[ilIj|]/.test(char)) {
+			width += 4.5;
+		} else if (/[mwMW@%#]/.test(char)) {
+			width += 11;
+		} else if (/[A-Z0-9]/.test(char)) {
+			width += 8;
+		} else {
+			width += 7;
+		}
+	}
+	return width;
+}
+
+function toExternalLinkUrl(value: string): string | null {
+	const text = value.trim();
+	if (/^https?:\/\/\S+$/i.test(text)) {
+		return text;
+	}
+	if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(text)) {
+		return `mailto:${text}`;
+	}
+	return null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
 }
 
 function assertFileId(fileId: unknown): asserts fileId is string {

--- a/src/extensions/csv/style.css
+++ b/src/extensions/csv/style.css
@@ -32,29 +32,29 @@
 }
 
 .csv-review-table th {
-	height: 2.5rem;
+	height: 40px;
 	border-right: 1px solid var(--color-border-table-grid);
 	border-bottom: 1px solid var(--color-border-subtle);
-	background: var(--color-bg-panel-muted);
+	background: var(--background);
 	padding: 0 1rem;
-	color: var(--color-text-secondary);
-	font-size: 11px;
+	color: var(--color-text-primary);
+	font-size: 14px;
 	font-weight: 700;
-	letter-spacing: 0.04em;
+	letter-spacing: 0;
 	text-align: left;
-	text-transform: uppercase;
+	text-transform: none;
 }
 
 .csv-review-table td {
 	min-width: 72px;
-	min-height: 3rem;
+	height: 48px;
 	border-right: 1px solid var(--color-border-table-grid);
 	border-bottom: 1px solid var(--color-border-table-grid);
-	padding: 0.65rem 1rem;
+	padding: 0 1rem;
 	color: var(--color-text-primary);
-	font-size: 13.5px;
+	font-size: 14px;
 	font-weight: 400;
-	line-height: 1.35;
+	line-height: 1.2;
 	white-space: normal;
 	word-break: break-word;
 }

--- a/src/extensions/markdown/style.css
+++ b/src/extensions/markdown/style.css
@@ -14,13 +14,6 @@
 	min-height: 0;
 }
 
-/* Scroll lives here so the scrollbar sits flush to the panel's right edge.
-   The writing gutter lives inside ProseMirror so the whole canvas remains
-   editable while the scrollbar stays at the border edge. */
-.markdown-view .tiptap-container {
-	padding-top: 2rem;
-}
-
 /* Hide the native scrollbar; a lightweight overlay thumb mirrors scroll
    position so fade behavior is reliable across Electron/Chromium repaints. */
 .markdown-view .tiptap-container {
@@ -124,7 +117,7 @@
 	font-size: 14.5px;
 	line-height: 1.7;
 	min-height: 100%;
-	padding: 0 max(2rem, calc((100% - 760px) / 2)) 4rem;
+	padding: 2rem max(2rem, calc((100% - 760px) / 2)) 4rem;
 	caret-color: var(--color-ring-focus-visible);
 	cursor: auto;
 	width: 100%;

--- a/src/shell/panel-v2.tsx
+++ b/src/shell/panel-v2.tsx
@@ -254,6 +254,7 @@ export function PanelV2({
 										view={view}
 										instance={entry}
 										context={context}
+										side={side}
 										isActive={isActive}
 									/>
 								</Activity>
@@ -486,11 +487,13 @@ function ViewRenderer({
 	view,
 	instance,
 	context,
+	side,
 	isActive,
 }: {
 	view: ExtensionDefinition;
 	instance: ExtensionInstance;
 	context: ExtensionContext;
+	side: PanelSide;
 	isActive: boolean;
 }) {
 	const registry = useExtensionHostRegistry();
@@ -506,6 +509,7 @@ function ViewRenderer({
 			host={host}
 			instance={instance.instance}
 			kind={instance.kind}
+			side={side}
 			isActive={isActive}
 		/>
 	);
@@ -515,11 +519,13 @@ function ViewHostMount({
 	host,
 	instance,
 	kind,
+	side,
 	isActive,
 }: {
 	host: ExtensionHostRecord | null;
 	instance: string;
 	kind: ExtensionKind;
+	side: PanelSide;
 	isActive: boolean;
 }) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
@@ -541,6 +547,7 @@ function ViewHostMount({
 			ref={containerRef}
 			data-view-instance={instance}
 			data-view-key={kind}
+			data-panel-side={side}
 			data-active={isActive ? "true" : undefined}
 			className="flex min-h-0 flex-1 flex-col overflow-hidden"
 		/>


### PR DESCRIPTION
## What changed
- Replaced the CSV table rendering with Glide Data Grid for smoother, virtualized CSV display.
- Added generic column sizing, orange link/selection styling, clickable URL and email cells, and disabled fixed overlay shadows.
- Added Electron bridge support for safe external URL opening.
- Updated CSV tests and the file tour E2E smoke test for canvas rendering.

## Why
The previous HTML table struggled with wide CSVs, overflowed text badly, and made horizontal navigation feel jumpy. Glide gives us a better MVP grid without hardcoding columns.

## Validation
- pnpm exec tsc -p . --pretty false --noEmit
- pnpm exec vitest run src/extensions/csv/index.test.ts src/extensions/csv/index.reactive.test.tsx
- pnpm exec oxlint --tsconfig ./tsconfig.json --format stylish src/extensions/csv/index.tsx src/extensions/csv/index.reactive.test.tsx e2e/files-click-tour.spec.ts electron/preload.mjs electron/types.d.ts
- pnpm exec playwright test e2e/files-click-tour.spec.ts

## Notes
Left unrelated local changes unstaged: src/extensions/markdown/style.css and submodule/lix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New third-party grid and Electron URL-opening surface area; protocol validation limits exposure. Large dependency swap may affect install/build stability.
> 
> **Overview**
> **Replaces the CSV viewer’s TanStack virtual table with `@glideapps/glide-data-grid`**, including themed styling, heuristic column widths with resize, and readonly multi-select/copy. **HTTP(S) and email cells** open via a new **`app:openExternal` IPC** path (protocol-limited to `http:`, `https:`, `mailto:`).
> 
> Dependency work: adds Glide and its peers (`lodash`, `marked`, `react-responsive-carousel`), drops `@tanstack/react-table` / `@tanstack/react-virtual`, and documents React 19 peer overrides in **CONTRIBUTING** and **pnpm** rules. **Panel hosts** now expose **`data-panel-side`** for E2E selectors.
> 
> Tests mock Glide in unit tests and assert URI cells; the file-click tour checks **canvas pixel content** instead of DOM cell text. CSV review diff table CSS is aligned to the new grid row/header sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d2c5b1517a46c995a899090373b67afd52752b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->