### PR TITLE
Harden on-demand ephemeral workspaces

### DIFF
--- a/e2e/workspace-windows.spec.ts
+++ b/e2e/workspace-windows.spec.ts
@@ -757,7 +757,9 @@ async function writeMarkerFile(
 }
 
 async function initializeLixWorkspace(workspaceDir: string): Promise<void> {
-	const lix = await openLix({ backend: new FsBackend({ path: workspaceDir }) });
+	const lix = await openLix({
+		backend: new FsBackend({ path: workspaceDir, syncAllFiles: true }),
+	});
 	await lix.close();
 }
 

--- a/electron/ipc-lix.mjs
+++ b/electron/ipc-lix.mjs
@@ -272,6 +272,12 @@ export function registerLixIpc(resolveWindowForEvent, options = {}) {
 		return result;
 	});
 
+	ipcMain.handle("lix:importFilesystemPaths", async (event, payload) => {
+		const lix = await ensureLixOpenForEvent(event);
+		const paths = Array.isArray(payload?.paths) ? payload.paths : [];
+		await lix.importFilesystemPaths(paths);
+	});
+
 	ipcMain.handle("lix:close", async (event) => {
 		await closeLixSession(getWindowForIpcEvent(event));
 	});

--- a/electron/lix.mjs
+++ b/electron/lix.mjs
@@ -386,6 +386,11 @@ function createDesktopLixHandle(nativeLix, workspaceDir) {
 				return receipt;
 			});
 		},
+		async importFilesystemPaths(paths = []) {
+			return await runQueued(() =>
+				nativeLix.importFilesystemPaths([...(paths ?? [])]),
+			);
+		},
 		async close() {
 			await runQueued(() => nativeLix.close());
 		},

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -13,6 +13,7 @@ import {
 	getWorkspace,
 	registerWorkspaceIpc,
 	resolveWorkspaceTargets,
+	setWorkspaceOpenFilePaths,
 	setWorkspaceFromTarget,
 	setWorkspaceTrackChanges,
 	showWorkspaceDialog,
@@ -1134,6 +1135,7 @@ function registerAppIpc() {
 		if (!workspaceEntry) {
 			return;
 		}
+		setWorkspaceOpenFilePaths(window, workspaceEntry.openFilePaths);
 		openFilePathsByWindowId.set(window.id, workspaceEntry.openFilePaths);
 		openWorkspaceEntriesByWindowId.set(window.id, workspaceEntry);
 		persistOpenWorkspacePathsSoon();

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -36,8 +36,6 @@ const workspace = {
 			ipcRenderer.off("workspace:ephemeralWatchedFileTreeChanged", wrapped);
 		};
 	},
-	readEphemeralFile: (payload) =>
-		ipcRenderer.invoke("workspace:readEphemeralFile", payload),
 	profile: () => ipcRenderer.invoke("workspace:profile"),
 	onNewFile: (listener) => {
 		const wrapped = () => listener();
@@ -81,6 +79,8 @@ const lix = {
 	activeBranchId: () => ipcRenderer.invoke("lix:activeBranchId"),
 	createBranch: (payload) => ipcRenderer.invoke("lix:createBranch", payload),
 	switchBranch: (payload) => ipcRenderer.invoke("lix:switchBranch", payload),
+	importFilesystemPaths: (payload) =>
+		ipcRenderer.invoke("lix:importFilesystemPaths", payload),
 	close: () => ipcRenderer.invoke("lix:close"),
 };
 

--- a/electron/recent-workspaces.test.ts
+++ b/electron/recent-workspaces.test.ts
@@ -147,7 +147,7 @@ describe("recent workspaces", () => {
 				ephemeral: true,
 				path: "/tmp",
 				name: "tmp",
-				includePaths: ["file.md"],
+				openFilePaths: ["file.md"],
 			}),
 		).toBeNull();
 	});

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -81,6 +81,7 @@ export type DesktopLixApi = {
 	switchBranch(payload: {
 		branchId: string;
 	}): Promise<DesktopSwitchBranchResult>;
+	importFilesystemPaths(payload: { paths: readonly string[] }): Promise<void>;
 	close(): Promise<void>;
 };
 
@@ -122,13 +123,13 @@ export type DesktopWorkspace =
 			ephemeral: false;
 			path: string;
 			name: string;
