### PR TITLE
[codex] Upgrade PostHog telemetry capture

### DIFF
--- a/electron/telemetry.mjs
+++ b/electron/telemetry.mjs
@@ -394,7 +394,15 @@ export function forgetTelemetrySessionContextForWebContents(webContents) {
 	if (!webContents) {
 		return;
 	}
+	const forgottenSessionId = rendererPostHogSessionIdsByWebContentsId.get(
+		webContents.id,
+	);
 	rendererPostHogSessionIdsByWebContentsId.delete(webContents.id);
+	if (latestRendererPostHogSessionId === forgottenSessionId) {
+		latestRendererPostHogSessionId = Array.from(
+			rendererPostHogSessionIdsByWebContentsId.values(),
+		).at(-1);
+	}
 }
 
 export function setTelemetrySessionContextForWebContents(

--- a/electron/telemetry.mjs
+++ b/electron/telemetry.mjs
@@ -9,6 +9,8 @@ const ENV_VARIABLES_FILE = "build/env-variables.mjs";
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 const DEV_TELEMETRY_DISTINCT_ID = "dev:mode";
 const SHUTDOWN_TIMEOUT_MS = 2_000;
+const APP_OPENED_SESSION_WAIT_MS = 5_000;
+const WORKSPACE_GROUP_TYPE = "workspace";
 
 let envVariablesPromise;
 let distinctIdPromise;
@@ -19,14 +21,23 @@ let telemetryShutdownPromise;
 let latestRendererPostHogSessionId;
 let cachedDistinctId;
 const rendererPostHogSessionIdsByWebContentsId = new Map();
+const identifiedWorkspaceGroupKeys = new Set();
+const rendererSessionWaiters = new Set();
 
 export async function captureAppOpened({ entryPoint = "app_direct" } = {}) {
+	if (isTelemetryEnabled() && !latestRendererPostHogSessionId) {
+		await waitForRendererPostHogSessionId(APP_OPENED_SESSION_WAIT_MS);
+	}
 	return await captureTelemetryEvent("app_opened", {
 		entry_point: entryPoint,
 	});
 }
 
-export async function captureTelemetryEvent(event, properties = {}) {
+export async function captureTelemetryEvent(
+	event,
+	properties = {},
+	options = {},
+) {
 	if (!isTelemetryEnabled()) {
 		return { status: "disabled" };
 	}
@@ -38,13 +49,16 @@ export async function captureTelemetryEvent(event, properties = {}) {
 		}
 
 		const distinctId = await getDistinctId();
+		const workspaceGroupKey = workspaceGroupKeyFromProperties(properties);
+		identifyWorkspaceGroup(client, workspaceGroupKey, distinctId);
+		const groups = telemetryEventGroups(properties);
 		client.capture({
 			distinctId,
 			event,
-			properties: {
-				...commonEventProperties(),
-				...properties,
-			},
+			properties: telemetryEventProperties(properties, {
+				sessionId: options.sessionId ?? latestRendererPostHogSessionId,
+			}),
+			...(groups ? { groups } : {}),
 		});
 		return { status: "queued" };
 	} catch (error) {
@@ -92,10 +106,16 @@ export function registerTelemetryIpc() {
 		if (!eventName) {
 			return { status: "ignored" };
 		}
-		return await captureTelemetryEvent(eventName, {
-			...(payload?.properties ?? {}),
-			source: "renderer",
-		});
+		return await captureTelemetryEvent(
+			eventName,
+			{
+				...(payload?.properties ?? {}),
+				source: "renderer",
+			},
+			{
+				sessionId: getTelemetrySessionIdForWebContents(_event.sender),
+			},
+		);
 	});
 
 	ipcMain.handle("telemetry:getClientConfig", async () => {
@@ -316,6 +336,52 @@ function commonEventProperties() {
 	};
 }
 
+export function telemetryEventProperties(properties = {}, { sessionId } = {}) {
+	const normalizedSessionId =
+		normalizePostHogSessionId(properties?.$session_id) ??
+		normalizePostHogSessionId(sessionId);
+	const workspaceGroupKey = workspaceGroupKeyFromProperties(properties);
+	const eventProperties = { ...properties };
+	if ("workspace_id" in eventProperties) {
+		delete eventProperties.workspace_id;
+	}
+	return {
+		...commonEventProperties(),
+		...eventProperties,
+		...(workspaceGroupKey ? { workspace_id: workspaceGroupKey } : {}),
+		...(normalizedSessionId ? { $session_id: normalizedSessionId } : {}),
+	};
+}
+
+export function telemetryEventGroups(properties = {}) {
+	const workspaceGroupKey = workspaceGroupKeyFromProperties(properties);
+	return workspaceGroupKey
+		? { [WORKSPACE_GROUP_TYPE]: workspaceGroupKey }
+		: undefined;
+}
+
+function workspaceGroupKeyFromProperties(properties = {}) {
+	return normalizeWorkspaceGroupKey(properties?.workspace_id);
+}
+
+function identifyWorkspaceGroup(client, workspaceGroupKey, distinctId) {
+	if (
+		!workspaceGroupKey ||
+		identifiedWorkspaceGroupKeys.has(workspaceGroupKey)
+	) {
+		return;
+	}
+	identifiedWorkspaceGroupKeys.add(workspaceGroupKey);
+	client.groupIdentify({
+		groupType: WORKSPACE_GROUP_TYPE,
+		groupKey: workspaceGroupKey,
+		distinctId,
+		properties: {
+			workspace_id: workspaceGroupKey,
+		},
+	});
+}
+
 function telemetryEnvironment() {
 	return app?.isPackaged === true ? "production" : "dev";
 }
@@ -341,7 +407,28 @@ export function setTelemetrySessionContextForWebContents(
 	}
 	latestRendererPostHogSessionId = sessionId;
 	rendererPostHogSessionIdsByWebContentsId.set(webContents.id, sessionId);
+	for (const resolve of rendererSessionWaiters) {
+		resolve(sessionId);
+	}
+	rendererSessionWaiters.clear();
 	return { status: "set" };
+}
+
+function waitForRendererPostHogSessionId(timeoutMs) {
+	if (latestRendererPostHogSessionId) {
+		return Promise.resolve(latestRendererPostHogSessionId);
+	}
+	return new Promise((resolve) => {
+		const waiter = (sessionId) => {
+			clearTimeout(timeout);
+			resolve(sessionId);
+		};
+		const timeout = setTimeout(() => {
+			rendererSessionWaiters.delete(waiter);
+			resolve(undefined);
+		}, timeoutMs);
+		rendererSessionWaiters.add(waiter);
+	});
 }
 
 function exceptionEventProperties(properties = {}, { sessionId } = {}) {
@@ -430,6 +517,17 @@ function normalizePostHogSessionId(value) {
 	)
 		? trimmed
 		: undefined;
+}
+
+function normalizeWorkspaceGroupKey(value) {
+	if (typeof value !== "string") {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > 200 || /[\\/]/.test(trimmed)) {
+		return undefined;
+	}
+	return trimmed;
 }
 
 export function scrubTelemetrySensitiveValues(value, depth = 0) {

--- a/electron/telemetry.mjs
+++ b/electron/telemetry.mjs
@@ -56,7 +56,7 @@ export async function captureTelemetryEvent(
 			distinctId,
 			event,
 			properties: telemetryEventProperties(properties, {
-				sessionId: options.sessionId ?? latestRendererPostHogSessionId,
+				sessionId: telemetrySessionIdFromOptions(options),
 			}),
 			...(groups ? { groups } : {}),
 		});
@@ -83,9 +83,7 @@ export async function captureTelemetryException(error, properties = {}) {
 			error,
 			distinctId,
 			exceptionEventProperties(properties, {
-				sessionId:
-					normalizePostHogSessionId(properties?.sessionId) ??
-					latestRendererPostHogSessionId,
+				sessionId: telemetrySessionIdFromProperties(properties),
 			}),
 		);
 		return { status: "queued" };
@@ -358,6 +356,22 @@ export function telemetryEventGroups(properties = {}) {
 	return workspaceGroupKey
 		? { [WORKSPACE_GROUP_TYPE]: workspaceGroupKey }
 		: undefined;
+}
+
+export function telemetrySessionIdFromOptions(options = {}) {
+	return hasOwnSessionId(options)
+		? options.sessionId
+		: latestRendererPostHogSessionId;
+}
+
+function telemetrySessionIdFromProperties(properties = {}) {
+	return hasOwnSessionId(properties)
+		? properties.sessionId
+		: latestRendererPostHogSessionId;
+}
+
+function hasOwnSessionId(value) {
+	return Object.prototype.hasOwnProperty.call(value, "sessionId");
 }
 
 function workspaceGroupKeyFromProperties(properties = {}) {

--- a/electron/telemetry.test.mjs
+++ b/electron/telemetry.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import os from "node:os";
 import {
 	beforeSendTelemetryEvent,
+	forgetTelemetrySessionContextForWebContents,
 	getDevelopmentTelemetryDistinctId,
 	scrubTelemetrySensitiveValues,
 	setTelemetrySessionContextForWebContents,
@@ -59,6 +60,41 @@ describe("beforeSendTelemetryEvent", () => {
 				},
 			})?.properties?.$session_id,
 		).toBe(explicitSessionId);
+	});
+
+	test("does not keep a closed window session as the latest renderer fallback", () => {
+		forgetTelemetrySessionContextForWebContents({ id: 42 });
+		const remainingWebContents = { id: 101 };
+		const closedWebContents = { id: 202 };
+		const remainingSessionId = "77777777-7777-4777-8777-777777777777";
+		const closedSessionId = "88888888-8888-4888-8888-888888888888";
+		setTelemetrySessionContextForWebContents(
+			remainingWebContents,
+			remainingSessionId,
+		);
+		setTelemetrySessionContextForWebContents(
+			closedWebContents,
+			closedSessionId,
+		);
+
+		forgetTelemetrySessionContextForWebContents(closedWebContents);
+
+		expect(
+			beforeSendTelemetryEvent({
+				event: "$exception",
+				distinctId: "install-id",
+				properties: {},
+			})?.properties?.$session_id,
+		).toBe(remainingSessionId);
+
+		forgetTelemetrySessionContextForWebContents(remainingWebContents);
+		expect(
+			beforeSendTelemetryEvent({
+				event: "$exception",
+				distinctId: "install-id",
+				properties: {},
+			})?.properties?.$session_id,
+		).toBeUndefined();
 	});
 });
 

