### PR TITLE
Resolve markdown image paths through workspace helpers

### DIFF
--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
+import { resolveMarkdownImageSrc } from "./workspace-paths.mjs";
 
 const app = {
 	checkForUpdates: () => ipcRenderer.invoke("app:checkForUpdates"),
@@ -57,6 +58,7 @@ const workspace = {
 	resetLixRepository: () => ipcRenderer.invoke("workspace:resetLixRepository"),
 	disableTrackChanges: () =>
 		ipcRenderer.invoke("workspace:disableTrackChanges"),
+	resolveMarkdownImageSrc: (payload) => resolveMarkdownImageSrc(payload),
 	// Resolves the on-disk path of a File dropped onto the window.
 	getPathForFile: (file) => webUtils.getPathForFile(file),
 };

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -199,6 +199,11 @@ export type DesktopWorkspaceApi = {
 	exportLixFile(): Promise<Uint8Array>;
 	resetLixRepository(): Promise<void>;
 	disableTrackChanges(): Promise<DesktopWorkspace>;
+	resolveMarkdownImageSrc(payload: {
+		src: string;
+		sourceFilePath: string;
+		workspacePath: string;
+	}): string;
 	getPathForFile(file: File): string;
 };
 

--- a/electron/workspace-paths.mjs
+++ b/electron/workspace-paths.mjs
@@ -1,4 +1,8 @@
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const TRANSPARENT_GIF_DATA_URL =
+	"data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
 
 export function workspaceRelativeFilePath(workspacePath, filePath) {
 	const workspaceRoot = path.resolve(workspacePath);
@@ -57,6 +61,95 @@ export function uniqueWorkspaceRelativeFilePaths(filePaths) {
 		uniqueFilePaths.push(filePath);
 	}
 	return uniqueFilePaths;
+}
+
+export function resolveMarkdownImageSrc(payload) {
+	const src = typeof payload?.src === "string" ? payload.src : "";
+	if (src.length === 0) {
+		return TRANSPARENT_GIF_DATA_URL;
+	}
+
+	const absoluteUrl = parseUrl(src);
+	if (absoluteUrl?.protocol === "http:" || absoluteUrl?.protocol === "https:") {
+		return src;
+	}
+	if (absoluteUrl) {
+		return TRANSPARENT_GIF_DATA_URL;
+	}
+
+	const workspacePath =
+		typeof payload?.workspacePath === "string" ? payload.workspacePath : "";
+	const sourceFilePath =
+		typeof payload?.sourceFilePath === "string" ? payload.sourceFilePath : "";
+	const sourceLocalFilePath = workspaceLocalFilePathForSource(
+		workspacePath,
+		sourceFilePath,
+	);
+	if (!sourceLocalFilePath) {
+		return TRANSPARENT_GIF_DATA_URL;
+	}
+
+	const imageUrl = parseUrl(src, pathToFileURL(sourceLocalFilePath));
+	if (!imageUrl || imageUrl.protocol !== "file:") {
+		return TRANSPARENT_GIF_DATA_URL;
+	}
+
+	let imageLocalFilePath;
+	try {
+		imageLocalFilePath = fileURLToPath(imageUrl);
+	} catch {
+		return TRANSPARENT_GIF_DATA_URL;
+	}
+
+	const imageWorkspaceRelativePath = workspaceRelativeFilePath(
+		workspacePath,
+		imageLocalFilePath,
+	);
+	if (!imageWorkspaceRelativePath) {
+		return TRANSPARENT_GIF_DATA_URL;
+	}
+
+	const normalizedImageLocalFilePath = workspaceLocalFilePath(
+		workspacePath,
+		imageWorkspaceRelativePath,
+	);
+	if (!normalizedImageLocalFilePath) {
+		return TRANSPARENT_GIF_DATA_URL;
+	}
+
+	const normalizedImageUrl = pathToFileURL(normalizedImageLocalFilePath);
+	normalizedImageUrl.search = imageUrl.search;
+	normalizedImageUrl.hash = imageUrl.hash;
+	return normalizedImageUrl.href;
+}
+
+function workspaceLocalFilePathForSource(workspacePath, sourceFilePath) {
+	if (!workspacePath || !sourceFilePath) {
+		return null;
+	}
+
+	const sourceWorkspaceRelativePath = sourceFilePath.startsWith("/")
+		? sourceFilePath.slice(1)
+		: sourceFilePath;
+	const sourceLocalFilePath = workspaceLocalFilePath(
+		workspacePath,
+		sourceWorkspaceRelativePath,
+	);
+	if (!sourceLocalFilePath) {
+		return null;
+	}
+
+	return workspaceRelativeFilePath(workspacePath, sourceLocalFilePath)
+		? sourceLocalFilePath
+		: null;
+}
+
+function parseUrl(value, base) {
+	try {
+		return base ? new URL(value, base) : new URL(value);
+	} catch {
+		return null;
+	}
 }
 
 function isValidRelativePathSegments(segments) {

--- a/electron/workspace-paths.mjs
+++ b/electron/workspace-paths.mjs
@@ -89,7 +89,13 @@ export function resolveMarkdownImageSrc(payload) {
 		return TRANSPARENT_GIF_DATA_URL;
 	}
 
-	const imageUrl = parseUrl(src, pathToFileURL(sourceLocalFilePath));
+	const workspaceRootRelative = path.posix.isAbsolute(src);
+	const imageUrl = workspaceRootRelative
+		? parseUrl(
+				path.posix.relative("/", src),
+				workspaceRootFileUrl(workspacePath),
+			)
+		: parseUrl(src, pathToFileURL(sourceLocalFilePath));
 	if (!imageUrl || imageUrl.protocol !== "file:") {
 		return TRANSPARENT_GIF_DATA_URL;
 	}
@@ -150,6 +156,10 @@ function parseUrl(value, base) {
 	} catch {
 		return null;
 	}
+}
+
+function workspaceRootFileUrl(workspacePath) {
+	return pathToFileURL(path.join(path.resolve(workspacePath), path.sep));
 }
 
 function isValidRelativePathSegments(segments) {

--- a/electron/workspace-paths.test.mjs
+++ b/electron/workspace-paths.test.mjs
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, test } from "vitest";
+import {
+	resolveMarkdownImageSrc,
+	TRANSPARENT_GIF_DATA_URL,
+} from "./workspace-paths.mjs";
+
+describe("resolveMarkdownImageSrc", () => {
+	test("uses http and https image URLs directly", () => {
+		const context = {
+			sourceFilePath: "/docs/readme.md",
+			workspacePath: "/Users/alec/project",
+		};
+
+		expect(
+			resolveMarkdownImageSrc({
+				...context,
+				src: "https://example.com/logo.png?size=2#preview",
+			}),
+		).toBe("https://example.com/logo.png?size=2#preview");
+		expect(
+			resolveMarkdownImageSrc({
+				...context,
+				src: "http://example.com/logo.png",
+			}),
+		).toBe("http://example.com/logo.png");
+	});
+
+	test("resolves non-http image paths relative to the markdown file path", () => {
+		const workspacePath = path.join("/Users/alec", "project");
+		const expectedPath = path.join(
+			workspacePath,
+			"docs",
+			"assets",
+			"product shot.png",
+		);
+
+		expect(
+			resolveMarkdownImageSrc({
+				src: "../assets/product shot.png?raw#preview",
+				sourceFilePath: "/docs/guides/readme.md",
+				workspacePath,
+			}),
+		).toBe(`${pathToFileURL(expectedPath).href}?raw#preview`);
+	});
+
+	test("uses a transparent gif when the normalized image path leaves the workspace", () => {
+		expect(
+			resolveMarkdownImageSrc({
+				src: "../outside.png",
+				sourceFilePath: "/readme.md",
+				workspacePath: "/Users/alec/project",
+			}),
+		).toBe(TRANSPARENT_GIF_DATA_URL);
+	});
+
+	test("uses a transparent gif for non-http absolute URLs", () => {
+		const workspacePath = "/Users/alec/project";
+		expect(
+			resolveMarkdownImageSrc({
+				src: "data:image/png;base64,abc",
+				sourceFilePath: "/docs/readme.md",
+				workspacePath,
+			}),
+		).toBe(TRANSPARENT_GIF_DATA_URL);
+		expect(
+			resolveMarkdownImageSrc({
+				src: pathToFileURL(path.join(workspacePath, "docs", "logo.png")).href,
+				sourceFilePath: "/docs/readme.md",
+				workspacePath,
+			}),
+		).toBe(TRANSPARENT_GIF_DATA_URL);
+	});
+});

--- a/electron/workspace-paths.test.mjs
+++ b/electron/workspace-paths.test.mjs
@@ -45,6 +45,19 @@ describe("resolveMarkdownImageSrc", () => {
 		).toBe(`${pathToFileURL(expectedPath).href}?raw#preview`);
 	});
 