-			includePaths?: never;
+			openFilePaths?: never;
 	  }
 	| {
 			ephemeral: true;
 			path: string;
 			name: string;
-			includePaths: string[];
+			openFilePaths: string[];
 	  };
 
 export type DesktopWorkspaceRecovery = {
@@ -179,7 +180,6 @@ export type DesktopWorkspaceApi = {
 	onEphemeralWatchedFileTreeChanged(
 		listener: (entries: DesktopWatchedFilesystemEntry[]) => void,
 	): () => void;
-	readEphemeralFile(payload: { path: string }): Promise<Uint8Array>;
 	profile(): Promise<DesktopWorkspaceProfile | null>;
 	/** Fired when the native menu asks the workspace UI to start a new file. */
 	onNewFile(listener: () => void): () => void;

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -349,13 +349,10 @@ export async function getWorkspaceFsBackendOptions(window) {
 	}
 	if (workspace.ephemeral === true) {
 		const lixDir = await ensureExternalLixDir(window);
-		const includePaths = Array.isArray(workspace.includePaths)
-			? workspace.includePaths
-			: [];
 		return {
 			path: workspace.path,
 			lixDir,
-			filter: { includePaths: [...includePaths] },
+			filter: { includePaths: [] },
 		};
 	}
 	return { path: workspace.path };

--- a/electron/workspace.mjs
+++ b/electron/workspace.mjs
@@ -7,7 +7,6 @@ import {
 	lstat,
 	mkdtemp,
 	opendir,
-	readFile,
 	realpath,
 	rename,
 	rm,
@@ -59,7 +58,7 @@ export async function resolveWorkspaceTarget(requestedPath) {
 			const workspace = createTransientDirectoryWorkspace([resolved]);
 			return {
 				workspace,
-				pendingOpenFilePaths: workspace.includePaths,
+				pendingOpenFilePaths: workspace.openFilePaths,
 			};
 		}
 		return {
@@ -118,7 +117,7 @@ export async function resolveWorkspaceTargets(requestedPaths) {
 		const workspace = createTransientDirectoryWorkspace(standaloneFiles);
 		targets.splice(standaloneFilesInsertIndex ?? targets.length, 0, {
 			workspace,
-			pendingOpenFilePaths: workspace.includePaths,
+			pendingOpenFilePaths: workspace.openFilePaths,
 		});
 	}
 
@@ -175,25 +174,6 @@ export async function openWorkspaceDialog(window, options = {}) {
 	return await setWorkspaceFromPath(dir, window, options);
 }
 
-export async function exportWorkspaceLixFile(window) {
-	const workspace = getWorkspace(window);
-	if (!workspace) {
-		throw new Error(
-			"No workspace is open. Open a folder before exporting lix.",
-		);
-	}
-	if (workspace.ephemeral === true) {
-		throw new Error(
-			"Cannot export a .lix database from a transient workspace.",
-		);
-	}
-	const databasePath = await findLixDatabasePath(workspace.path);
-	if (!databasePath) {
-		throw new Error("The opened workspace does not have a .lix database.");
-	}
-	return await readFile(databasePath);
-}
-
 export function getWorkspaceLixDatabasePath(window) {
 	const workspace = getWorkspace(window);
 	if (!workspace) {
@@ -221,6 +201,21 @@ export function consumePendingOpenFiles(window) {
 	return pendingOpenFilePaths ?? [];
 }
 
+export function setWorkspaceOpenFilePaths(window, filePaths) {
+	const state = getWindowState(window);
+	if (!state?.workspace) {
+		return [];
+	}
+	const openFilePaths = uniqueWorkspaceRelativeFilePaths(filePaths);
+	if (state.workspace.ephemeral === true) {
+		state.workspace = {
+			...state.workspace,
+			openFilePaths,
+		};
+	}
+	return openFilePaths;
+}
+
 export async function setEphemeralWatchedDirectories(window, payload) {
 	const state = getOrCreateWindowState(window);
 	const workspace = state.workspace;
@@ -241,24 +236,6 @@ export async function setEphemeralWatchedDirectories(window, payload) {
 	}
 	await refreshEphemeralFileTree(window, state, { emit: false });
 	return state.ephemeralWatchedEntries;
-}
-
-export async function readEphemeralWorkspaceFile(window, payload) {
-	const state = getWindowState(window);
-	const workspace = state?.workspace;
-	if (!state || !workspace || workspace.ephemeral !== true) {
-		throw new Error("No transient workspace is open.");
-	}
-	const filePath = normalizeWorkspaceFilePath(payload?.path);
-	if (!isEphemeralWatchedFileEntry(state, filePath)) {
-		throw new Error(`File is not in the opened Files view: ${filePath}`);
-	}
-	const { localPath } = await resolveExistingWorkspacePath(
-		workspace,
-		filePath,
-		"file",
-	);
-	return await readFile(localPath);
 }
 
 export async function profileWorkspaceFilesystem(workspace) {
@@ -312,8 +289,8 @@ export async function profileWorkspaceFilesystem(workspace) {
 
 async function profileTransientWorkspaceSourceFiles(profile, workspace) {
 	const directories = new Set();
-	for (const includePath of workspace.includePaths ?? []) {
-		const sourceFilePath = path.join(workspace.path, includePath);
+	for (const openFilePath of workspace.openFilePaths ?? []) {
+		const sourceFilePath = path.join(workspace.path, openFilePath);
 		let stats;
 		try {
 			stats = await lstat(sourceFilePath);
@@ -352,10 +329,10 @@ export async function getWorkspaceFsBackendOptions(window) {
 		return {
 			path: workspace.path,
 			lixDir,
-			filter: { includePaths: [] },
+			syncAllFiles: false,
 		};
 	}
-	return { path: workspace.path };
+	return { path: workspace.path, syncAllFiles: true };
 }
 
 export async function setWorkspaceTrackChanges(window, trackChanges) {
@@ -588,17 +565,6 @@ function normalizeWorkspaceDirectoryPath(directoryPath, state) {
 	return directoryPath;
 }
 
-function normalizeWorkspaceFilePath(filePath) {
-	if (
-		typeof filePath !== "string" ||
-		!filePath.startsWith("/") ||
-		filePath.endsWith("/")
-	) {
-		throw new Error(`Invalid workspace file path: ${filePath}`);
-	}
-	return filePath;
-}
-
 function parentDirectoryPathForDirectoryPath(directoryPath) {
 	if (directoryPath === "/") {
 		return null;
@@ -636,15 +602,6 @@ function isEphemeralWatchedDirectoryEntry(state, directoryPath) {
 			entry.kind === "directory" &&
 			entry.source === "watched" &&
 			entry.path === directoryPath,
-	);
-}
-
-function isEphemeralWatchedFileEntry(state, filePath) {
-	return state.ephemeralWatchedEntries.some(
-		(entry) =>
-			entry.kind === "file" &&
-			entry.source === "watched" &&
-			entry.path === filePath,
 	);
 }
 
@@ -957,12 +914,12 @@ function createPersistentWorkspace(workspacePath) {
 	};
 }
 
-function createEphemeralWorkspace(workspacePath, includePaths = []) {
+function createEphemeralWorkspace(workspacePath, openFilePaths = []) {
 	const resolvedPath = path.resolve(workspacePath);
 	return {
 		ephemeral: true,
 		path: resolvedPath,
-		includePaths: uniqueWorkspaceRelativeFilePaths(includePaths),
+		openFilePaths: uniqueWorkspaceRelativeFilePaths(openFilePaths),
 		name: path.basename(resolvedPath) || resolvedPath,
 	};
 }
@@ -1137,7 +1094,7 @@ function workspaceKey(workspace) {
 		return null;
 	}
 	if (workspace.ephemeral === true) {
-		return `ephemeral:${workspace.path}:${(workspace.includePaths ?? []).join("\0")}`;
+		return `ephemeral:${workspace.path}:${(workspace.openFilePaths ?? []).join("\0")}`;
 	}
 	return `directory:${workspace.path}`;
 }
@@ -1242,10 +1199,6 @@ export function registerWorkspaceIpc(getWindowForEvent, options = {}) {
 			);
 		},
 	);
-
-	ipcMain.handle("workspace:readEphemeralFile", async (event, payload) => {
-		return await readEphemeralWorkspaceFile(getWindowForEvent(event), payload);
-	});
 
 	ipcMain.handle("workspace:profile", async (event) => {
 		return await profileWorkspaceFilesystem(

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -1,11 +1,4 @@
-import {
-	mkdir,
-	readFile,
-	rm,
-	stat,
-	symlink,
-	writeFile,
-} from "node:fs/promises";
+import { mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -14,12 +7,13 @@ import {
 	profileWorkspaceFilesystem,
 	disableWorkspaceTrackChanges,
 	disposeWorkspaceWindowState,
+	getWorkspace,
 	getWorkspaceFsBackendOptions,
-	readEphemeralWorkspaceFile,
 	resolveWorkspace,
 	resolveWorkspaceTarget,
 	resolveWorkspaceTargets,
 	setEphemeralWatchedDirectories,
+	setWorkspaceOpenFilePaths,
 	setWorkspaceFromPath,
 } from "./workspace.mjs";
 
@@ -51,7 +45,7 @@ describe("workspace resolution", () => {
 		await expect(resolveWorkspace(directory)).resolves.toEqual({
 			ephemeral: true,
 			path: directory,
-			includePaths: [],
+			openFilePaths: [],
 			name: "workspace",
 		});
 	});
@@ -70,7 +64,7 @@ describe("workspace resolution", () => {
 			workspace: {
 				ephemeral: true,
 				path: directory,
-				includePaths: [],
+				openFilePaths: [],
 				name: "workspace",
 			},
 			pendingOpenFilePaths: [],
@@ -106,7 +100,7 @@ describe("workspace resolution", () => {
 			workspace: {
 				ephemeral: true,
 				path: directory,
-				includePaths: [],
+				openFilePaths: [],
 				name: "workspace",
 			},
 			pendingOpenFilePaths: [],
@@ -359,7 +353,7 @@ describe("workspace resolution", () => {
 			workspace: {
 				ephemeral: true,
 				path: directory,
-				includePaths: ["readme.md"],
+				openFilePaths: ["readme.md"],
 				name: "workspace",
 			},
 			pendingOpenFilePaths: ["readme.md"],
@@ -386,7 +380,7 @@ describe("workspace resolution", () => {
 				workspace: {
 					ephemeral: true,
 					path: directory,
-					includePaths: ["alpha.md", "nested/beta.markdown"],
+					openFilePaths: ["alpha.md", "nested/beta.markdown"],
 					name: "workspace",
 				},
 				pendingOpenFilePaths: ["alpha.md", "nested/beta.markdown"],
@@ -468,7 +462,7 @@ describe("workspace resolution", () => {
 				workspace: {
 					ephemeral: true,
 					path: directory,
-					includePaths: ["alpha.txt", "beta.csv"],
+					openFilePaths: ["alpha.txt", "beta.csv"],
 					name: "workspace",
 				},
 				pendingOpenFilePaths: ["alpha.txt", "beta.csv"],
@@ -510,10 +504,6 @@ describe("workspace resolution", () => {
 				"/notes.txt",
 			]);
 
-			await expect(
-				readEphemeralWorkspaceFile(window, { path: "/docs/nested.txt" }),
-			).rejects.toThrow("opened Files view");
-
 			const nestedEntries = await setEphemeralWatchedDirectories(window, {
 				ownerId: "files",
 				paths: ["/", "/docs/"],
@@ -525,9 +515,6 @@ describe("workspace resolution", () => {
 				"/docs/nested.txt",
 				"/notes.txt",
 			]);
-			await expect(
-				readEphemeralWorkspaceFile(window, { path: "/docs/nested.txt" }),
-			).resolves.toEqual(Buffer.from("Nested\n"));
 		} finally {
 			await disposeWorkspaceWindowState(window);
 		}
@@ -558,51 +545,6 @@ describe("workspace resolution", () => {
 					paths: [],
 				}),
 			).resolves.toEqual([]);
-			await expect(
-				readEphemeralWorkspaceFile(window, { path: "/notes.txt" }),
-			).rejects.toThrow("opened Files view");
-		} finally {
-			await disposeWorkspaceWindowState(window);
-		}
-	});
-
-	test("does not read listed transient files through symlinked ancestors", async () => {
-		const directory = path.join(
-			tmpdir(),
-			"flashtype-workspace-test",
-			randomUUID(),
-			"workspace",
-		);
-		const outsideDirectory = path.join(
-			tmpdir(),
-			"flashtype-workspace-test",
-			randomUUID(),
-			"outside",
-		);
-		const docsDirectory = path.join(directory, "docs");
-		await mkdir(docsDirectory, { recursive: true });
-		await mkdir(outsideDirectory, { recursive: true });
-		await writeFile(path.join(docsDirectory, "secret.txt"), "inside\n");
-		await writeFile(path.join(outsideDirectory, "secret.txt"), "outside\n");
-
-		const window = createTestWindow();
-		try {
-			await setWorkspaceFromPath(directory, window);
-			await setEphemeralWatchedDirectories(window, {
-				ownerId: "files",
-				paths: ["/"],
-			});
-			await setEphemeralWatchedDirectories(window, {
-				ownerId: "files",
-				paths: ["/", "/docs/"],
-			});
-
-			await rm(docsDirectory, { force: true, recursive: true });
-			await symlink(outsideDirectory, docsDirectory, "dir");
-
-			await expect(
-				readEphemeralWorkspaceFile(window, { path: "/docs/secret.txt" }),
-			).rejects.toThrow("escapes the workspace");
 		} finally {
 			await disposeWorkspaceWindowState(window);
 		}
@@ -715,7 +657,7 @@ describe("workspace resolution", () => {
 				ephemeral: true,
 				path: directory,
 				name: "workspace",
-				includePaths: ["notes/today.md"],
+				openFilePaths: ["notes/today.md"],
 			}),
 		).resolves.toMatchObject({
 			file_count: 1,
@@ -744,9 +686,38 @@ describe("workspace resolution", () => {
 
 			expect(options).toMatchObject({
 				path: directory,
-				filter: { includePaths: [] },
+				syncAllFiles: false,
 			});
 			expect(options.lixDir).toEqual(expect.any(String));
+		} finally {
+			await disposeWorkspaceWindowState(window);
+		}
+	});
+
+	test("tracks transient open file paths on the workspace state", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		await mkdir(path.join(directory, "docs"), { recursive: true });
+
+		const window = createTestWindow();
+		try {
+			await setWorkspaceFromPath(directory, window);
+
+			expect(
+				setWorkspaceOpenFilePaths(window, [
+					"docs/readme.md",
+					"../outside.md",
+					"docs/readme.md",
+				]),
+			).toEqual(["docs/readme.md"]);
+			expect(getWorkspace(window)).toMatchObject({
+				ephemeral: true,
+				openFilePaths: ["docs/readme.md"],
+			});
 		} finally {
 			await disposeWorkspaceWindowState(window);
 		}
@@ -802,7 +773,7 @@ describe("workspace resolution", () => {
 				workspace: {
 					ephemeral: true,
 					path: directory,
-					includePaths: ["docs/readme.md"],
+					openFilePaths: ["docs/readme.md"],
 					name: "workspace",
 				},
 				pendingOpenFilePaths: ["docs/readme.md"],
@@ -831,7 +802,7 @@ describe("workspace resolution", () => {
 			await expect(disableWorkspaceTrackChanges(window)).resolves.toEqual({
 				ephemeral: true,
 				path: directory,
-				includePaths: [],
+				openFilePaths: [],
 				name: "workspace",
 			});
 			await expect(readFile(workspaceFile, "utf8")).resolves.toBe(
@@ -868,7 +839,7 @@ describe("workspace resolution", () => {
 				workspace: {
 					ephemeral: true,
 					path: directory,
-					includePaths: [],
+					openFilePaths: [],
 					name: "workspace",
 				},
 				pendingOpenFilePaths: [],

--- a/electron/workspace.test.ts
+++ b/electron/workspace.test.ts
@@ -14,6 +14,7 @@ import {
 	profileWorkspaceFilesystem,
 	disableWorkspaceTrackChanges,
 	disposeWorkspaceWindowState,
+	getWorkspaceFsBackendOptions,
 	readEphemeralWorkspaceFile,
 	resolveWorkspace,
 	resolveWorkspaceTarget,
@@ -722,6 +723,33 @@ describe("workspace resolution", () => {
 			extension_counts: { md: 1 },
 			total_size_mb: 0,
 		});
+	});
+
+	test("opens transient FsBackend with an empty dynamic filter", async () => {
+		const directory = path.join(
+			tmpdir(),
+			"flashtype-workspace-test",
+			randomUUID(),
+			"workspace",
+		);
+		const filePath = path.join(directory, "today.md");
+		await mkdir(directory, { recursive: true });
+		await writeFile(filePath, "# Today\n");
+
+		const window = createTestWindow();
+		try {
+			await setWorkspaceFromPath(filePath, window);
+
+			const options = await getWorkspaceFsBackendOptions(window);
+
+			expect(options).toMatchObject({
+				path: directory,
+				filter: { includePaths: [] },
+			});
+			expect(options.lixDir).toEqual(expect.any(String));
+		} finally {
+			await disposeWorkspaceWindowState(window);
+		}
 	});
 
 	test("ignores saved open files for tracked workspace session entries", async () => {

--- a/src/extension-runtime/types.ts
+++ b/src/extension-runtime/types.ts
@@ -37,7 +37,7 @@ export type WorkspaceContext =
 			readonly ephemeral: true;
 			readonly path: string;
 			readonly name: string;
-			readonly includePaths: readonly string[];
+			readonly openFilePaths: readonly string[];
 	  };
 
 /**

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -641,7 +641,7 @@ describe("FilesView", () => {
 										ephemeral: true,
 										path: "/workspace",
 										name: "workspace",
-										includePaths: [],
+										openFilePaths: [],
 									},
 								})}
 							/>
@@ -860,7 +860,7 @@ describe("FilesView", () => {
 										ephemeral: true,
 										path: "/tmp/workspace",
 										name: "workspace",
-										includePaths: [],
+										openFilePaths: [],
 									},
 								})}
 							/>

--- a/src/lib/lix-client.ts
+++ b/src/lib/lix-client.ts
@@ -236,6 +236,13 @@ export async function openDesktopLix(): Promise<Lix> {
 		return await runQueued(() => desktop.lix.switchBranch(options));
 	};
 
+	const importFilesystemPaths = async (
+		paths: readonly string[],
+	): Promise<void> => {
+		ensureOpen("importFilesystemPaths");
+		await runQueued(() => desktop.lix.importFilesystemPaths({ paths }));
+	};
+
 	const close = async (): Promise<void> => {
 		if (closed) {
 			return;
@@ -261,6 +268,7 @@ export async function openDesktopLix(): Promise<Lix> {
 		activeBranchId,
 		createBranch,
 		switchBranch,
+		importFilesystemPaths,
 		close,
 	};
 	return lix satisfies Lix;

--- a/src/lib/lix-types.ts
+++ b/src/lib/lix-types.ts
@@ -62,6 +62,7 @@ export interface FlashtypeLix extends SdkLixBase {
 		statements: ReadonlyArray<TransactionStatement>,
 	): Promise<ExecuteResult>;
 	observe(sql: string, params?: ReadonlyArray<unknown>): ObserveEvents;
+	importFilesystemPaths(paths: readonly string[]): Promise<void>;
 	mergeBranchPreview?: SdkLix["mergeBranchPreview"];
 	mergeBranch?: SdkLix["mergeBranch"];
 }

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -26,9 +26,7 @@ afterEach(() => {
 describe("resolveLixFileForOpen", () => {
 	test("uses the existing Lix row for normalized file paths", async () => {
 		const lix = await openLix();
-		const readEphemeralFile = vi.fn(async () =>
-			new TextEncoder().encode("Disk content"),
-		);
+		const importFilesystemPaths = vi.spyOn(lix, "importFilesystemPaths");
 		await qb(lix)
 			.insertInto("lix_file")
 			.values({
@@ -42,17 +40,16 @@ describe("resolveLixFileForOpen", () => {
 			lix,
 			workspace: ephemeralWorkspace(),
 			filePath: "docs/./readme.md",
-			readEphemeralFile,
 		});
 
 		expect(resolved).toEqual({ id: "real_file", path: "/docs/readme.md" });
-		expect(readEphemeralFile).not.toHaveBeenCalled();
+		expect(importFilesystemPaths).not.toHaveBeenCalled();
 		await lix.close();
 	});
 
 	test("preserves backslashes as filename characters in Lix paths", async () => {
 		const lix = await openLix();
-		const readEphemeralFile = vi.fn(async () => undefined);
+		const importFilesystemPaths = vi.spyOn(lix, "importFilesystemPaths");
 		await qb(lix)
 			.insertInto("lix_file")
 			.values({
@@ -66,20 +63,19 @@ describe("resolveLixFileForOpen", () => {
 			lix,
 			workspace: ephemeralWorkspace(),
 			filePath: "/erjtyjtyr\\treytj.md",
-			readEphemeralFile,
 		});
 
 		expect(resolved).toEqual({
 			id: "backslash_file",
 			path: "/erjtyjtyr\\treytj.md",
 		});
-		expect(readEphemeralFile).not.toHaveBeenCalled();
+		expect(importFilesystemPaths).not.toHaveBeenCalled();
 		await lix.close();
 	});
 
 	test("preserves surrounding whitespace in Lix path segments", async () => {
 		const lix = await openLix();
-		const readEphemeralFile = vi.fn(async () => undefined);
+		const importFilesystemPaths = vi.spyOn(lix, "importFilesystemPaths");
 		await qb(lix)
 			.insertInto("lix_file")
 			.values({
@@ -93,31 +89,37 @@ describe("resolveLixFileForOpen", () => {
 			lix,
 			workspace: ephemeralWorkspace(),
 			filePath: "/ notes.md ",
-			readEphemeralFile,
 		});
 
 		expect(resolved).toEqual({
 			id: "spaced_file",
 			path: "/ notes.md ",
 		});
-		expect(readEphemeralFile).not.toHaveBeenCalled();
+		expect(importFilesystemPaths).not.toHaveBeenCalled();
 		await lix.close();
 	});
 
 	test("imports an ephemeral disk file and returns the inserted Lix id", async () => {
 		const lix = await openLix();
-		const readEphemeralFile = vi.fn(async () =>
-			new TextEncoder().encode("# Imported"),
-		);
+		const importFilesystemPaths = vi
+			.spyOn(lix, "importFilesystemPaths")
+			.mockImplementation(async ([path]) => {
+				await qb(lix)
+					.insertInto("lix_file")
+					.values({
+						path,
+						data: new TextEncoder().encode("# Imported"),
+					})
+					.execute();
+			});
 
 		const resolved = await resolveLixFileForOpen({
 			lix,
 			workspace: ephemeralWorkspace(),
 			filePath: "/notes.md",
-			readEphemeralFile,
 		});
 
-		expect(readEphemeralFile).toHaveBeenCalledWith({ path: "/notes.md" });
+		expect(importFilesystemPaths).toHaveBeenCalledWith(["/notes.md"]);
 		expect(resolved?.path).toBe("/notes.md");
 		expect(resolved?.id).toBeTruthy();
 		const row = await qb(lix)
@@ -132,7 +134,7 @@ describe("resolveLixFileForOpen", () => {
 
 	test("does not overwrite a Lix row created while importing", async () => {
 		const lix = await openLix();
-		const readEphemeralFile = vi.fn(async () => {
+		vi.spyOn(lix, "importFilesystemPaths").mockImplementation(async () => {
 			await qb(lix)
 				.insertInto("lix_file")
 				.values({
@@ -141,14 +143,12 @@ describe("resolveLixFileForOpen", () => {
 					data: new TextEncoder().encode("Existing Lix data"),
 				})
 				.execute();
-			return new TextEncoder().encode("Disk data");
 		});
 
 		const resolved = await resolveLixFileForOpen({
 			lix,
 			workspace: ephemeralWorkspace(),
 			filePath: "/race.md",
-			readEphemeralFile,
 		});
 
 		expect(resolved).toEqual({ id: "raced_file", path: "/race.md" });
@@ -165,7 +165,9 @@ describe("resolveLixFileForOpen", () => {
 
 	test("refuses files that cannot be found or imported", async () => {
 		const lix = await openLix();
-		const readEphemeralFile = vi.fn(async () => undefined);
+		const importFilesystemPaths = vi
+			.spyOn(lix, "importFilesystemPaths")
+			.mockResolvedValue();
 
 		await expect(
 			resolveLixFileForOpen({
@@ -176,20 +178,18 @@ describe("resolveLixFileForOpen", () => {
 					name: "workspace",
 				},
 				filePath: "/missing.md",
-				readEphemeralFile,
 			}),
 		).resolves.toBeNull();
-		expect(readEphemeralFile).not.toHaveBeenCalled();
+		expect(importFilesystemPaths).not.toHaveBeenCalled();
 
 		await expect(
 			resolveLixFileForOpen({
 				lix,
 				workspace: ephemeralWorkspace(),
 				filePath: "/missing.md",
-				readEphemeralFile,
 			}),
 		).resolves.toBeNull();
-		expect(readEphemeralFile).toHaveBeenCalledWith({ path: "/missing.md" });
+		expect(importFilesystemPaths).toHaveBeenCalledWith(["/missing.md"]);
 		await lix.close();
 	});
 });
@@ -417,6 +417,6 @@ function ephemeralWorkspace() {
 		ephemeral: true,
 		path: "/workspace",
 		name: "workspace",
-		includePaths: [],
+		openFilePaths: [],
 	} as const;
 }

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -423,10 +423,6 @@ type LixFileForOpen = {
 	readonly path: string;
 };
 
-type ReadEphemeralFile = (payload: {
-	readonly path: string;
-}) => Promise<Uint8Array | undefined>;
-
 function normalizeLixFileOpenPath(filePath: string): string | null {
 	if (!filePath) return null;
 	const rootedPath = filePath.startsWith("/") ? filePath : `/${filePath}`;
@@ -461,12 +457,10 @@ export async function resolveLixFileForOpen({
 	lix,
 	workspace,
 	filePath,
-	readEphemeralFile,
 }: {
 	readonly lix: Lix;
 	readonly workspace?: WorkspaceContext;
 	readonly filePath: string;
-	readonly readEphemeralFile?: ReadEphemeralFile;
 }): Promise<LixFileForOpen | null> {
 	const normalizedPath = normalizeLixFileOpenPath(filePath);
 	if (!normalizedPath) return null;
@@ -474,21 +468,11 @@ export async function resolveLixFileForOpen({
 	const existingFile = await selectLixFileForOpen(lix, normalizedPath);
 	if (existingFile) return existingFile;
 
-	if (workspace?.ephemeral !== true || !readEphemeralFile) {
+	if (workspace?.ephemeral !== true) {
 		return null;
 	}
 
-	const data = await readEphemeralFile({ path: normalizedPath });
-	if (!data) return null;
-
-	await qb(lix)
-		.insertInto("lix_file")
-		.values({
-			path: normalizedPath,
-			data,
-		})
-		.onConflict((oc) => oc.column("path").doNothing())
-		.execute();
+	await lix.importFilesystemPaths([normalizedPath]);
 
 	return selectLixFileForOpen(lix, normalizedPath);
 }
@@ -1295,8 +1279,6 @@ function LayoutShellLoadedContent({
 					lix,
 					workspace,
 					filePath,
-					readEphemeralFile:
-						window.flashtypeDesktop?.workspace.readEphemeralFile,
 				});
 			} catch (error) {
 				onError?.(error);
@@ -1337,8 +1319,6 @@ function LayoutShellLoadedContent({
 					lix,
 					workspace,
 					filePath: `/${pendingOpenFilePath}`,
-					readEphemeralFile:
-						window.flashtypeDesktop?.workspace.readEphemeralFile,
 				});
 				if (cancelled) return;
 				if (!file) {

--- a/src/test-utils/node-lix-sdk.ts
+++ b/src/test-utils/node-lix-sdk.ts
@@ -153,6 +153,9 @@ function createTestLixAdapter(sdkLix: SdkLix): Lix {
 		async switchBranch(options) {
 			return await sdkLix.switchBranch(options);
 		},
+		async importFilesystemPaths(paths) {
+			await sdkLix.importFilesystemPaths(paths);
+		},
 		async mergeBranchPreview(options) {
 			return await sdkLix.mergeBranchPreview(options);
 		},


### PR DESCRIPTION
- Replaced Flashtype transient `includePaths` with `openFilePaths`.
- Removed Flashtype filesystem file-content reads; transient file opens now import through Lix.
- Added `importFilesystemPaths()` to the Lix Rust/JS/native filesystem backend path.
- Replaced FS backend `filter/includePaths` with required `syncAllFiles: boolean`.
- Updated tests and docs for full-sync vs on-demand filesystem sync.