--- a/electron/telemetry.test.mjs
+++ b/electron/telemetry.test.mjs
@@ -5,6 +5,8 @@ import {
 	getDevelopmentTelemetryDistinctId,
 	scrubTelemetrySensitiveValues,
 	setTelemetrySessionContextForWebContents,
+	telemetryEventGroups,
+	telemetryEventProperties,
 } from "./telemetry.mjs";
 
 describe("scrubTelemetrySensitiveValues", () => {
@@ -57,6 +59,68 @@ describe("beforeSendTelemetryEvent", () => {
 				},
 			})?.properties?.$session_id,
 		).toBe(explicitSessionId);
+	});
+});
+
+describe("telemetryEventProperties", () => {
+	test("attaches the current renderer session id to product events", () => {
+		const sessionId = "33333333-3333-4333-8333-333333333333";
+
+		expect(
+			telemetryEventProperties({ source: "renderer" }, { sessionId })
+				.$session_id,
+		).toBe(sessionId);
+	});
+
+	test("does not overwrite an explicit product event session id", () => {
+		const explicitSessionId = "44444444-4444-4444-8444-444444444444";
+		const fallbackSessionId = "55555555-5555-4555-8555-555555555555";
+
+		expect(
+			telemetryEventProperties(
+				{ $session_id: explicitSessionId },
+				{ sessionId: fallbackSessionId },
+			).$session_id,
+		).toBe(explicitSessionId);
+	});
+
+	test("replaces an invalid explicit session id with a valid renderer session id", () => {
+		const fallbackSessionId = "66666666-6666-4666-8666-666666666666";
+
+		expect(
+			telemetryEventProperties(
+				{ $session_id: "not-a-session-id" },
+				{ sessionId: fallbackSessionId },
+			).$session_id,
+		).toBe(fallbackSessionId);
+	});
+
+	test("normalizes workspace id properties for grouped events", () => {
+		expect(
+			telemetryEventProperties({ workspace_id: " workspace-123 " })
+				.workspace_id,
+		).toBe("workspace-123");
+	});
+
+	test("drops path-like workspace ids from grouped events", () => {
+		expect(
+			telemetryEventProperties({ workspace_id: "/Users/sam/project" })
+				.workspace_id,
+		).toBeUndefined();
+	});
+});
+
+describe("telemetryEventGroups", () => {
+	test("derives the PostHog workspace group from workspace_id", () => {
+		expect(telemetryEventGroups({ workspace_id: "workspace-123" })).toEqual({
+			workspace: "workspace-123",
+		});
+	});
+
+	test("does not derive a group for invalid workspace ids", () => {
+		expect(
+			telemetryEventGroups({ workspace_id: "/Users/sam/project" }),
+		).toBeUndefined();
 	});
 });
 

