### PR TITLE
Add Track Changes crash recovery flow

### DIFF
--- a/e2e/workspace-windows.spec.ts
+++ b/e2e/workspace-windows.spec.ts
@@ -343,6 +343,73 @@ test("Track Changes menu toggles workspace .lix storage", async ({
 	}
 });
 
+test("Track Changes recovery screen can disable tracking", async ({
+	browserName: _browserName,
+}, testInfo) => {
+	const workspaceDir = testInfo.outputPath("track-changes-recovery-workspace");
+	const userDataDir = testInfo.outputPath("track-changes-recovery-user-data");
+	const filePath = path.join(workspaceDir, "marker.md");
+
+	let electronApp: ElectronApplication | undefined;
+	try {
+		await writeMarkerFile(workspaceDir, "marker.md");
+		await mkdir(path.join(workspaceDir, ".lix", ".internal"), {
+			recursive: true,
+		});
+		await writeFile(
+			path.join(workspaceDir, ".lix", ".internal", "db.sqlite"),
+			"",
+		);
+		await mkdir(userDataDir, { recursive: true });
+		await writeFile(
+			path.join(userDataDir, "workspace-recovery.json"),
+			JSON.stringify({
+				version: 1,
+				recoveries: [
+					{
+						kind: "track_changes",
+						workspacePath: workspaceDir,
+						workspaceName: path.basename(workspaceDir),
+						reason: "renderer_crash",
+						createdAt: "2026-06-25T12:00:00.000Z",
+					},
+				],
+			}),
+			"utf8",
+		);
+
+		electronApp = await launchDevElectronAppWithArgs([workspaceDir], {
+			userDataDir,
+		});
+		const page = await pageWithTitle(electronApp, path.basename(workspaceDir));
+		registerRendererConsoleLogging(page);
+
+		await expectTrackChangesMenuChecked(electronApp, true);
+		await expectPathExists(path.join(workspaceDir, ".lix"));
+
+		await expect(
+			page.getByRole("heading", {
+				name: "Track Changes could not be opened",
+			}),
+		).toBeVisible();
+		await expect(
+			page.getByText("Your project files will not be deleted."),
+		).toBeVisible();
+
+		await Promise.all([
+			page.waitForNavigation({ waitUntil: "domcontentloaded" }),
+			page.getByRole("button", { name: "Disable Track Changes" }).click(),
+		]);
+
+		await expect(page.getByTestId("file-tree-item-marker-md")).toBeVisible();
+		await expectTrackChangesMenuChecked(electronApp, false);
+		await expectPathMissing(path.join(workspaceDir, ".lix"));
+		await expect(readFile(filePath, "utf8")).resolves.toBe("# marker.md\n");
+	} finally {
+		await closeElectronApp(electronApp);
+	}
+});
+
 test("macOS open-file events create workspace windows for folders and files", async ({
 	browserName: _browserName,
 }, testInfo) => {

--- a/electron/ipc-lix.mjs
+++ b/electron/ipc-lix.mjs
@@ -14,6 +14,7 @@ const observeTraceMeta = createOwnedHandleStore("observe trace");
 const transactionHandles = createOwnedHandleStore("transaction");
 let registered = false;
 let getWindowForEvent = null;
+let registerOptions = {};
 const LIX_VALUE_ENVELOPE_KEY = "__lixValue";
 const LIX_TRACE_SLOW_MS = Number.parseInt(
 	process.env.FLASHTYPE_TRACE_LIX_SLOW_MS ?? "25",
@@ -21,12 +22,13 @@ const LIX_TRACE_SLOW_MS = Number.parseInt(
 );
 const LIX_TRACE_ENABLED = process.env.FLASHTYPE_TRACE_LIX_IPC === "1";
 
-export function registerLixIpc(resolveWindowForEvent) {
+export function registerLixIpc(resolveWindowForEvent, options = {}) {
 	if (registered) {
 		return;
 	}
 	registered = true;
 	getWindowForEvent = resolveWindowForEvent;
+	registerOptions = options;
 
 	ipcMain.handle("lix:open", async (event) => {
 		await ensureLixOpenForEvent(event);
@@ -280,6 +282,15 @@ export function registerLixIpc(resolveWindowForEvent) {
 		await resetLixRepository(window);
 	});
 
+	ipcMain.handle("workspace:disableTrackChanges", async (event) => {
+		if (typeof registerOptions.disableTrackChanges !== "function") {
+			throw new Error("workspace.disableTrackChanges is not available");
+		}
+		const window = getWindowForIpcEvent(event);
+		await closeLixSession(window, { ignoreOpenError: true });
+		return await registerOptions.disableTrackChanges(window);
+	});
+
 	ipcMain.handle("workspace:exportLixFile", async (event) => {
 		const window = getWindowForIpcEvent(event);
 		await closeAllHandles(window.id);
@@ -294,6 +305,7 @@ async function ensureLixOpenForEvent(event) {
 export async function disposeLixIpc() {
 	await closeAllHandles();
 	await closeAllLixSessions({ ignoreOpenError: true });
+	registerOptions = {};
 }
 
 export async function closeLixSession(window, options = {}) {

--- a/electron/lix.mjs
+++ b/electron/lix.mjs
@@ -1,3 +1,4 @@
+import { app } from "electron";
 import { FsBackend, bundledPluginArchives, openLix } from "@lix-js/sdk";
 import path from "node:path";
 import { readFile, rm } from "node:fs/promises";
@@ -6,6 +7,11 @@ import {
 	getWorkspaceFsBackendOptions,
 	getWorkspaceLixDatabasePath,
 } from "./workspace.mjs";
+import {
+	clearWorkspaceLixOpenPendingSync,
+	markWorkspaceLixOpenPendingSync,
+	writeWorkspaceRecoverySync,
+} from "./workspace-recovery.mjs";
 
 const LIX_DATABASE_DIR = ".lix";
 const sessions = new Map();
@@ -23,15 +29,38 @@ export async function ensureLixOpen(window) {
 					);
 				}
 				let nativeLix;
+				const tracksPersistentWorkspace = workspace.ephemeral !== true;
+				const userDataPath = app.getPath("userData");
 				try {
+					if (tracksPersistentWorkspace) {
+						markWorkspaceLixOpenPendingSync(
+							userDataPath,
+							createTrackChangesRecovery(workspace, {
+								reason: "lix_open_pending",
+							}),
+						);
+					}
 					const backendOptions = await getWorkspaceFsBackendOptions(window);
 					nativeLix = await openLix({
 						backend: new FsBackend(backendOptions),
 					});
 					await ensureDefaultPluginsInstalledOnCurrentBranch(nativeLix);
+					if (tracksPersistentWorkspace) {
+						clearWorkspaceLixOpenPendingSync(userDataPath, workspace.path);
+					}
 					return createDesktopLixHandle(nativeLix, workspace.path);
 				} catch (error) {
 					await nativeLix?.close().catch(() => {});
+					if (tracksPersistentWorkspace) {
+						clearWorkspaceLixOpenPendingSync(userDataPath, workspace.path);
+						writeWorkspaceRecoverySync(
+							userDataPath,
+							createTrackChangesRecovery(workspace, {
+								reason: "lix_open_failed",
+								message: errorMessage(error),
+							}),
+						);
+					}
 					throw error;
 				}
 			})();
@@ -81,6 +110,24 @@ function bytesEqual(actual, expected) {
 		return false;
 	}
 	return Buffer.compare(Buffer.from(actual), Buffer.from(expected)) === 0;
+}
+
+function createTrackChangesRecovery(workspace, options) {
+	return {
+		kind: "track_changes",
+		workspacePath: workspace.path,
+		workspaceName: workspace.name,
+		reason: options.reason,
+		message: options.message,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+function errorMessage(error) {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
 }
 
 export async function closeLix(window, options = {}) {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import {
 	applyWorkspaceWindowChrome,
+	disableWorkspaceTrackChanges,
 	disposeAllWorkspaceWindowStates,
 	disposeWorkspaceWindowState,
 	getWorkspace,
@@ -54,6 +55,14 @@ import {
 	recentWorkspaceEntryFromWorkspace,
 	writeRecentWorkspaceEntriesSync,
 } from "./recent-workspaces.mjs";
+import {
+	clearWorkspaceRecoverySync,
+	readWorkspaceRecoveries,
+	readWorkspaceRecovery,
+	recoverPendingWorkspaceLixOpenSync,
+	workspaceRecoveryToSessionEntry,
+	writeWorkspaceRecoverySync,
+} from "./workspace-recovery.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const execFileAsync = promisify(execFile);
@@ -203,7 +212,7 @@ async function openWorkspaceRequests(
 		requestsBySource.set(taggedRequest.requestedSource, requests);
 	}
 
-	for (const [source, requests] of requestsBySource) {
+	for (const [_source, requests] of requestsBySource) {
 		const workspaceTargets = await resolveWorkspaceTargets(requests);
 		for (const workspaceTarget of workspaceTargets) {
 			await createMainWindow(workspaceTarget);
@@ -219,6 +228,60 @@ function createWorkspaceOpenRequest(request, requestedSource) {
 
 function isCrashLikeProcessGoneReason(reason) {
 	return CRASH_LIKE_PROCESS_GONE_REASONS.has(reason);
+}
+
+async function reloadPersistentWorkspaceIntoRecovery(window, details) {
+	if (isQuitting || !window || window.isDestroyed()) {
+		return false;
+	}
+	const workspace = getWorkspace(window);
+	if (!workspace || workspace.ephemeral === true) {
+		return false;
+	}
+	writeWorkspaceRecoverySync(
+		app.getPath("userData"),
+		createTrackChangesRecovery(workspace, {
+			reason: "renderer_crash",
+			exitCode: details.exitCode,
+			message: `Renderer process exited: ${details.reason} (${details.exitCode ?? "n/a"})`,
+		}),
+	);
+	void closeLixSession(window, { ignoreOpenError: true });
+	if (window.isDestroyed() || window.webContents.isDestroyed()) {
+		return true;
+	}
+	void loadWorkspaceWindow(window);
+	return true;
+}
+
+function clearWorkspaceRecoveryForWorkspace(workspace) {
+	if (!workspace) {
+		return;
+	}
+	clearWorkspaceRecoverySync(app.getPath("userData"), workspace.path);
+}
+
+function createTrackChangesRecovery(workspace, options) {
+	const recovery = {
+		kind: "track_changes",
+		workspacePath: workspace.path,
+		workspaceName: workspace.name,
+		reason: options.reason,
+		message: options.message,
+		createdAt: new Date().toISOString(),
+	};
+	if (Number.isFinite(options.exitCode)) {
+		recovery.exitCode = options.exitCode;
+	}
+	return recovery;
+}
+
+async function loadWorkspaceWindow(window) {
+	if (app.isPackaged) {
+		await window.loadFile(path.join(__dirname, "../dist/index.html"));
+		return;
+	}
+	await window.loadURL(DEV_SERVER_URL);
 }
 
 function shouldUseWorkspaceBootRecoveryGuard() {
@@ -434,6 +497,9 @@ async function toggleTrackChangesFromApplicationMenu(trackChanges) {
 	}
 	await closeLixSession(window, { ignoreOpenError: true });
 	const workspace = await setWorkspaceTrackChanges(window, trackChanges);
+	if (!trackChanges) {
+		clearWorkspaceRecoveryForWorkspace(workspace);
+	}
 	recordOpenWorkspacePath(window, workspace);
 	persistOpenWorkspacePathsSoon();
 	applyDockWindowChrome(window);
@@ -447,7 +513,7 @@ async function toggleTrackChangesFromApplicationMenu(trackChanges) {
 
 async function openWorkspacePathInNewWindow(
 	requestedPath,
-	requestedSource = "open_in_new_window",
+	_requestedSource = "open_in_new_window",
 ) {
 	const workspaceTarget = (await resolveWorkspaceTargets([requestedPath]))[0];
 	if (!workspaceTarget) {
@@ -709,7 +775,8 @@ async function createMainWindow(workspaceRequest) {
 		console.error(
 			`Renderer process exited: ${details.reason} (${details.exitCode ?? "n/a"})`,
 		);
-		if (isCrashLikeProcessGoneReason(details.reason)) {
+		const crashLike = isCrashLikeProcessGoneReason(details.reason);
+		if (crashLike) {
 			void captureTelemetryException(
 				new Error(
 					`Renderer process exited: ${details.reason} (${details.exitCode ?? "n/a"})`,
@@ -722,6 +789,7 @@ async function createMainWindow(workspaceRequest) {
 					source: "electron-renderer",
 				},
 			);
+			void reloadPersistentWorkspaceIntoRecovery(window, details);
 		}
 		void triggerRecoveryUpdateCheck(
 			new Error(
@@ -735,11 +803,7 @@ async function createMainWindow(workspaceRequest) {
 		return { action: "deny" };
 	});
 
-	if (app.isPackaged) {
-		void window.loadFile(path.join(__dirname, "../dist/index.html"));
-	} else {
-		void window.loadURL(DEV_SERVER_URL);
-	}
+	void loadWorkspaceWindow(window);
 
 	return window;
 }
@@ -786,10 +850,32 @@ async function startWorkspaceLifecycle() {
 	if (isQuitting) {
 		return;
 	}
-	registerLixIpc((event) => BrowserWindow.fromWebContents(event.sender));
+	const userDataPath = app.getPath("userData");
+	recoverPendingWorkspaceLixOpenSync(userDataPath);
+	registerLixIpc((event) => BrowserWindow.fromWebContents(event.sender), {
+		disableTrackChanges: async (window) => {
+			const workspace = await disableWorkspaceTrackChanges(window);
+			clearWorkspaceRecoveryForWorkspace(workspace);
+			recordOpenWorkspacePath(window, workspace);
+			persistOpenWorkspacePathsSoon();
+			applyDockWindowChrome(window);
+			updateDockMenu();
+			installApplicationMenu();
+			return workspace;
+		},
+	});
 	registerTerminalIpc();
 	registerWorkspaceIpc((event) => BrowserWindow.fromWebContents(event.sender), {
 		...createWorkspaceChangeOptions(),
+		getRecovery: async (workspace) => {
+			if (!workspace) {
+				return null;
+			}
+			return await readWorkspaceRecovery(userDataPath, workspace.path);
+		},
+		clearRecovery: async (workspace) => {
+			clearWorkspaceRecoveryForWorkspace(workspace);
+		},
 		openInNewWindow: async (requestedPath) => {
 			return await openWorkspacePathInNewWindow(
 				requestedPath,
@@ -805,21 +891,20 @@ async function startWorkspaceLifecycle() {
 	}).catch((error) => {
 		console.warn("Failed to register Flashtype as the Markdown editor", error);
 	});
-	const savedWorkspaceEntries = await readWorkspaceSessionEntries(
-		app.getPath("userData"),
-	);
-	const restorableSavedWorkspaceEntries = await filterExistingWorkspaceEntries(
-		savedWorkspaceEntries,
-	);
+	const savedWorkspaceEntries = await readWorkspaceSessionEntries(userDataPath);
+	const recoveryWorkspaceEntries = (await readWorkspaceRecoveries(userDataPath))
+		.map(workspaceRecoveryToSessionEntry)
+		.filter(Boolean);
+	const restorableSavedWorkspaceEntries = await filterExistingWorkspaceEntries([
+		...savedWorkspaceEntries,
+		...recoveryWorkspaceEntries,
+	]);
 	recentWorkspaceEntries = await filterExistingRecentWorkspaceEntries(
-		await readRecentWorkspaceEntries(app.getPath("userData")),
+		await readRecentWorkspaceEntries(userDataPath),
 	);
 	void syncMacOSDockRecentWorkspaceDocuments();
 	try {
-		writeRecentWorkspaceEntriesSync(
-			app.getPath("userData"),
-			recentWorkspaceEntries,
-		);
+		writeRecentWorkspaceEntriesSync(userDataPath, recentWorkspaceEntries);
 	} catch (error) {
 		console.warn("Failed to clean Flashtype recent workspaces", error);
 	}
@@ -827,7 +912,7 @@ async function startWorkspaceLifecycle() {
 	if (restorableSavedWorkspaceEntries.length !== savedWorkspaceEntries.length) {
 		try {
 			writeWorkspaceSessionEntriesSync(
-				app.getPath("userData"),
+				userDataPath,
 				restorableSavedWorkspaceEntries,
 			);
 		} catch (error) {

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -23,6 +23,8 @@ const telemetry = {
 
 const workspace = {
 	get: () => ipcRenderer.invoke("workspace:get"),
+	getRecovery: () => ipcRenderer.invoke("workspace:getRecovery"),
+	clearRecovery: () => ipcRenderer.invoke("workspace:clearRecovery"),
 	consumePendingOpenFiles: () =>
 		ipcRenderer.invoke("workspace:consumePendingOpenFiles"),
 	setEphemeralWatchedDirectories: (payload) =>
@@ -53,6 +55,8 @@ const workspace = {
 		ipcRenderer.invoke("workspace:setOpenFilePaths", payload),
 	exportLixFile: () => ipcRenderer.invoke("workspace:exportLixFile"),
 	resetLixRepository: () => ipcRenderer.invoke("workspace:resetLixRepository"),
+	disableTrackChanges: () =>
+		ipcRenderer.invoke("workspace:disableTrackChanges"),
 	// Resolves the on-disk path of a File dropped onto the window.
 	getPathForFile: (file) => webUtils.getPathForFile(file),
 };

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -131,6 +131,16 @@ export type DesktopWorkspace =
 			includePaths: string[];
 	  };
 
+export type DesktopWorkspaceRecovery = {
+	kind: "track_changes";
+	workspacePath: string;
+	workspaceName: string;
+	reason: string;
+	createdAt: string;
+	exitCode?: number;
+	message?: string;
+};
+
 export type DesktopWorkspaceExtensionProfile = {
 	file_extension: string;
 	file_count: number;
@@ -158,6 +168,8 @@ export type DesktopWatchedFilesystemEntry = {
 
 export type DesktopWorkspaceApi = {
 	get(): Promise<DesktopWorkspace | null>;
+	getRecovery(): Promise<DesktopWorkspaceRecovery | null>;
+	clearRecovery(): Promise<void>;
 	/** Returns workspace-relative file paths queued for editor opening. */
 	consumePendingOpenFiles(): Promise<string[]>;
 	setEphemeralWatchedDirectories(payload: {
@@ -186,6 +198,7 @@ export type DesktopWorkspaceApi = {
 	setOpenFilePaths(payload: { filePaths: string[] }): Promise<void>;
 	exportLixFile(): Promise<Uint8Array>;
 	resetLixRepository(): Promise<void>;
+	disableTrackChanges(): Promise<DesktopWorkspace>;
 	getPathForFile(file: File): string;
 };
 

--- a/electron/workspace-recovery.mjs
+++ b/electron/workspace-recovery.mjs
@@ -1,0 +1,291 @@
+import fs from "node:fs/promises";
+import {
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+export const WORKSPACE_RECOVERY_FILE = "workspace-recovery.json";
+export const WORKSPACE_PENDING_LIX_OPEN_FILE =
+	"workspace-pending-lix-open.json";
+export const WORKSPACE_RECOVERY_VERSION = 1;
+
+export async function readWorkspaceRecovery(userDataPath, workspacePath) {
+	const normalizedWorkspacePath = normalizeWorkspacePath(workspacePath);
+	if (!normalizedWorkspacePath) {
+		return null;
+	}
+	const recoveries = await readWorkspaceRecoveries(userDataPath);
+	return (
+		recoveries.find(
+			(recovery) => recovery.workspacePath === normalizedWorkspacePath,
+		) ?? null
+	);
+}
+
+export async function readWorkspaceRecoveries(userDataPath) {
+	const recoveries = normalizeWorkspaceRecoveries(
+		await readRecoveryStore(userDataPath),
+	);
+	const existingRecoveries = recoveries.filter((recovery) =>
+		isDirectorySync(recovery.workspacePath),
+	);
+	if (existingRecoveries.length !== recoveries.length) {
+		writeWorkspaceRecoveriesSync(userDataPath, existingRecoveries);
+	}
+	return existingRecoveries;
+}
+
+export function readWorkspaceRecoveriesSync(userDataPath) {
+	const recoveries = normalizeWorkspaceRecoveries(
+		readRecoveryStoreSync(userDataPath),
+	);
+	const existingRecoveries = recoveries.filter((recovery) =>
+		isDirectorySync(recovery.workspacePath),
+	);
+	if (existingRecoveries.length !== recoveries.length) {
+		writeWorkspaceRecoveriesSync(userDataPath, existingRecoveries);
+	}
+	return existingRecoveries;
+}
+
+export function writeWorkspaceRecoverySync(userDataPath, recovery) {
+	const normalizedRecovery = normalizeWorkspaceRecovery(recovery);
+	if (!normalizedRecovery) {
+		return null;
+	}
+	const recoveries = readWorkspaceRecoveriesSync(userDataPath).filter(
+		(existing) => existing.workspacePath !== normalizedRecovery.workspacePath,
+	);
+	writeWorkspaceRecoveriesSync(userDataPath, [
+		...recoveries,
+		normalizedRecovery,
+	]);
+	return normalizedRecovery;
+}
+
+export function clearWorkspaceRecoverySync(userDataPath, workspacePath) {
+	const normalizedWorkspacePath = normalizeWorkspacePath(workspacePath);
+	if (!normalizedWorkspacePath) {
+		return;
+	}
+	const recoveries = readWorkspaceRecoveriesSync(userDataPath).filter(
+		(recovery) => recovery.workspacePath !== normalizedWorkspacePath,
+	);
+	writeWorkspaceRecoveriesSync(userDataPath, recoveries);
+}
+
+export function markWorkspaceLixOpenPendingSync(userDataPath, recovery) {
+	const normalizedRecovery = normalizeWorkspaceRecovery(recovery);
+	if (!normalizedRecovery) {
+		return null;
+	}
+	const pendingRecoveries = readPendingLixOpenRecoveriesSync(
+		userDataPath,
+	).filter(
+		(existing) => existing.workspacePath !== normalizedRecovery.workspacePath,
+	);
+	writePendingLixOpenRecoveriesSync(userDataPath, [
+		...pendingRecoveries,
+		normalizedRecovery,
+	]);
+	return normalizedRecovery;
+}
+
+export function clearWorkspaceLixOpenPendingSync(userDataPath, workspacePath) {
+	const normalizedWorkspacePath = normalizeWorkspacePath(workspacePath);
+	if (!normalizedWorkspacePath) {
+		return;
+	}
+	const pendingRecoveries = readPendingLixOpenRecoveriesSync(
+		userDataPath,
+	).filter((recovery) => recovery.workspacePath !== normalizedWorkspacePath);
+	writePendingLixOpenRecoveriesSync(userDataPath, pendingRecoveries);
+}
+
+export function recoverPendingWorkspaceLixOpenSync(userDataPath) {
+	const pendingRecoveries = readPendingLixOpenRecoveriesSync(userDataPath);
+	const recoveriesToWrite = pendingRecoveries
+		.filter((recovery) => isDirectorySync(recovery.workspacePath))
+		.map((recovery) => ({
+			...recovery,
+			reason: "previous_lix_open_crash",
+			createdAt: new Date().toISOString(),
+		}));
+
+	for (const recovery of recoveriesToWrite) {
+		writeWorkspaceRecoverySync(userDataPath, recovery);
+	}
+	writePendingLixOpenRecoveriesSync(userDataPath, []);
+	return recoveriesToWrite.length;
+}
+
+export function workspaceRecoveryToSessionEntry(recovery) {
+	const normalizedRecovery = normalizeWorkspaceRecovery(recovery);
+	if (!normalizedRecovery) {
+		return null;
+	}
+	return {
+		path: normalizedRecovery.workspacePath,
+		openFilePaths: [],
+	};
+}
+
+async function readRecoveryStore(userDataPath) {
+	try {
+		return JSON.parse(
+			await fs.readFile(getWorkspaceRecoveryPath(userDataPath), "utf8"),
+		);
+	} catch {
+		return null;
+	}
+}
+
+function readRecoveryStoreSync(userDataPath) {
+	try {
+		return JSON.parse(
+			readFileSync(getWorkspaceRecoveryPath(userDataPath), "utf8"),
+		);
+	} catch {
+		return null;
+	}
+}
+
+function writeWorkspaceRecoveriesSync(userDataPath, recoveries) {
+	writeStoreSync(
+		getWorkspaceRecoveryPath(userDataPath),
+		normalizeWorkspaceRecoveryList(recoveries),
+	);
+}
+
+function readPendingLixOpenRecoveriesSync(userDataPath) {
+	try {
+		return normalizeWorkspaceRecoveries(
+			JSON.parse(readFileSync(getPendingLixOpenPath(userDataPath), "utf8")),
+		);
+	} catch {
+		return [];
+	}
+}
+
+function writePendingLixOpenRecoveriesSync(userDataPath, recoveries) {
+	const normalizedRecoveries = normalizeWorkspaceRecoveryList(recoveries);
+	if (normalizedRecoveries.length === 0) {
+		rmSync(getPendingLixOpenPath(userDataPath), { force: true });
+		return;
+	}
+	writeStoreSync(getPendingLixOpenPath(userDataPath), normalizedRecoveries);
+}
+
+function writeStoreSync(filePath, recoveries) {
+	const normalizedRecoveries = normalizeWorkspaceRecoveryList(recoveries);
+	if (normalizedRecoveries.length === 0) {
+		rmSync(filePath, { force: true });
+		return;
+	}
+	mkdirSync(path.dirname(filePath), { recursive: true });
+	writeFileSync(
+		filePath,
+		JSON.stringify(
+			{
+				version: WORKSPACE_RECOVERY_VERSION,
+				recoveries: normalizedRecoveries,
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+}
+
+function normalizeWorkspaceRecoveries(store) {
+	if (
+		!store ||
+		typeof store !== "object" ||
+		store.version !== WORKSPACE_RECOVERY_VERSION ||
+		!Array.isArray(store.recoveries)
+	) {
+		return [];
+	}
+	return normalizeWorkspaceRecoveryList(store.recoveries);
+}
+
+function normalizeWorkspaceRecoveryList(recoveries) {
+	if (!Array.isArray(recoveries)) {
+		return [];
+	}
+	const seen = new Set();
+	const normalizedRecoveries = [];
+	for (const recovery of recoveries) {
+		const normalizedRecovery = normalizeWorkspaceRecovery(recovery);
+		if (!normalizedRecovery || seen.has(normalizedRecovery.workspacePath)) {
+			continue;
+		}
+		seen.add(normalizedRecovery.workspacePath);
+		normalizedRecoveries.push(normalizedRecovery);
+	}
+	return normalizedRecoveries;
+}
+
+function normalizeWorkspaceRecovery(recovery) {
+	if (!recovery || typeof recovery !== "object") {
+		return null;
+	}
+	const workspacePath = normalizeWorkspacePath(recovery.workspacePath);
+	if (!workspacePath) {
+		return null;
+	}
+	const workspaceName =
+		typeof recovery.workspaceName === "string" &&
+		recovery.workspaceName.trim().length > 0
+			? recovery.workspaceName.trim()
+			: path.basename(workspacePath) || workspacePath;
+	const reason =
+		typeof recovery.reason === "string" && recovery.reason.trim().length > 0
+			? recovery.reason.trim()
+			: "unknown";
+	const createdAt =
+		typeof recovery.createdAt === "string" && recovery.createdAt.length > 0
+			? recovery.createdAt
+			: new Date().toISOString();
+	const normalized = {
+		kind: "track_changes",
+		workspacePath,
+		workspaceName,
+		reason,
+		createdAt,
+	};
+	if (Number.isFinite(recovery.exitCode)) {
+		normalized.exitCode = recovery.exitCode;
+	}
+	if (typeof recovery.message === "string" && recovery.message.length > 0) {
+		normalized.message = recovery.message;
+	}
+	return normalized;
+}
+
+function normalizeWorkspacePath(workspacePath) {
+	if (typeof workspacePath !== "string" || workspacePath.length === 0) {
+		return null;
+	}
+	return path.resolve(workspacePath);
+}
+
+function getWorkspaceRecoveryPath(userDataPath) {
+	return path.join(userDataPath, WORKSPACE_RECOVERY_FILE);
+}
+
+function getPendingLixOpenPath(userDataPath) {
+	return path.join(userDataPath, WORKSPACE_PENDING_LIX_OPEN_FILE);
+}
+
+function isDirectorySync(filePath) {
+	try {
+		return statSync(filePath).isDirectory();
+	} catch {
+		return false;
+	}
+}

--- a/electron/workspace-recovery.test.mjs
+++ b/electron/workspace-recovery.test.mjs
@@ -1,0 +1,113 @@
+import { mkdir, stat } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+	clearWorkspaceRecoverySync,
+	markWorkspaceLixOpenPendingSync,
+	readWorkspaceRecoveries,
+	readWorkspaceRecovery,
+	recoverPendingWorkspaceLixOpenSync,
+	workspaceRecoveryToSessionEntry,
+	writeWorkspaceRecoverySync,
+	WORKSPACE_PENDING_LIX_OPEN_FILE,
+} from "./workspace-recovery.mjs";
+
+describe("workspace recovery store", () => {
+	test("persists, reads, and clears workspace recovery entries", async () => {
+		const userDataPath = createUserDataPath();
+		const workspacePath = path.join(userDataPath, "workspace");
+		await mkdir(workspacePath, { recursive: true });
+
+		writeWorkspaceRecoverySync(userDataPath, {
+			kind: "track_changes",
+			workspacePath,
+			workspaceName: "workspace",
+			reason: "renderer_crash",
+			exitCode: 100,
+			createdAt: "2026-06-25T12:00:00.000Z",
+		});
+
+		await expect(
+			readWorkspaceRecovery(userDataPath, workspacePath),
+		).resolves.toMatchObject({
+			kind: "track_changes",
+			workspacePath,
+			workspaceName: "workspace",
+			reason: "renderer_crash",
+			exitCode: 100,
+			createdAt: "2026-06-25T12:00:00.000Z",
+		});
+		expect(
+			workspaceRecoveryToSessionEntry({
+				kind: "track_changes",
+				workspacePath,
+				workspaceName: "workspace",
+				reason: "renderer_crash",
+				createdAt: "2026-06-25T12:00:00.000Z",
+			}),
+		).toEqual({ path: workspacePath, openFilePaths: [] });
+
+		clearWorkspaceRecoverySync(userDataPath, workspacePath);
+
+		await expect(
+			readWorkspaceRecovery(userDataPath, workspacePath),
+		).resolves.toBe(null);
+	});
+
+	test("converts stale pending Lix opens into recovery entries", async () => {
+		const userDataPath = createUserDataPath();
+		const workspacePath = path.join(userDataPath, "workspace");
+		const missingWorkspacePath = path.join(userDataPath, "missing");
+		await mkdir(workspacePath, { recursive: true });
+
+		markWorkspaceLixOpenPendingSync(userDataPath, {
+			kind: "track_changes",
+			workspacePath,
+			workspaceName: "workspace",
+			reason: "lix_open_pending",
+			createdAt: "2026-06-25T12:00:00.000Z",
+		});
+		markWorkspaceLixOpenPendingSync(userDataPath, {
+			kind: "track_changes",
+			workspacePath: missingWorkspacePath,
+			workspaceName: "missing",
+			reason: "lix_open_pending",
+			createdAt: "2026-06-25T12:00:00.000Z",
+		});
+
+		expect(recoverPendingWorkspaceLixOpenSync(userDataPath)).toBe(1);
+		await expect(
+			readWorkspaceRecovery(userDataPath, workspacePath),
+		).resolves.toMatchObject({
+			workspacePath,
+			reason: "previous_lix_open_crash",
+		});
+		await expect(
+			readWorkspaceRecovery(userDataPath, missingWorkspacePath),
+		).resolves.toBe(null);
+		await expect(
+			stat(path.join(userDataPath, WORKSPACE_PENDING_LIX_OPEN_FILE)),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	test("drops recovery entries whose workspace no longer exists", async () => {
+		const userDataPath = createUserDataPath();
+		const missingWorkspacePath = path.join(userDataPath, "missing");
+
+		writeWorkspaceRecoverySync(userDataPath, {
+			kind: "track_changes",
+			workspacePath: missingWorkspacePath,
+			workspaceName: "missing",
+			reason: "renderer_crash",
+			createdAt: "2026-06-25T12:00:00.000Z",
+		});
+
+		await expect(readWorkspaceRecoveries(userDataPath)).resolves.toEqual([]);
+	});
+});
+
+function createUserDataPath() {
+	return path.join(tmpdir(), "flashtype-workspace-recovery-test", randomUUID());
+}

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -251,9 +251,7 @@ export async function readEphemeralWorkspaceFile(window, payload) {
 	}
 	const filePath = normalizeWorkspaceFilePath(payload?.path);
 	if (!isEphemeralWatchedFileEntry(state, filePath)) {
-		throw new Error(
-			`File is not in the opened Files view: ${filePath}`,
-		);
+		throw new Error(`File is not in the opened Files view: ${filePath}`);
 	}
 	const { localPath } = await resolveExistingWorkspacePath(
 		workspace,
@@ -385,6 +383,23 @@ export async function setWorkspaceTrackChanges(window, trackChanges) {
 			await moveWorkspaceLixToExternalStorage(state);
 			state.workspace = createEphemeralWorkspace(workspace.path);
 		}
+		state.pendingOpenFilePaths = [];
+		applyWindowChrome(window);
+		return state.workspace;
+	});
+}
+
+export async function disableWorkspaceTrackChanges(window) {
+	const state = getOrCreateWindowState(window);
+	return await enqueueWorkspaceChange(state, async () => {
+		const workspace = state.workspace;
+		if (!workspace) {
+			throw new Error("No workspace is open.");
+		}
+		disposeEphemeralFileTreeState(state);
+		await disposeExternalLixState(state);
+		await removeWorkspaceLixDirectory(workspace.path);
+		state.workspace = createEphemeralWorkspace(workspace.path);
 		state.pendingOpenFilePaths = [];
 		applyWindowChrome(window);
 		return state.workspace;
@@ -1040,6 +1055,13 @@ async function movePath(source, target) {
 	await rm(source, { force: true, recursive: true });
 }
 
+async function removeWorkspaceLixDirectory(workspacePath) {
+	await rm(path.join(workspacePath, LIX_DIRECTORY_NAME), {
+		force: true,
+		recursive: true,
+	});
+}
+
 async function pathExists(filePath) {
 	try {
 		await stat(filePath);
@@ -1195,6 +1217,19 @@ export function registerWorkspaceIpc(getWindowForEvent, options = {}) {
 
 	ipcMain.handle("workspace:get", (event) => {
 		return getWorkspace(getWindowForEvent(event));
+	});
+
+	ipcMain.handle("workspace:getRecovery", async (event) => {
+		const window = getWindowForEvent(event);
+		if (typeof options.getRecovery !== "function") {
+			return null;
+		}
+		return await options.getRecovery(getWorkspace(window), window);
+	});
+
+	ipcMain.handle("workspace:clearRecovery", async (event) => {
+		const window = getWindowForEvent(event);
+		await options.clearRecovery?.(getWorkspace(window), window);
 	});
 
 	ipcMain.handle("workspace:consumePendingOpenFiles", (event) => {

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -1,10 +1,18 @@
-import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import {
+	mkdir,
+	readFile,
+	rm,
+	stat,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import {
 	profileWorkspaceFilesystem,
+	disableWorkspaceTrackChanges,
 	disposeWorkspaceWindowState,
 	readEphemeralWorkspaceFile,
 	resolveWorkspace,
@@ -772,6 +780,41 @@ describe("workspace resolution", () => {
 				pendingOpenFilePaths: ["docs/readme.md"],
 			},
 		]);
+	});
+
+	test("disables Track Changes by deleting only .lix and reopening transiently", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		const workspaceFile = path.join(directory, "docs", "readme.md");
+		const lixFile = path.join(directory, ".lix", ".internal", "db.sqlite");
+		await mkdir(path.dirname(workspaceFile), { recursive: true });
+		await mkdir(path.dirname(lixFile), { recursive: true });
+		await writeFile(workspaceFile, "# Keep me\n");
+		await writeFile(lixFile, "lix data\n");
+
+		const window = createTestWindow();
+		try {
+			await setWorkspaceFromPath(directory, window);
+
+			await expect(disableWorkspaceTrackChanges(window)).resolves.toEqual({
+				ephemeral: true,
+				path: directory,
+				includePaths: [],
+				name: "workspace",
+			});
+			await expect(readFile(workspaceFile, "utf8")).resolves.toBe(
+				"# Keep me\n",
+			);
+			await expect(stat(path.join(directory, ".lix"))).rejects.toMatchObject({
+				code: "ENOENT",
+			});
+		} finally {
+			await disposeWorkspaceWindowState(window);
+		}
 	});
 
 	test("restores saved non-Lix directory session entries without include scans", async () => {

--- a/src/main.error.tsx
+++ b/src/main.error.tsx
@@ -1,6 +1,12 @@
 import { useState } from "react";
 import { RotateCcw, Bug, AlertTriangle, Trash2 } from "lucide-react";
 
+type WorkspaceRecovery = Awaited<
+	ReturnType<
+		NonNullable<Window["flashtypeDesktop"]>["workspace"]["getRecovery"]
+	>
+>;
+
 function formatError(err: unknown): string {
 	const asAny = err as any;
 	try {
@@ -59,27 +65,46 @@ function containsOpfsHandleConflict(err: unknown): boolean {
 /**
  * Minimal error UI shown when Lix fails to load.
  */
-export function ErrorFallback(props: { error: unknown }) {
-	const [busyAction, setBusyAction] = useState<"reset" | null>(null);
-	const [resetError, setResetError] = useState<unknown>(null);
+export function ErrorFallback(props: {
+	readonly error?: unknown;
+	readonly recovery?: WorkspaceRecovery | null;
+}) {
+	const [busyAction, setBusyAction] = useState<"disable" | "try-again" | null>(
+		null,
+	);
+	const [actionError, setActionError] = useState<unknown>(null);
 	const busy = busyAction !== null;
+	const recovery = props.recovery ?? null;
 
-	async function handleReset() {
+	async function handleDisableTrackChanges() {
 		if (busy) return;
-		setBusyAction("reset");
-		setResetError(null);
+		setBusyAction("disable");
+		setActionError(null);
 		try {
-			const resetRepository =
-				window.flashtypeDesktop?.workspace?.resetLixRepository;
-			if (typeof resetRepository !== "function") {
+			const disableTrackChanges =
+				window.flashtypeDesktop?.workspace?.disableTrackChanges;
+			if (typeof disableTrackChanges !== "function") {
 				throw new Error(
-					"Reset Lix repository is only available in the desktop app.",
+					"Disabling Track Changes is only available in the desktop app.",
 				);
 			}
-			await resetRepository();
+			await disableTrackChanges();
 			window.location.reload();
 		} catch (error) {
-			setResetError(error);
+			setActionError(error);
+			setBusyAction(null);
+		}
+	}
+
+	async function handleTryAgain() {
+		if (busy) return;
+		setBusyAction("try-again");
+		setActionError(null);
+		try {
+			await window.flashtypeDesktop?.workspace?.clearRecovery();
+			window.location.reload();
+		} catch (error) {
+			setActionError(error);
 			setBusyAction(null);
 		}
 	}
@@ -118,37 +143,49 @@ export function ErrorFallback(props: { error: unknown }) {
 		);
 	}
 
+	const details = recovery ?? props.error;
+
 	return (
 		<div className="min-h-dvh w-full overflow-auto p-6">
 			<div className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-4xl items-center">
 				<div className="min-w-0 w-full border rounded-lg p-6 bg-card text-card-foreground">
 					<h1 className="text-xl font-semibold mb-2">
-						Flashtype failed to start
+						Track Changes could not be opened
 					</h1>
 					<p className="text-sm text-muted-foreground mb-4">
-						Lix could not be loaded. This can happen if the lix schema was
-						changed in development. If this is unexpected, please contact the
-						developer.
+						Flashtype had trouble opening change tracking for
+						{recovery?.workspaceName
+							? ` ${recovery.workspaceName}`
+							: " this workspace"}
+						. You can disable Track Changes to remove the workspace .lix data
+						and open the folder normally. Your project files will not be
+						deleted.
 					</p>
 					<div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 mb-4">
 						<p className="text-sm font-medium text-destructive">
-							Reset the Lix repository to rebuild it from this workspace.
+							Disabling Track Changes removes change history stored in .lix.
 						</p>
 					</div>
 					<div className="flex flex-wrap items-center gap-3">
 						<button
-							onClick={handleReset}
+							onClick={handleDisableTrackChanges}
 							disabled={busy}
 							className="inline-flex items-center gap-2 rounded-md bg-destructive px-3 py-2 text-[var(--color-text-on-action-primary)] text-sm disabled:opacity-60"
 						>
 							<Trash2 className="h-4 w-4" />
-							{busyAction === "reset" ? "Resetting..." : "Reset Lix repository"}
+							{busyAction === "disable"
+								? "Disabling..."
+								: "Disable Track Changes"}
 						</button>
 						<button
-							onClick={() => window.location.reload()}
+							onClick={
+								recovery ? handleTryAgain : () => window.location.reload()
+							}
+							disabled={busy}
 							className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
 						>
-							<RotateCcw className="h-4 w-4" /> Reload app
+							<RotateCcw className="h-4 w-4" />
+							{busyAction === "try-again" ? "Trying..." : "Try again"}
 						</button>
 						<a
 							href="https://github.com/opral/flashtype/issues"
@@ -159,18 +196,18 @@ export function ErrorFallback(props: { error: unknown }) {
 							<Bug className="h-4 w-4" /> Report bug
 						</a>
 					</div>
-					{resetError ? (
+					{actionError ? (
 						<div className="mt-4 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
-							<div className="font-medium mb-2">Reset failed</div>
+							<div className="font-medium mb-2">Action failed</div>
 							<pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
-								{formatError(resetError)}
+								{formatError(actionError)}
 							</pre>
 						</div>
 					) : null}
 					<div className="mt-4 max-h-[50dvh] overflow-auto text-xs opacity-80 border rounded p-3 bg-muted/20">
 						<div className="font-medium mb-2">Error details</div>
 						<pre className="whitespace-pre-wrap break-words font-mono leading-relaxed">
-							{formatError(props.error)}
+							{formatError(details)}
 						</pre>
 					</div>
 				</div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,11 @@ import { activatePostHogRecording } from "./lib/posthog-client";
 type Workspace = Awaited<
 	ReturnType<NonNullable<Window["flashtypeDesktop"]>["workspace"]["get"]>
 >;
+type WorkspaceRecovery = Awaited<
+	ReturnType<
+		NonNullable<Window["flashtypeDesktop"]>["workspace"]["getRecovery"]
+	>
+>;
 
 /**
  * The workspace gates the app: without a folder, only the first-run screen
@@ -31,6 +36,9 @@ type Workspace = Awaited<
 export const AppRoot = () => {
 	// undefined = still asking the main process; null = first run.
 	const [workspace, setWorkspace] = useState<Workspace | undefined>(undefined);
+	const [workspaceRecovery, setWorkspaceRecovery] = useState<
+		WorkspaceRecovery | null | undefined
+	>(undefined);
 	const [lix, setLix] = useState<Lix | null>(null);
 	const [pendingOpenFilePaths, setPendingOpenFilePaths] = useState<string[]>(
 		[],
@@ -53,7 +61,13 @@ export const AppRoot = () => {
 			try {
 				const current =
 					(await window.flashtypeDesktop?.workspace.get()) ?? null;
-				if (!cancelled) setWorkspace(current);
+				const recovery = current
+					? ((await window.flashtypeDesktop?.workspace.getRecovery()) ?? null)
+					: null;
+				if (!cancelled) {
+					setWorkspaceRecovery(recovery);
+					setWorkspace(current);
+				}
 			} catch (e) {
 				if (!cancelled) setError(e);
 			}
@@ -110,6 +124,7 @@ export const AppRoot = () => {
 				if (!opened || opened.path === workspace?.path) return;
 				if (workspace) return;
 				setOpeningWorkspaceName(opened.name);
+				setWorkspaceRecovery((await desktop.workspace.getRecovery?.()) ?? null);
 				keepLoadingScreen = true;
 				// When switching, close the running lix before the workspace state
 				// flips: close() lags its IPC, so an unawaited close could race the
@@ -146,7 +161,9 @@ export const AppRoot = () => {
 	}, [handleOpenFolder]);
 
 	useEffect(() => {
-		if (!workspace) return;
+		if (!workspace || workspaceRecovery === undefined || workspaceRecovery) {
+			return;
+		}
 		let cancelled = false;
 		let current: Lix | undefined;
 		(async () => {
@@ -159,7 +176,15 @@ export const AppRoot = () => {
 				current = instance;
 				setLix(instance);
 			} catch (e) {
-				if (!cancelled) setError(e);
+				const recovery =
+					(await window.flashtypeDesktop?.workspace.getRecovery()) ?? null;
+				if (!cancelled) {
+					if (recovery) {
+						setWorkspaceRecovery(recovery);
+					} else {
+						setError(e);
+					}
+				}
 			}
 		})();
 		return () => {
@@ -169,7 +194,7 @@ export const AppRoot = () => {
 				if (current) await current.close();
 			})();
 		};
-	}, [workspace]);
+	}, [workspace, workspaceRecovery]);
 
 	useEffect(() => {
 		if (!workspace || !lix) return;
@@ -210,8 +235,10 @@ export const AppRoot = () => {
 		);
 	}, []);
 
+	if (workspaceRecovery) return <ErrorFallback recovery={workspaceRecovery} />;
 	if (error) return <ErrorFallback error={error} />;
 	if (workspace === undefined) return <BootPlaceholder />;
+	if (workspaceRecovery === undefined) return <BootPlaceholder />;
 	if (workspace === null) {
 		if (openingWorkspaceName !== undefined) {
 			return <WorkspaceLoadingScreen workspaceName={openingWorkspaceName} />;


### PR DESCRIPTION
Adds Track Changes crash recovery for persistent Lix workspaces. If Lix fails to open, a renderer crash occurs, or a previous app run died during persistent Lix startup, Flashtype now records recovery state and reloads into a user-facing recovery screen instead of immediately retrying Lix and crash-looping.

closes #210

**Changes**

- Added persisted workspace recovery and pending Lix-open markers.
- Added recovery handling for crash-like `render-process-gone` events.
- Added desktop APIs: `getRecovery`, `clearRecovery`, and `disableTrackChanges`.
- Updated app startup to skip `openDesktopLix()` when recovery exists.
- Reworked the error screen to offer **Disable Track Changes**, which removes `.lix/` and reopens the folder transiently.
- Added unit coverage for recovery markers and `.lix/` removal.
- Added e2e coverage for the recovery screen disable flow.