+	test("resolves leading-slash non-http image paths relative to the workspace root", () => {
+		const workspacePath = path.join("/Users/alec", "project");
+		const expectedPath = path.join(workspacePath, "images", "logo.png");
+
+		expect(
+			resolveMarkdownImageSrc({
+				src: "/assets/../images/logo.png?raw#preview",
+				sourceFilePath: "/docs/guides/readme.md",
+				workspacePath,
+			}),
+		).toBe(`${pathToFileURL(expectedPath).href}?raw#preview`);
+	});
+
 	test("uses a transparent gif when the normalized image path leaves the workspace", () => {
 		expect(
 			resolveMarkdownImageSrc({

--- a/src/extensions/markdown/editor/create-editor.ts
+++ b/src/extensions/markdown/editor/create-editor.ts
@@ -26,6 +26,7 @@ type CreateEditorArgs = {
 	defaultBlock?: EmptyMarkdownDefaultBlock;
 	persistDebounceMs?: number;
 	persistState?: boolean;
+	resolveImageSrc?: (src: string) => string;
 };
 
 const createNodeId = (): string => {
@@ -80,6 +81,7 @@ export function createEditor(args: CreateEditorArgs): Editor {
 		defaultBlock,
 		persistDebounceMs,
 		persistState = true,
+		resolveImageSrc,
 	} = args;
 
 	const ast = contentAst ?? (parseMarkdown(initialMarkdown ?? "") as any);
@@ -144,7 +146,7 @@ export function createEditor(args: CreateEditorArgs): Editor {
 			node.childCount === 0,
 	};
 
-	const markdownExtensions = MarkdownWc({}) as any[];
+	const markdownExtensions = MarkdownWc({ resolveImageSrc }) as any[];
 
 	editorInstance = new Editor({
 		extensions: [

--- a/src/extensions/markdown/editor/render-markdown-html.ts
+++ b/src/extensions/markdown/editor/render-markdown-html.ts
@@ -5,9 +5,12 @@ import { MarkdownWc, astToTiptapDoc } from "./tiptap-markdown-bridge";
 import { SlashCommandsExtension } from "./extensions/slash-commands";
 import { TableNavigationExtension } from "./extensions/table-navigation";
 
-export function renderMarkdownAstEditorHtml(ast: any): string {
+export function renderMarkdownAstEditorHtml(
+	ast: any,
+	options: { readonly resolveImageSrc?: (src: string) => string } = {},
+): string {
 	return generateHTML(astToTiptapDoc(ast) as any, [
-		...(MarkdownWc({}) as any[]),
+		...(MarkdownWc({ resolveImageSrc: options.resolveImageSrc }) as any[]),
 		History,
 		Placeholder,
 		SlashCommandsExtension.configure({ onStateChange: () => {} }),

--- a/src/extensions/markdown/editor/tip-tap-editor.tsx
+++ b/src/extensions/markdown/editor/tip-tap-editor.tsx
@@ -15,6 +15,7 @@ import { decodeMarkdownData } from "./decode-markdown-data";
 
 type TipTapEditorProps = {
 	fileId?: string | null;
+	filePath?: string | null;
 	className?: string;
 	onReady?: (editor: Editor) => void;
 	persistDebounceMs?: number;
@@ -22,6 +23,66 @@ type TipTapEditorProps = {
 	defaultBlock?: EmptyMarkdownDefaultBlock;
 	isActiveView?: boolean;
 };
+
+type WorkspaceDirState = {
+	readonly loaded: boolean;
+	readonly workspaceDir: string | null;
+};
+
+function useDesktopWorkspaceDir(): WorkspaceDirState {
+	const [state, setState] = useState<WorkspaceDirState>(() => {
+		const desktopLix = desktopLixApi();
+		return desktopLix
+			? { loaded: false, workspaceDir: null }
+			: { loaded: true, workspaceDir: null };
+	});
+
+	useEffect(() => {
+		const desktopLix = desktopLixApi();
+		if (!desktopLix) {
+			setState({ loaded: true, workspaceDir: null });
+			return;
+		}
+
+		let cancelled = false;
+		void desktopLix.workspaceDir().then(
+			(workspaceDir) => {
+				if (!cancelled) {
+					setState({ loaded: true, workspaceDir });
+				}
+			},
+			() => {
+				if (!cancelled) {
+					setState({ loaded: true, workspaceDir: null });
+				}
+			},
+		);
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return state;
+}
+
+function desktopLixApi():
+	| NonNullable<Window["flashtypeDesktop"]>["lix"]
+	| undefined {
+	if (typeof window === "undefined") {
+		return undefined;
+	}
+	return window.flashtypeDesktop?.lix;
+}
+
+function desktopWorkspaceApi():
+	| NonNullable<Window["flashtypeDesktop"]>["workspace"]
+	| undefined {
+	if (typeof window === "undefined") {
+		return undefined;
+	}
+	return window.flashtypeDesktop?.workspace;
+}
 
 /**
  * Rich text editor for Markdown files backed by the Lix store.
@@ -39,6 +100,7 @@ type TipTapEditorProps = {
  */
 export function TipTapEditor({
 	fileId,
+	filePath,
 	className,
 	onReady,
 	persistDebounceMs,
@@ -50,6 +112,7 @@ export function TipTapEditor({
 		return (
 			<TipTapEditorContent
 				activeFileId={fileId}
+				filePath={filePath}
 				className={className}
 				onReady={onReady}
 				persistDebounceMs={persistDebounceMs}
@@ -127,7 +190,7 @@ function TipTapEditorFileContent({
 		(lix) =>
 			qb(lix)
 				.selectFrom("lix_file")
-				.select("data")
+				.select(["data", "path"])
 				.select(() => [sql<string>`${activeBranchId}`.as("active_branch_id")])
 				.where("id", "=", activeFileId),
 		{ subscribe: false },
@@ -141,6 +204,7 @@ function TipTapEditorFileContent({
 			activeBranchId={activeBranchId}
 			hasInitialFile={Boolean(initialFile)}
 			initialMarkdown={initialMarkdown}
+			sourceFilePath={props.filePath ?? initialFile?.path ?? null}
 		/>
 	);
 }
@@ -156,16 +220,36 @@ function TipTapEditorLoadedContent({
 	isActiveView = true,
 	hasInitialFile,
 	initialMarkdown,
+	sourceFilePath,
 }: TipTapEditorContentProps & {
 	readonly activeBranchId: string;
 	readonly hasInitialFile: boolean;
 	readonly initialMarkdown: string;
+	readonly sourceFilePath?: string | null;
 }) {
 	const lix = useLix();
 	const { setEditor } = useEditorCtx();
+	const workspaceDirState = useDesktopWorkspaceDir();
 	const PERSIST_DEBOUNCE_MS = persistDebounceMs ?? 500;
 	const normalizePersistedMarkdown = (markdown: string): string =>
 		markdown.endsWith("\n") ? markdown : `${markdown}\n`;
+	const resolveImageSrc = useMemo(() => {
+		const workspaceApi = desktopWorkspaceApi();
+		const workspacePath = workspaceDirState.workspaceDir;
+		if (
+			!sourceFilePath ||
+			!workspacePath ||
+			!workspaceApi?.resolveMarkdownImageSrc
+		) {
+			return undefined;
+		}
+		return (src: string) =>
+			workspaceApi.resolveMarkdownImageSrc({
+				src,
+				sourceFilePath,
+				workspacePath,
+			});
+	}, [sourceFilePath, workspaceDirState.workspaceDir]);
 
 	const [initialAst, setInitialAst] = useState<any | null>(null);
 	const [initialAstLoaded, setInitialAstLoaded] = useState(false);
@@ -174,7 +258,14 @@ function TipTapEditorLoadedContent({
 	const mountedEditorRef = useRef<Editor | null>(null);
 
 	const editor = useMemo(() => {
-		if (!activeFileId || !hasInitialFile || !initialAstLoaded) return null;
+		if (
+			!activeFileId ||
+			!hasInitialFile ||
+			!initialAstLoaded ||
+			!workspaceDirState.loaded
+		) {
+			return null;
+		}
 		// Prefer assembled AST from the current file bytes so initialization stays deterministic.
 		const hasAstSnapshot =
 			Array.isArray(initialAst?.children) && initialAst.children.length > 0;
@@ -185,6 +276,7 @@ function TipTapEditorLoadedContent({
 			fileId: activeFileId,
 			defaultBlock,
 			persistDebounceMs: PERSIST_DEBOUNCE_MS,
+			resolveImageSrc,
 		});
 	}, [
 		lix,
@@ -195,6 +287,8 @@ function TipTapEditorLoadedContent({
 		initialAstLoaded,
 		initialMarkdown,
 		defaultBlock,
+		resolveImageSrc,
+		workspaceDirState.loaded,
 	]);
 
 	useEffect(() => {

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/markdown-wc.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/markdown-wc.ts
@@ -3,6 +3,11 @@ import { markdownWcNodes } from "./nodes";
 import { MarkdownWcShortcuts } from "./shortcuts";
 import { createAssignDataIdExtension } from "./assign-data-id";
 
+export type MarkdownWcOptions = {
+	readonly idProvider?: () => string;
+	readonly resolveImageSrc?: (src: string) => string;
+};
+
 // --- TipTap minimal extensions (no HTML parsing, schema only) ---
 
 /**
@@ -40,9 +45,9 @@ import { createAssignDataIdExtension } from "./assign-data-id";
  * })
  * ```
  */
-export function MarkdownWc(opts?: { idProvider?: () => string }): Extensions {
+export function MarkdownWc(opts?: MarkdownWcOptions): Extensions {
 	return [
-		...markdownWcNodes(),
+		...markdownWcNodes({ resolveImageSrc: opts?.resolveImageSrc }),
 		createAssignDataIdExtension(opts),
 		MarkdownWcShortcuts,
 	];

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/nodes.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/nodes.ts
@@ -1,5 +1,7 @@
 import { Node, Mark, type Extensions, type CommandProps } from "@tiptap/core";
 
+export type MarkdownImageSrcResolver = (src: string) => string;
+
 // Extend TipTap's command types
 declare module "@tiptap/core" {
 	interface Commands<ReturnType> {
@@ -25,7 +27,10 @@ function diffAttrs(node: any, mode: "words" | "element" = "words"): any {
 	};
 }
 
-export function markdownWcNodes(): Extensions {
+export function markdownWcNodes(
+	options: { readonly resolveImageSrc?: MarkdownImageSrcResolver } = {},
+): Extensions {
+	const resolveImageSrc = options.resolveImageSrc;
 	return [
 		// doc
 		Node.create({ name: "doc", topNode: true, content: "block+" }),
@@ -388,7 +393,9 @@ export function markdownWcNodes(): Extensions {
 			renderHTML({ node }) {
 				const attrs: any = {};
 				const src = (node as any).attrs?.src;
-				if (src) attrs.src = src;
+				if (typeof src === "string" && src.length > 0) {
+					attrs.src = resolveRenderedImageSrc(src, resolveImageSrc);
+				}
 				const alt = (node as any).attrs?.alt;
 				if (alt) attrs.alt = alt;
 				const title = (node as any).attrs?.title;
@@ -397,4 +404,18 @@ export function markdownWcNodes(): Extensions {
 			},
 		}),
 	];
+}
+
+function resolveRenderedImageSrc(
+	src: string,
+	resolveImageSrc: MarkdownImageSrcResolver | undefined,
+): string {
+	if (!resolveImageSrc) {
+		return src;
+	}
+	try {
+		return resolveImageSrc(src);
+	} catch {
+		return src;
+	}
 }

--- a/src/extensions/markdown/editor/tiptap-markdown-bridge/roundtrip.test.ts
+++ b/src/extensions/markdown/editor/tiptap-markdown-bridge/roundtrip.test.ts
@@ -540,6 +540,26 @@ describe("blocks", () => {
 });
 
 describe("inline", () => {
+	test("resolved image render src does not change serialized markdown src", () => {
+		const ast = parseMarkdown('![Alt](images/logo.png "Logo")');
+		const editor = new Editor({
+			extensions: MarkdownWc({
+				resolveImageSrc: (src) => `file:///workspace/docs/${src}`,
+			}),
+			content: astToTiptapDoc(ast),
+		});
+
+		const image = editor.view.dom.querySelector("img");
+		expect(image?.getAttribute("src")).toBe(
+			"file:///workspace/docs/images/logo.png",
+		);
+
+		const markdown = serializeAst(tiptapDocToAst(editor.getJSON() as any));
+		expect(markdown).toContain("images/logo.png");
+		expect(markdown).not.toContain("file:///workspace");
+		editor.destroy();
+	});
+
 	test("hard break", () => {
 		const input: Ast = {
 			type: "root",

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -156,6 +156,7 @@ function MarkdownViewLoaded({
 						<TipTapEditor
 							className="h-full"
 							fileId={fileRow.id}
+							filePath={fileRow.path}
 							isActiveView={isActiveView}
 							focusOnLoad={focusOnLoad}
 							defaultBlock={defaultBlock}


### PR DESCRIPTION
## Summary
- Resolve markdown image sources in the desktop workspace layer using existing workspace path helpers instead of hand-rolled path parsing.
- Keep direct `http`/`https` image URLs unchanged.
- Normalize non-HTTP image refs relative to the source markdown file, and fall back to a 1x1 transparent GIF when the resolved path escapes the workspace.
- Wire the resolver into markdown rendering so editor output still serializes the original markdown path.

## Testing
- Added unit coverage for workspace image resolution rules, including HTTP(S), in-workspace normalization, and fallback behavior.
- Added a round-trip editor test to verify rendered `src` values do not leak into serialized markdown.
- `pnpm run typecheck` passed.
- `pnpm exec vitest run electron/workspace-paths.test.mjs src/extensions/markdown/editor/tiptap-markdown-bridge/roundtrip.test.ts` passed.
- `pnpm exec prettier --check ...` and `git diff --check` passed.

## TODO
- Should probably switch to eg for invalid images:

```html
<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='150'%3E%3Crect width='100%25' height='100%25' fill='%23eee'/%3E%3Ctext x='50%25' y='50%25' text-anchor='middle' dominant-baseline='middle' fill='%23999' font-family='sans-serif'%3EImage unavailable%3C/text%3E%3C/svg%3E" alt="Image unavailable">
```