--- a/electron/telemetry.test.mjs
+++ b/electron/telemetry.test.mjs
@@ -8,6 +8,7 @@ import {
 	setTelemetrySessionContextForWebContents,
 	telemetryEventGroups,
 	telemetryEventProperties,
+	telemetrySessionIdFromOptions,
 } from "./telemetry.mjs";
 
 describe("scrubTelemetrySensitiveValues", () => {
@@ -99,6 +100,18 @@ describe("beforeSendTelemetryEvent", () => {
 });
 
 describe("telemetryEventProperties", () => {
+	test("does not borrow another renderer session when caller explicitly has none", () => {
+		const latestSessionId = "99999999-9999-4999-8999-999999999999";
+		setTelemetrySessionContextForWebContents({ id: 303 }, latestSessionId);
+
+		expect(telemetrySessionIdFromOptions({ sessionId: undefined })).toBe(
+			undefined,
+		);
+		expect(telemetrySessionIdFromOptions({})).toBe(latestSessionId);
+
+		forgetTelemetrySessionContextForWebContents({ id: 303 });
+	});
+
 	test("attaches the current renderer session id to product events", () => {
 		const sessionId = "33333333-3333-4333-8333-333333333333";
 

--- a/src/extension-runtime/external-write-review-controls.tsx
+++ b/src/extension-runtime/external-write-review-controls.tsx
@@ -53,6 +53,7 @@ export function ExternalWriteReviewControls({
 				type="button"
 				className="external-write-review-button external-write-review-button-reject"
 				onClick={onReject}
+				data-attr="diff-reject"
 			>
 				<span>Undo</span>
 				<kbd className="external-write-review-shortcut external-write-review-shortcut-dark">
@@ -63,6 +64,7 @@ export function ExternalWriteReviewControls({
 				type="button"
 				className="external-write-review-button external-write-review-button-accept"
 				onClick={onAccept}
+				data-attr="diff-accept"
 			>
 				<span>Keep</span>
 				<kbd className="external-write-review-shortcut">

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -76,6 +76,14 @@ describe("FilesView", () => {
 		expect(utils!.getByRole("button", { name: "New file" })).toHaveClass(
 			"select-none",
 		);
+		expect(utils!.getByRole("button", { name: "New file" })).toHaveAttribute(
+			"data-attr",
+			"file-new",
+		);
+		expect(utils!.getByTestId("files-view-tree-scroll")).toHaveAttribute(
+			"data-attr",
+			"file-tree",
+		);
 
 		utils!.unmount();
 		await lix.close();

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -604,6 +604,7 @@ function FilesViewContent({
 					className="mb-px flex h-7 w-full select-none items-center justify-between gap-2 rounded-[7px] px-2.25 text-left text-xs text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)]"
 					aria-label="New file"
 					title="New file (⌘.)"
+					data-attr="file-new"
 				>
 					<span className="flex items-center gap-2">
 						<FilePlus
@@ -644,6 +645,7 @@ function FilesViewContent({
 			)}
 			<div
 				data-testid="files-view-tree-scroll"
+				data-attr="file-tree"
 				className="ph-mask min-h-0 flex-1 overflow-x-hidden overflow-y-auto pr-1"
 			>
 				<FileTree

--- a/src/extensions/markdown/components/formatting-toolbar.test.tsx
+++ b/src/extensions/markdown/components/formatting-toolbar.test.tsx
@@ -130,6 +130,53 @@ describe("FormattingToolbar", () => {
 		});
 	});
 
+	test("renders stable analytics selectors for toolbar controls", async () => {
+		const setup = createEditor(paragraphDoc);
+		const utils = renderToolbar(setup.editor);
+
+		const toolbar = await screen.findByRole("toolbar", {
+			name: "Formatting toolbar",
+		});
+
+		expect(toolbar).toHaveAttribute("data-attr", "markdown-format-toolbar");
+		expect(toolbar.querySelector("[data-attr='markdown-block-selector']")).toBe(
+			screen.getByRole("combobox"),
+		);
+		expect(screen.getByLabelText("Bold")).toHaveAttribute(
+			"data-attr",
+			"markdown-format-bold",
+		);
+		expect(screen.getByLabelText("Italic")).toHaveAttribute(
+			"data-attr",
+			"markdown-format-italic",
+		);
+		expect(screen.getByLabelText("Inline code")).toHaveAttribute(
+			"data-attr",
+			"markdown-format-code",
+		);
+		expect(screen.getByLabelText("Numbered list")).toHaveAttribute(
+			"data-attr",
+			"markdown-format-ordered-list",
+		);
+		expect(screen.getByLabelText("Bullet list")).toHaveAttribute(
+			"data-attr",
+			"markdown-format-bullet-list",
+		);
+		expect(screen.getByLabelText("Checklist")).toHaveAttribute(
+			"data-attr",
+			"markdown-format-task-list",
+		);
+		expect(screen.getByLabelText("Copy markdown")).toHaveAttribute(
+			"data-attr",
+			"markdown-copy-markdown",
+		);
+
+		await act(async () => {
+			utils.unmount();
+		});
+		destroyEditor(setup);
+	});
+
 	test("applies bold formatting to the current selection", async () => {
 		const setup = createEditor(paragraphDoc);
 		const utils = renderToolbar(setup.editor);

--- a/src/extensions/markdown/components/formatting-toolbar.tsx
+++ b/src/extensions/markdown/components/formatting-toolbar.tsx
@@ -229,6 +229,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 				className,
 			)}
 			aria-label="Formatting toolbar"
+			data-attr="markdown-format-toolbar"
 		>
 			<Toolbar.Group className="flex flex-1 items-center gap-0.5">
 				<Select.Root
@@ -240,6 +241,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					<Toolbar.Button
 						render={<Select.Trigger />}
 						nativeButton={false}
+						data-attr="markdown-block-selector"
 						className={clsx(
 							"inline-flex h-7 shrink-0 select-none items-center gap-1 rounded-[7px] pr-1.5 pl-2.25 text-[12.5px] font-medium text-[var(--color-text-secondary)] transition-[background-color,color,box-shadow] duration-100 ease-out hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)]",
 							blockMenuOpen &&
@@ -304,6 +306,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					onMouseDown={suppressMouseDown}
 					aria-pressed={formatState.isBold}
 					aria-label="Bold"
+					data-attr="markdown-format-bold"
 				>
 					<Bold className="size-3.5" aria-hidden />
 				</Toolbar.Button>
@@ -317,6 +320,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					onMouseDown={suppressMouseDown}
 					aria-pressed={formatState.isItalic}
 					aria-label="Italic"
+					data-attr="markdown-format-italic"
 				>
 					<Italic className="size-3.5" aria-hidden />
 				</Toolbar.Button>
@@ -330,6 +334,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					onMouseDown={suppressMouseDown}
 					aria-pressed={formatState.isCode}
 					aria-label="Inline code"
+					data-attr="markdown-format-code"
 				>
 					<Code2 className="size-3.5" aria-hidden />
 				</Toolbar.Button>
@@ -345,6 +350,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					onMouseDown={suppressMouseDown}
 					aria-pressed={formatState.isOrderedList}
 					aria-label="Numbered list"
+					data-attr="markdown-format-ordered-list"
 				>
 					<ListOrdered className="size-3.5" aria-hidden />
 				</Toolbar.Button>
@@ -358,6 +364,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					onMouseDown={suppressMouseDown}
 					aria-pressed={formatState.isBulletList}
 					aria-label="Bullet list"
+					data-attr="markdown-format-bullet-list"
 				>
 					<List className="size-3.5" aria-hidden />
 				</Toolbar.Button>
@@ -371,6 +378,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 					onMouseDown={suppressMouseDown}
 					aria-pressed={formatState.isTaskList}
 					aria-label="Checklist"
+					data-attr="markdown-format-task-list"
 				>
 					<ListChecks className="size-3.5" aria-hidden />
 				</Toolbar.Button>
@@ -388,6 +396,7 @@ export function FormattingToolbar({ className }: { className?: string }) {
 							)}
 							onClick={handleCopyMarkdown}
 							onMouseDown={suppressMouseDown}
+							data-attr="markdown-copy-markdown"
 							aria-label={
 								copyStatus === "success" ? "Copied markdown" : "Copy markdown"
 							}

--- a/src/extensions/markdown/index.test.tsx
+++ b/src/extensions/markdown/index.test.tsx
@@ -52,6 +52,11 @@ describe("MarkdownView", () => {
 		});
 
 		expect(await screen.findByTestId("tiptap-editor")).toBeInTheDocument();
+		expect(
+			screen
+				.getByTestId("tiptap-editor")
+				.closest("[data-attr='markdown-editor']"),
+		).toBeInTheDocument();
 
 		await waitFor(async () => {
 			const rows = await qb(lix)
@@ -406,8 +411,11 @@ describe("MarkdownView", () => {
 
 		expect(
 			await screen.findByRole("button", { name: /keep/i }),
-		).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: /undo/i })).toBeInTheDocument();
+		).toHaveAttribute("data-attr", "diff-accept");
+		expect(screen.getByRole("button", { name: /undo/i })).toHaveAttribute(
+			"data-attr",
+			"diff-reject",
+		);
 
 		await act(async () => {
 			utils?.unmount();

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -165,7 +165,7 @@ function MarkdownViewLoaded({
 					<div className={reviewDiff ? "pointer-events-none" : undefined}>
 						<FormattingToolbar />
 					</div>
-					<div className="relative min-h-0 flex-1">
+					<div className="relative min-h-0 flex-1" data-attr="markdown-editor">
 						<TipTapEditor
 							className="h-full"
 							fileId={fileRow.id}

--- a/src/lib/posthog-client.test.ts
+++ b/src/lib/posthog-client.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import posthog from "posthog-js";
+import type { CaptureResult } from "posthog-js";
+import type { Lix } from "@/lib/lix-types";
+import { readWorkspaceId } from "@/lib/workspace-profile-telemetry";
+import {
+	activatePostHogRecording,
+	syncPostHogWorkspaceContext,
+} from "./posthog-client";
+
+vi.mock("posthog-js", () => ({
+	default: {
+		init: vi.fn(),
+		group: vi.fn(),
+		register: vi.fn(),
+		identify: vi.fn(),
+		get_session_id: vi.fn(() => "session_123"),
+		onSessionId: vi.fn(),
+		startSessionRecording: vi.fn(),
+	},
+}));
+
+vi.mock("@/lib/workspace-profile-telemetry", () => ({
+	readWorkspaceId: vi.fn(),
+}));
+
+const originalDesktop = window.flashtypeDesktop;
+
+afterEach(() => {
+	window.flashtypeDesktop = originalDesktop;
+	vi.clearAllMocks();
+});
+
+describe("activatePostHogRecording", () => {
+	test("enables broad safe autocapture and syncs workspace context", async () => {
+		vi.mocked(readWorkspaceId).mockResolvedValue("workspace_123");
+		window.flashtypeDesktop = {
+			...(originalDesktop ?? {}),
+			telemetry: {
+				...(originalDesktop?.telemetry ?? {}),
+				capture: vi.fn().mockResolvedValue({ status: "queued" }),
+				getClientConfig: vi.fn().mockResolvedValue({
+					enabled: true,
+					token: "phc_test",
+					host: "https://us.i.posthog.com",
+					distinctId: "user_123",
+					environment: "dev",
+					sessionRecordingEnabled: true,
+				}),
+				setSessionContext: vi.fn().mockResolvedValue(undefined),
+			},
+		} as Window["flashtypeDesktop"];
+
+		await expect(activatePostHogRecording()).resolves.toBe(true);
+
+		expect(posthog.init).toHaveBeenCalledWith(
+			"phc_test",
+			expect.objectContaining({
+				api_host: "https://us.i.posthog.com",
+				autocapture: {
+					element_attribute_ignorelist: [
+						"aria-label",
+						"title",
+						"href",
+						"data-testid",
+						"data-view-instance",
+						"data-view-key",
+					],
+				},
+				capture_pageview: false,
+				disable_session_recording: false,
+				mask_all_text: true,
+				before_send: expect.any(Function),
+				session_recording: {
+					maskAllInputs: true,
+					maskTextSelector: "*",
+					blockSelector: ".ph-no-capture",
+				},
+			}),
+		);
+
+		const initOptions = vi.mocked(posthog.init).mock.calls[0]?.[1] as {
+			before_send: (event: CaptureResult | null) => CaptureResult | null;
+		};
+		expect(
+			initOptions.before_send({
+				uuid: "event_123",
+				event: "$autocapture",
+				properties: {
+					$el_text: "Customer roadmap",
+					$external_click_url: "https://example.com/secret",
+					"attr__aria-label": "Branch actions for secret-branch",
+					"attr__data-testid": "file-tree-item-customers-roadmap-md",
+					"attr__data-attr": "markdown-format-bold",
+					$elements: [
+						{
+							$el_text: "roadmap.md",
+							attr__title: "roadmap.md",
+							"attr__data-attr": "file-tree",
+						},
+					],
+				},
+			})?.properties,
+		).toEqual({
+			"attr__data-attr": "markdown-format-bold",
+			$elements: [
+				{
+					"attr__data-attr": "file-tree",
+				},
+			],
+		});
+
+		await expect(syncPostHogWorkspaceContext({} as Lix)).resolves.toBe(true);
+		expect(posthog.group).toHaveBeenCalledWith("workspace", "workspace_123", {
+			workspace_id: "workspace_123",
+		});
+		expect(posthog.register).toHaveBeenCalledWith(
+			expect.objectContaining({
+				workspace_id: "workspace_123",
+			}),
+		);
+	});
+});

--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -1,8 +1,20 @@
 import posthog, { type CaptureResult } from "posthog-js";
+import type { Lix } from "@/lib/lix-types";
+import { readWorkspaceId } from "@/lib/workspace-profile-telemetry";
 
 let activated = false;
 let activationPromise: Promise<boolean> | null = null;
 let sessionContextSynced = false;
+let syncedWorkspaceGroupKey: string | null = null;
+
+const AUTOCAPTURE_ATTRIBUTE_IGNORELIST = [
+	"aria-label",
+	"title",
+	"href",
+	"data-testid",
+	"data-view-instance",
+	"data-view-key",
+];
 
 export async function activatePostHogRecording() {
 	if (activated) {
@@ -23,9 +35,12 @@ async function activatePostHogRecordingUncached() {
 	posthog.init(config.token, {
 		api_host: config.host,
 		defaults: "2026-05-30",
-		autocapture: false,
+		autocapture: {
+			element_attribute_ignorelist: AUTOCAPTURE_ATTRIBUTE_IGNORELIST,
+		},
 		capture_pageview: false,
 		disable_session_recording: !config.sessionRecordingEnabled,
+		mask_all_text: true,
 		before_send: (event) => scrubPostHogEvent(event),
 		session_recording: {
 			maskAllInputs: true,
@@ -45,6 +60,25 @@ async function activatePostHogRecordingUncached() {
 		posthog.startSessionRecording();
 	}
 	activated = true;
+	return true;
+}
+
+export async function syncPostHogWorkspaceContext(lix: Lix) {
+	const isActive = await activatePostHogRecording();
+	if (!isActive) {
+		return false;
+	}
+	const workspaceId = await readWorkspaceId(lix);
+	if (!workspaceId || workspaceId === syncedWorkspaceGroupKey) {
+		return Boolean(workspaceId);
+	}
+	syncedWorkspaceGroupKey = workspaceId;
+	posthog.group("workspace", workspaceId, {
+		workspace_id: workspaceId,
+	});
+	posthog.register({
+		workspace_id: workspaceId,
+	});
 	return true;
 }
 
@@ -77,11 +111,35 @@ function scrubPostHogEvent(event: CaptureResult | null) {
 	}
 	const scrubbableEvent = event as ScrubbableCaptureResult;
 	if (scrubbableEvent.properties) {
+		const safeProperties =
+			(event as { event?: string }).event === "$autocapture"
+				? scrubAutocaptureProperties(scrubbableEvent.properties)
+				: scrubbableEvent.properties;
 		scrubbableEvent.properties = scrubPostHogValue(
-			scrubbableEvent.properties,
+			safeProperties,
 		) as ScrubbableCaptureResult["properties"];
 	}
 	return event;
+}
+
+function scrubAutocaptureProperties(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => scrubAutocaptureProperties(item));
+	}
+	if (!value || typeof value !== "object") {
+		return value;
+	}
+	const scrubbed: Record<string, unknown> = {};
+	for (const [key, nestedValue] of Object.entries(value)) {
+		if (key === "$el_text" || key === "$external_click_url") {
+			continue;
+		}
+		if (key.startsWith("attr__") && key !== "attr__data-attr") {
+			continue;
+		}
+		scrubbed[key] = scrubAutocaptureProperties(nestedValue);
+	}
+	return scrubbed;
 }
 
 function scrubPostHogValue(value: unknown, depth = 0): unknown {

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -68,7 +68,6 @@ export function workspaceTelemetryProperties(workspaceId: string | undefined) {
 	return workspaceId
 		? {
 				workspace_id: workspaceId,
-				$groups: { workspace: workspaceId },
 			}
 		: {};
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,10 @@ import { FirstRunScreen } from "./shell/first-run-screen";
 import { WorkspaceLoadingScreen } from "./shell/workspace-loading-screen";
 import { openDesktopLix } from "./lib/lix-client";
 import { captureWorkspaceProfile } from "./lib/workspace-profile-telemetry";
-import { activatePostHogRecording } from "./lib/posthog-client";
+import {
+	activatePostHogRecording,
+	syncPostHogWorkspaceContext,
+} from "./lib/posthog-client";
 
 type Workspace = Awaited<
 	ReturnType<NonNullable<Window["flashtypeDesktop"]>["workspace"]["get"]>
@@ -199,6 +202,9 @@ export const AppRoot = () => {
 	useEffect(() => {
 		if (!workspace || !lix) return;
 		setOpeningWorkspaceName(undefined);
+		void syncPostHogWorkspaceContext(lix).catch((error: unknown) => {
+			console.warn("Failed to sync PostHog workspace context", error);
+		});
 		void captureWorkspaceProfile({
 			lix,
 		}).catch((error: unknown) => {

--- a/src/shell/agent-invite.tsx
+++ b/src/shell/agent-invite.tsx
@@ -17,7 +17,10 @@ export function AgentInvite({
 	readonly onStartCodex?: () => void;
 }): JSX.Element {
 	return (
-		<div className="flex flex-1 flex-col items-center justify-center gap-3.5 px-6 py-7 text-center">
+		<div
+			className="flex flex-1 flex-col items-center justify-center gap-3.5 px-6 py-7 text-center"
+			data-attr="agent-panel"
+		>
 			<div className="flex items-center gap-2.75">
 				<img
 					src={claudeIcon}
@@ -38,6 +41,7 @@ export function AgentInvite({
 					<button
 						type="button"
 						onClick={onStartClaude}
+						data-attr="agent-start-claude"
 						className="flex items-center gap-1.75 rounded-lg bg-[var(--color-bg-action-secondary)] px-4.5 py-2.25 text-[12.5px] font-bold text-[var(--color-text-on-action-secondary)] hover:bg-[var(--color-bg-action-secondary-hover)]"
 					>
 						<img src={claudeIcon} alt="" className="size-3.25 object-contain" />
@@ -47,6 +51,7 @@ export function AgentInvite({
 						<button
 							type="button"
 							onClick={onStartCodex}
+							data-attr="agent-start-codex"
 							className="rounded-md px-1.5 py-0.5 text-[11.5px] text-[var(--color-icon-tertiary)] hover:text-[var(--color-text-secondary)]"
 						>
 							Use Codex instead

--- a/src/shell/central-panel.test.tsx
+++ b/src/shell/central-panel.test.tsx
@@ -91,6 +91,34 @@ const createViewContext = (
 });
 
 describe("CentralPanel", () => {
+	test("renders stable analytics selectors for empty state actions", async () => {
+		const panelState: PanelState = {
+			views: [],
+			activeInstance: null,
+		};
+
+		await renderWithProviders(
+			<DndContext>
+				<CentralPanel
+					panel={panelState}
+					onSelectView={() => {}}
+					onRemoveView={() => {}}
+					viewContext={createViewContext({ isPanelFocused: true })}
+					isFocused={true}
+					onFocusPanel={vi.fn()}
+					onCreateNewFile={vi.fn()}
+				/>
+			</DndContext>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: /new document/i }),
+		).toHaveAttribute("data-attr", "central-empty-new-document");
+		expect(
+			screen.getByRole("button", { name: /ask your agent/i }),
+		).toHaveAttribute("data-attr", "central-empty-ask-agent");
+	});
+
 	test("renders the active view without a tab strip", async () => {
 		// The central editor hides tabs; files are switched from the left list.
 		const panelState: PanelState = {

--- a/src/shell/central-panel.tsx
+++ b/src/shell/central-panel.tsx
@@ -113,6 +113,7 @@ function EmptyStateContent({
 				<button
 					type="button"
 					onClick={() => void onCreateNewFile()}
+					data-attr="central-empty-new-document"
 					className="mt-6 flex items-center gap-2 rounded-[10px] bg-[var(--color-bg-action-primary)] px-6 py-2.75 text-sm font-bold text-[var(--color-text-on-action-primary)] shadow-[0_6px_18px_rgba(154,52,18,0.24),inset_0_1px_0_rgba(255,255,255,0.18)] hover:bg-[var(--color-bg-action-primary-hover)]"
 				>
 					New document
@@ -122,6 +123,7 @@ function EmptyStateContent({
 			<button
 				type="button"
 				onClick={onAskAgent}
+				data-attr="central-empty-ask-agent"
 				className="mt-4.5 flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[12.5px] text-[var(--color-icon-tertiary)] hover:text-[var(--color-text-secondary)]"
 			>
 				or ask your agent to draft one

--- a/src/shell/panel-v2.test.tsx
+++ b/src/shell/panel-v2.test.tsx
@@ -196,6 +196,18 @@ describe("PanelV2", () => {
 		expect(
 			screen.getByRole("button", { name: "Custom Search" }),
 		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Custom Search" }),
+		).not.toHaveAttribute("data-attr", "panel-tab-select");
+		expect(screen.getByText("Custom Search")).toHaveAttribute(
+			"data-attr",
+			"panel-tab-select",
+		);
+		expect(
+			screen
+				.getByRole("button", { name: "Custom Search" })
+				.querySelector("[data-attr='panel-tab-close']"),
+		).toBeInTheDocument();
 	});
 
 	test("registers sortable handlers for tabs", () => {
@@ -241,7 +253,39 @@ describe("PanelV2", () => {
 			/>,
 		);
 
-		expect(screen.getByLabelText("Add view")).toBeInTheDocument();
+		expect(screen.getByLabelText("Add view")).toHaveAttribute(
+			"data-attr",
+			"panel-add-view",
+		);
+	});
+
+	test("renders stable analytics selectors for agent add-view commands", async () => {
+		renderWithinProvider(
+			<PanelV2
+				side="left"
+				panel={singleSearchPanel}
+				isFocused={false}
+				onFocusPanel={vi.fn()}
+				onSelectView={vi.fn()}
+				onRemoveView={vi.fn()}
+				onAddView={vi.fn()}
+				viewContext={createViewContext()}
+				viewOverrides={[searchViewOverride]}
+			/>,
+		);
+
+		await act(async () => {
+			fireEvent.pointerDown(screen.getByLabelText("Add view"), { button: 0 });
+			fireEvent.pointerUp(screen.getByLabelText("Add view"), { button: 0 });
+		});
+
+		expect(
+			await screen.findByRole("menuitem", { name: "Claude Code" }),
+		).toHaveAttribute("data-attr", "panel-add-agent-claude");
+		expect(screen.getByRole("menuitem", { name: "Codex" })).toHaveAttribute(
+			"data-attr",
+			"panel-add-agent-codex",
+		);
 	});
 
 	test("invokes the pending finalizer when the active view is interacted with", async () => {

--- a/src/shell/panel-v2.tsx
+++ b/src/shell/panel-v2.tsx
@@ -325,6 +325,7 @@ function AddViewMenu({
 					type="button"
 					title="Add view"
 					aria-label="Add view"
+					data-attr="panel-add-view"
 					className="flex size-6 flex-none items-center justify-center rounded-md text-[var(--color-icon-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-icon-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus-visible)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-bg-panel)]"
 				>
 					<Plus className="size-3.25" strokeWidth={2} />
@@ -339,6 +340,11 @@ function AddViewMenu({
 						{AGENT_LAUNCH_PRESETS.map((preset) => (
 							<DropdownMenuItem
 								key={preset.key}
+								data-attr={
+									preset.key === "claude"
+										? "panel-add-agent-claude"
+										: "panel-add-agent-codex"
+								}
 								onSelect={() =>
 									onAddView(TERMINAL_EXTENSION_KIND, preset.state)
 								}
@@ -689,6 +695,7 @@ const TabButtonBase = forwardRef<HTMLButtonElement, TabBaseProps>(
 			>
 				<span
 					data-tab-icon
+					data-attr="panel-tab-select"
 					className="relative flex size-3.25 items-center justify-center"
 				>
 					<Icon className="size-3.25" />
@@ -706,6 +713,7 @@ const TabButtonBase = forwardRef<HTMLButtonElement, TabBaseProps>(
 					) : null}
 				</span>
 				<span
+					data-attr="panel-tab-select"
 					className={clsx("max-w-[10rem] truncate", isPending && "italic")}
 					title={label}
 				>
@@ -714,6 +722,7 @@ const TabButtonBase = forwardRef<HTMLButtonElement, TabBaseProps>(
 				<span className="relative flex size-3.25 items-center justify-center">
 					{onClose ? (
 						<X
+							data-attr="panel-tab-close"
 							className={clsx(
 								"h-3 w-3",
 								isActive && isFocused

--- a/src/shell/side-panel.test.tsx
+++ b/src/shell/side-panel.test.tsx
@@ -122,6 +122,38 @@ const createViewContext = (
 });
 
 describe("SidePanel", () => {
+	test("renders stable analytics selectors for agent invite CTAs", () => {
+		const emptyPanel: PanelState = { views: [], activeInstance: null };
+
+		render(
+			<ExtensionHostRegistryProvider>
+				<DndContext>
+					<SidePanel
+						side="right"
+						title="Agent"
+						panel={emptyPanel}
+						onSelectView={() => {}}
+						onAddView={() => {}}
+						onRemoveView={() => {}}
+						viewContext={createViewContext()}
+						isFocused={false}
+						onFocusPanel={vi.fn()}
+					/>
+				</DndContext>
+			</ExtensionHostRegistryProvider>,
+		);
+
+		expect(
+			screen.getByText("Your agent writes here").closest("[data-attr]"),
+		).toHaveAttribute("data-attr", "agent-panel");
+		expect(
+			screen.getByRole("button", { name: /start claude code/i }),
+		).toHaveAttribute("data-attr", "agent-start-claude");
+		expect(
+			screen.getByRole("button", { name: /use codex instead/i }),
+		).toHaveAttribute("data-attr", "agent-start-codex");
+	});
+
 	test("renders the empty state helper when nothing is open", () => {
 		const emptyPanel: PanelState = { views: [], activeInstance: null };
 

--- a/src/shell/top-bar/branch-switcher.test.tsx
+++ b/src/shell/top-bar/branch-switcher.test.tsx
@@ -74,6 +74,7 @@ describe("BranchSwitcher", () => {
 		});
 
 		const draftItem = await screen.findByRole("menuitem", { name: draftName });
+		expect(draftItem).toHaveAttribute("data-attr", "branch-switch");
 
 		await act(async () => {
 			fireEvent.click(draftItem);
@@ -121,6 +122,7 @@ describe("BranchSwitcher", () => {
 		});
 
 		const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
+		expect(renameItem).toHaveAttribute("data-attr", "branch-rename");
 		await act(async () => {
 			fireEvent.click(renameItem);
 		});
@@ -162,6 +164,7 @@ describe("BranchSwitcher", () => {
 		});
 
 		const deleteItem = await screen.findByRole("menuitem", { name: "Delete" });
+		expect(deleteItem).toHaveAttribute("data-attr", "branch-delete");
 		await act(async () => {
 			fireEvent.click(deleteItem);
 		});

--- a/src/shell/top-bar/branch-switcher.tsx
+++ b/src/shell/top-bar/branch-switcher.tsx
@@ -228,6 +228,7 @@ function BranchSwitcherContent({
 							<DropdownMenuItem
 								key={branch.id}
 								aria-labelledby={branchLabelId}
+								data-attr="branch-switch"
 								onSelect={(event) => {
 									type DropdownSelectEvent = Event & {
 										detail?: { originalEvent?: Event };
@@ -282,6 +283,7 @@ function BranchSwitcherContent({
 									>
 										<DropdownMenuItem
 											className="flex items-center gap-2 text-xs"
+											data-attr="branch-rename"
 											onSelect={(event) => {
 												event.preventDefault();
 												void handleRenameBranch(branch.id, branch.name);
@@ -292,6 +294,7 @@ function BranchSwitcherContent({
 										</DropdownMenuItem>
 										<DropdownMenuItem
 											className="flex items-center gap-2 text-xs text-destructive focus:bg-destructive/10 focus:text-destructive [&_svg]:!text-destructive"
+											data-attr="branch-delete"
 											onSelect={() => {
 												if (isDeleteDisabled) return;
 												void handleDeleteBranch(branch.id, branch.name);

--- a/src/shell/top-bar/index.test.tsx
+++ b/src/shell/top-bar/index.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { TopBar } from ".";
+
+describe("TopBar", () => {
+	test("renders stable analytics selectors for chrome controls", () => {
+		render(
+			<TopBar
+				workspaceName="Workspace"
+				onWorkspaceTitleClick={vi.fn()}
+				onToggleLeftSidebar={vi.fn()}
+				onToggleRightSidebar={vi.fn()}
+				isUpdateReady={true}
+				onInstallUpdate={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByLabelText("Toggle left panel")).toHaveAttribute(
+			"data-attr",
+			"topbar-toggle-left-panel",
+		);
+		expect(screen.getByTitle("Switch workspace")).toHaveAttribute(
+			"data-attr",
+			"workspace-switch",
+		);
+		expect(screen.getByLabelText("Install update")).toHaveAttribute(
+			"data-attr",
+			"update-install",
+		);
+		expect(screen.getByTitle("GitHub")).toHaveAttribute(
+			"data-attr",
+			"github-open",
+		);
+		expect(screen.getByLabelText("Toggle right panel")).toHaveAttribute(
+			"data-attr",
+			"topbar-toggle-right-panel",
+		);
+	});
+});

--- a/src/shell/top-bar/index.tsx
+++ b/src/shell/top-bar/index.tsx
@@ -90,6 +90,7 @@ export function TopBar({
 							aria-label="Toggle left panel"
 							aria-pressed={isLeftSidebarVisible}
 							data-state={isLeftSidebarVisible ? "on" : "off"}
+							data-attr="topbar-toggle-left-panel"
 						>
 							<PanelToggleIcon side="left" isActive={isLeftSidebarVisible} />
 						</Button>
@@ -108,6 +109,7 @@ export function TopBar({
 							onClick={onWorkspaceTitleClick}
 							disabled={!onWorkspaceTitleClick}
 							title="Switch workspace"
+							data-attr="workspace-switch"
 							className={`flex h-7 min-w-0 items-center gap-1.5 rounded-[7px] px-2 enabled:hover:bg-[var(--color-bg-hover)] ${
 								activeFileName
 									? "font-medium text-[var(--color-text-secondary)]"
@@ -143,6 +145,7 @@ export function TopBar({
 							void handleInstallUpdate();
 						}}
 						aria-label="Install update"
+						data-attr="update-install"
 					>
 						Update
 					</Button>
@@ -152,6 +155,7 @@ export function TopBar({
 					target="_blank"
 					rel="noreferrer"
 					title="GitHub"
+					data-attr="github-open"
 					className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-[7px] text-sm font-medium whitespace-nowrap text-[var(--color-icon-tertiary)] transition-all outline-none hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring [-webkit-app-region:no-drag] [&_svg]:pointer-events-none [&_svg]:shrink-0"
 				>
 					<svg
@@ -178,6 +182,7 @@ export function TopBar({
 							aria-label="Toggle right panel"
 							aria-pressed={isRightSidebarVisible}
 							data-state={isRightSidebarVisible ? "on" : "off"}
+							data-attr="topbar-toggle-right-panel"
 						>
 							<PanelToggleIcon side="right" isActive={isRightSidebarVisible} />
 						</Button>

--- a/website/src/posthog-analytics.tsx
+++ b/website/src/posthog-analytics.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const PRODUCTION_POSTHOG_TOKEN =
+	"phc_ydLjaAJyed68q8a6ymxvUNCmiNNZtdkZny8YErSQTZEU";
 
 let initialized = false;
 let initializationPromise: Promise<void> | null = null;
@@ -18,7 +20,9 @@ async function initializePostHog() {
 		return;
 	}
 
-	const token = import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN?.trim();
+	const token = import.meta.env.PROD
+		? PRODUCTION_POSTHOG_TOKEN
+		: import.meta.env.VITE_PUBLIC_POSTHOG_TOKEN?.trim();
 	if (!token) {
 		return;
 	}


### PR DESCRIPTION
## Summary
- enable safe renderer PostHog autocapture with text masking and defensive autocapture payload scrubbing
- link renderer autocapture and custom product telemetry to PostHog sessions and workspace groups
- add stable `data-attr` selectors across product-relevant UI controls and hardcode the website production PostHog token

## Why
We want session recordings, custom product events, and retroactive UI usage questions to share enough linkage to answer product questions in PostHog without adding one-off events for every control. The Electron app also needs broad autocapture to be safe around document text, paths, file names, branches, and workspace labels.

## Validation
- `corepack pnpm exec vitest run src/lib/posthog-client.test.ts electron/telemetry.test.mjs src/extensions/markdown/index.test.tsx src/shell/panel-v2.test.tsx`
- `corepack pnpm run typecheck`

Notes: the markdown test suite still emits existing React `act(...)` warnings, but the tests pass. Unrelated local submodule dirt was left unstaged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches telemetry privacy (autocapture scrubbing, session/workspace linkage) and ships a production PostHog token in the website bundle; grouping logic changes how workspace-scoped events appear in PostHog.
> 
> **Overview**
> **PostHog linkage and grouping** — Main-process capture now attaches `$session_id` from the renderer (per-window IPC, with a short wait on `app_opened`), fixes stale session fallbacks when windows close, and maps `workspace_id` to PostHog **workspace** groups via `groupIdentify` / `groups` (path-like IDs are dropped). Renderer startup calls `syncPostHogWorkspaceContext` when a workspace opens.
> 
> **Safe autocapture** — PostHog JS turns on broad autocapture with text masking and recording safeguards; `$autocapture` payloads are stripped to mostly `attr__data-attr` so labels, paths, and element text do not leak. Shared `workspaceTelemetryProperties` no longer sends `$groups` from the renderer (main owns grouping).
> 
> **Product analytics hooks** — Stable `data-attr` selectors are added on files, markdown toolbar/editor, diff accept/reject, panels, top bar, branch switcher, and agent CTAs, with tests asserting them. The marketing site uses a hardcoded production PostHog token when `PROD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce4d0fe4ecd797b2d98ed3ed82a140e270bdab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->