### PR TITLE
[codex] Capture workspace recovery telemetry

### DIFF
--- a/electron/lix.mjs
+++ b/electron/lix.mjs
@@ -12,6 +12,8 @@ import {
 	markWorkspaceLixOpenPendingSync,
 	writeWorkspaceRecoverySync,
 } from "./workspace-recovery.mjs";
+import { captureTelemetryException } from "./telemetry.mjs";
+import { captureWorkspaceRecoveryLifecycle } from "./workspace-recovery-telemetry.mjs";
 
 const LIX_DATABASE_DIR = ".lix";
 const sessions = new Map();
@@ -51,15 +53,26 @@ export async function ensureLixOpen(window) {
 					return createDesktopLixHandle(nativeLix, workspace.path);
 				} catch (error) {
 					await nativeLix?.close().catch(() => {});
+					let recovery;
 					if (tracksPersistentWorkspace) {
 						clearWorkspaceLixOpenPendingSync(userDataPath, workspace.path);
-						writeWorkspaceRecoverySync(
+						recovery = writeWorkspaceRecoverySync(
 							userDataPath,
 							createTrackChangesRecovery(workspace, {
 								reason: "lix_open_failed",
 								message: errorMessage(error),
 							}),
 						);
+					}
+					void captureTelemetryException(error, {
+						reason: "lix_open_failed",
+						persistent_workspace: tracksPersistentWorkspace,
+						source: "electron-lix-open",
+					});
+					if (recovery) {
+						void captureWorkspaceRecoveryLifecycle("created", recovery, {
+							source: "electron-lix-open",
+						});
 					}
 					throw error;
 				}

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -60,10 +60,11 @@ import {
 	clearWorkspaceRecoverySync,
 	readWorkspaceRecoveries,
 	readWorkspaceRecovery,
-	recoverPendingWorkspaceLixOpenSync,
+	recoverPendingWorkspaceLixOpenRecoveriesSync,
 	workspaceRecoveryToSessionEntry,
 	writeWorkspaceRecoverySync,
 } from "./workspace-recovery.mjs";
+import { captureWorkspaceRecoveryLifecycle } from "./workspace-recovery-telemetry.mjs";
 import { disposeAgentHookIpc, registerAgentHookIpc } from "./agent-hooks.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -240,7 +241,7 @@ async function reloadPersistentWorkspaceIntoRecovery(window, details) {
 	if (!workspace || workspace.ephemeral === true) {
 		return false;
 	}
-	writeWorkspaceRecoverySync(
+	const recovery = writeWorkspaceRecoverySync(
 		app.getPath("userData"),
 		createTrackChangesRecovery(workspace, {
 			reason: "renderer_crash",
@@ -248,6 +249,9 @@ async function reloadPersistentWorkspaceIntoRecovery(window, details) {
 			message: `Renderer process exited: ${details.reason} (${details.exitCode ?? "n/a"})`,
 		}),
 	);
+	void captureWorkspaceRecoveryLifecycle("created", recovery, {
+		source: "electron-renderer-recovery",
+	});
 	void closeLixSession(window, { ignoreOpenError: true });
 	if (window.isDestroyed() || window.webContents.isDestroyed()) {
 		return true;
@@ -762,14 +766,18 @@ async function createMainWindow(workspaceRequest) {
 			console.error(
 				`Failed to load ${validatedURL} (${errorCode}): ${errorDescription}`,
 			);
+			const error = new Error(
+				`Failed to load ${validatedURL} (${errorCode}): ${errorDescription}`,
+			);
+			void captureTelemetryException(error, {
+				error_code: errorCode,
+				source: "electron-did-fail-load",
+				validated_url: validatedURL,
+			});
 			if (!isHeadless && !window.isDestroyed() && !window.isVisible()) {
 				window.show();
 			}
-			void triggerRecoveryUpdateCheck(
-				new Error(
-					`Failed to load ${validatedURL} (${errorCode}): ${errorDescription}`,
-				),
-			);
+			void triggerRecoveryUpdateCheck(error);
 		},
 	);
 
@@ -854,7 +862,13 @@ async function startWorkspaceLifecycle() {
 		return;
 	}
 	const userDataPath = app.getPath("userData");
-	recoverPendingWorkspaceLixOpenSync(userDataPath);
+	const recoveredLixOpenRecoveries =
+		recoverPendingWorkspaceLixOpenRecoveriesSync(userDataPath);
+	for (const recovery of recoveredLixOpenRecoveries) {
+		void captureWorkspaceRecoveryLifecycle("created", recovery, {
+			source: "electron-workspace-recovery",
+		});
+	}
 	registerLixIpc((event) => BrowserWindow.fromWebContents(event.sender), {
 		disableTrackChanges: async (window) => {
 			const workspace = await disableWorkspaceTrackChanges(window);

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -17,6 +17,8 @@ const app = {
 
 const telemetry = {
 	capture: (payload) => ipcRenderer.invoke("telemetry:capture", payload),
+	captureException: (payload) =>
+		ipcRenderer.invoke("telemetry:captureException", payload),
 	getClientConfig: () => ipcRenderer.invoke("telemetry:getClientConfig"),
 	setSessionContext: (payload) =>
 		ipcRenderer.invoke("telemetry:setSessionContext", payload),

--- a/electron/telemetry.mjs
+++ b/electron/telemetry.mjs
@@ -107,10 +107,21 @@ export function registerTelemetryIpc() {
 		return await captureTelemetryEvent(
 			eventName,
 			{
-				...(payload?.properties ?? {}),
 				source: "renderer",
+				...(payload?.properties ?? {}),
 			},
 			{
+				sessionId: getTelemetrySessionIdForWebContents(_event.sender),
+			},
+		);
+	});
+
+	ipcMain.handle("telemetry:captureException", async (_event, payload) => {
+		return await captureTelemetryException(
+			deserializeRendererError(payload?.error),
+			{
+				source: "renderer",
+				...(payload?.properties ?? {}),
 				sessionId: getTelemetrySessionIdForWebContents(_event.sender),
 			},
 		);
@@ -141,6 +152,24 @@ export function registerTelemetryIpc() {
 			payload?.sessionId,
 		);
 	});
+}
+
+function deserializeRendererError(value) {
+	if (value && typeof value === "object") {
+		const error = new Error(
+			typeof value.message === "string" && value.message.length > 0
+				? value.message
+				: "Renderer error",
+		);
+		if (typeof value.name === "string" && value.name.length > 0) {
+			error.name = value.name;
+		}
+		if (typeof value.stack === "string" && value.stack.length > 0) {
+			error.stack = value.stack;
+		}
+		return error;
+	}
+	return new Error(typeof value === "string" ? value : "Renderer error");
 }
 
 export async function shutdownTelemetry(timeoutMs = SHUTDOWN_TIMEOUT_MS) {

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -261,12 +261,26 @@ export type DesktopTelemetryEventName =
 	| "document_open_attempted"
 	| "document_modified"
 	| "document_viewed"
+	| "workspace_recovery_lifecycle"
 	| "workspace_extension_profiled"
 	| "workspace_profiled";
 
 export type DesktopTelemetryApi = {
 	capture(payload: {
 		event: DesktopTelemetryEventName;
+		properties?: Record<
+			string,
+			string | number | boolean | Record<string, string | number> | undefined
+		>;
+	}): Promise<{
+		status: "disabled" | "error" | "ignored" | "queued" | "throttled";
+	}>;
+	captureException(payload: {
+		error: {
+			message: string;
+			name?: string;
+			stack?: string;
+		};
 		properties?: Record<
 			string,
 			string | number | boolean | Record<string, string | number> | undefined

--- a/electron/workspace-recovery-telemetry.mjs
+++ b/electron/workspace-recovery-telemetry.mjs
@@ -1,0 +1,17 @@
+import { captureTelemetryEvent } from "./telemetry.mjs";
+
+export function captureWorkspaceRecoveryLifecycle(
+	phase,
+	recovery,
+	properties = {},
+) {
+	if (!recovery) {
+		return { status: "ignored" };
+	}
+	return captureTelemetryEvent("workspace_recovery_lifecycle", {
+		kind: recovery.kind ?? "unknown",
+		phase,
+		reason: recovery.reason ?? "unknown",
+		...properties,
+	});
+}

--- a/electron/workspace-recovery.mjs
+++ b/electron/workspace-recovery.mjs
@@ -107,6 +107,10 @@ export function clearWorkspaceLixOpenPendingSync(userDataPath, workspacePath) {
 }
 
 export function recoverPendingWorkspaceLixOpenSync(userDataPath) {
+	return recoverPendingWorkspaceLixOpenRecoveriesSync(userDataPath).length;
+}
+
+export function recoverPendingWorkspaceLixOpenRecoveriesSync(userDataPath) {
 	const pendingRecoveries = readPendingLixOpenRecoveriesSync(userDataPath);
 	const recoveriesToWrite = pendingRecoveries
 		.filter((recovery) => isDirectorySync(recovery.workspacePath))
@@ -120,7 +124,7 @@ export function recoverPendingWorkspaceLixOpenSync(userDataPath) {
 		writeWorkspaceRecoverySync(userDataPath, recovery);
 	}
 	writePendingLixOpenRecoveriesSync(userDataPath, []);
-	return recoveriesToWrite.length;
+	return recoveriesToWrite;
 }
 
 export function workspaceRecoveryToSessionEntry(recovery) {

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -32,6 +32,27 @@ export async function captureTelemetryAsync(
 	});
 }
 
+export function captureTelemetryException(
+	error: unknown,
+	properties: TelemetryProperties = {},
+) {
+	void captureTelemetryExceptionAsync(error, properties).catch(
+		(captureError: unknown) => {
+			console.warn("Failed to capture telemetry exception", captureError);
+		},
+	);
+}
+
+export async function captureTelemetryExceptionAsync(
+	error: unknown,
+	properties: TelemetryProperties = {},
+) {
+	return await window.flashtypeDesktop?.telemetry?.captureException({
+		error: serializeError(error),
+		properties,
+	});
+}
+
 export function captureTelemetryThrottled(
 	key: string,
 	event: TelemetryEventName,
@@ -70,4 +91,17 @@ export function workspaceTelemetryProperties(workspaceId: string | undefined) {
 				workspace_id: workspaceId,
 			}
 		: {};
+}
+
+function serializeError(error: unknown) {
+	if (error instanceof Error) {
+		return {
+			message: error.message || "Renderer error",
+			name: error.name,
+			stack: error.stack,
+		};
+	}
+	return {
+		message: typeof error === "string" ? error : "Renderer error",
+	};
 }

--- a/src/lib/workspace-recovery-telemetry.ts
+++ b/src/lib/workspace-recovery-telemetry.ts
@@ -1,0 +1,22 @@
+import { captureTelemetry } from "./telemetry";
+
+type WorkspaceRecovery = {
+	kind?: string;
+	reason?: string;
+};
+
+export function captureWorkspaceRecoveryLifecycle(
+	phase: "created" | "shown" | "cleared" | "action_failed",
+	recovery: WorkspaceRecovery | null | undefined,
+	properties: Record<string, string | number | boolean | undefined> = {},
+) {
+	if (!recovery) {
+		return;
+	}
+	captureTelemetry("workspace_recovery_lifecycle", {
+		kind: recovery.kind ?? "unknown",
+		phase,
+		reason: recovery.reason ?? "unknown",
+		...properties,
+	});
+}

--- a/src/main.error.tsx
+++ b/src/main.error.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { RotateCcw, Bug, AlertTriangle, Trash2 } from "lucide-react";
+import { captureTelemetryException } from "./lib/telemetry";
+import { captureWorkspaceRecoveryLifecycle } from "./lib/workspace-recovery-telemetry";
 
 type WorkspaceRecovery = Awaited<
 	ReturnType<
@@ -75,6 +77,24 @@ export function ErrorFallback(props: {
 	const [actionError, setActionError] = useState<unknown>(null);
 	const busy = busyAction !== null;
 	const recovery = props.recovery ?? null;
+
+	useEffect(() => {
+		if (!recovery) {
+			return;
+		}
+		captureWorkspaceRecoveryLifecycle("shown", recovery, {
+			source: "renderer-error-fallback",
+		});
+	}, [recovery]);
+
+	useEffect(() => {
+		if (!props.error) {
+			return;
+		}
+		captureTelemetryException(props.error, {
+			source: "renderer-error-fallback",
+		});
+	}, [props.error]);
 
 	async function handleDisableTrackChanges() {
 		if (busy) return;


### PR DESCRIPTION
## Summary
- add a centralized `workspace_recovery_lifecycle` telemetry event for recovery creation/display
- capture handled Lix open failures, stale pending-open recovery, renderer-crash recovery, and renderer fallback errors
- add renderer-to-main exception capture plus `did-fail-load` exception reporting

## Root cause
PostHog/Electron autocapture can catch some unhandled process exceptions, but it cannot infer semantic recovery state such as a stale pending Lix open becoming a Track Changes recovery screen. The previous flow could show recovery UI without a corresponding PostHog signal.

## Validation
- `./node_modules/.bin/tsc -p . --pretty false`
- `./node_modules/.bin/vitest run electron/workspace-recovery.test.mjs electron/telemetry.test.mjs src/lib/telemetry.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes; recovery behavior is unchanged aside from emitting telemetry on existing paths.
> 
> **Overview**
> Adds **`workspace_recovery_lifecycle`** telemetry so recovery flows are visible in PostHog, not only generic exceptions. A shared helper emits events with **phase** (`created`, `shown`, etc.), **kind**, **reason**, and a **source** tag.
> 
> **Creation** is reported when Track Changes recovery is written after Lix open failure, renderer crash reload, or boot-time promotion of stale pending Lix opens (`previous_lix_open_crash`). **Shown** is reported when the renderer error fallback displays recovery UI.
> 
> Adds an end-to-end **exception capture** path: renderer helpers serialize errors, preload exposes `telemetry.captureException`, and main forwards to PostHog with session context. Main also reports Lix open failures and **`did-fail-load`** errors. Types include the new event and API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c3328ac4216b10bff1a8161531803f5a054c736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->