### PR TITLE
Resolve markdown review diff image paths

### DIFF
--- a/src/extensions/markdown/editor/desktop-workspace.ts
+++ b/src/extensions/markdown/editor/desktop-workspace.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+
+type WorkspaceDirState = {
+	readonly loaded: boolean;
+	readonly workspaceDir: string | null;
+};
+
+export function useDesktopWorkspaceDir(): WorkspaceDirState {
+	const [state, setState] = useState<WorkspaceDirState>(() => {
+		const desktopLix = desktopLixApi();
+		return desktopLix
+			? { loaded: false, workspaceDir: null }
+			: { loaded: true, workspaceDir: null };
+	});
+
+	useEffect(() => {
+		const desktopLix = desktopLixApi();
+		if (!desktopLix) {
+			setState({ loaded: true, workspaceDir: null });
+			return;
+		}
+
+		let cancelled = false;
+		void desktopLix.workspaceDir().then(
+			(workspaceDir) => {
+				if (!cancelled) {
+					setState({ loaded: true, workspaceDir });
+				}
+			},
+			() => {
+				if (!cancelled) {
+					setState({ loaded: true, workspaceDir: null });
+				}
+			},
+		);
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return state;
+}
+
+function desktopLixApi():
+	| NonNullable<Window["flashtypeDesktop"]>["lix"]
+	| undefined {
+	if (typeof window === "undefined") {
+		return undefined;
+	}
+	return window.flashtypeDesktop?.lix;
+}
+
+export function desktopWorkspaceApi():
+	| NonNullable<Window["flashtypeDesktop"]>["workspace"]
+	| undefined {
+	if (typeof window === "undefined") {
+		return undefined;
+	}
+	return window.flashtypeDesktop?.workspace;
+}

--- a/src/extensions/markdown/editor/tip-tap-editor.tsx
+++ b/src/extensions/markdown/editor/tip-tap-editor.tsx
@@ -12,6 +12,10 @@ import type { EmptyMarkdownDefaultBlock } from "./tiptap-markdown-bridge";
 import { parseMarkdown, serializeAst } from "./markdown";
 import { tiptapDocToAst } from "./tiptap-markdown-bridge";
 import { decodeMarkdownData } from "./decode-markdown-data";
+import {
+	desktopWorkspaceApi,
+	useDesktopWorkspaceDir,
+} from "./desktop-workspace";
 
 type TipTapEditorProps = {
 	fileId?: string | null;
@@ -23,66 +27,6 @@ type TipTapEditorProps = {
 	defaultBlock?: EmptyMarkdownDefaultBlock;
 	isActiveView?: boolean;
 };
-
-type WorkspaceDirState = {
-	readonly loaded: boolean;
-	readonly workspaceDir: string | null;
-};
-
-function useDesktopWorkspaceDir(): WorkspaceDirState {
-	const [state, setState] = useState<WorkspaceDirState>(() => {
-		const desktopLix = desktopLixApi();
-		return desktopLix
-			? { loaded: false, workspaceDir: null }
-			: { loaded: true, workspaceDir: null };
-	});
-
-	useEffect(() => {
-		const desktopLix = desktopLixApi();
-		if (!desktopLix) {
-			setState({ loaded: true, workspaceDir: null });
-			return;
-		}
-
-		let cancelled = false;
-		void desktopLix.workspaceDir().then(
-			(workspaceDir) => {
-				if (!cancelled) {
-					setState({ loaded: true, workspaceDir });
-				}
-			},
-			() => {
-				if (!cancelled) {
-					setState({ loaded: true, workspaceDir: null });
-				}
-			},
-		);
-
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
-	return state;
-}
-
-function desktopLixApi():
-	| NonNullable<Window["flashtypeDesktop"]>["lix"]
-	| undefined {
-	if (typeof window === "undefined") {
-		return undefined;
-	}
-	return window.flashtypeDesktop?.lix;
-}
-
-function desktopWorkspaceApi():
-	| NonNullable<Window["flashtypeDesktop"]>["workspace"]
-	| undefined {
-	if (typeof window === "undefined") {
-		return undefined;
-	}
-	return window.flashtypeDesktop?.workspace;
-}
 
 /**
  * Rich text editor for Markdown files backed by the Lix store.

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -12,6 +12,10 @@ import { qb } from "@/lib/lix-kysely";
 import { isMarkdownFilePath } from "@/extension-runtime/file-handlers";
 import { EditorProvider } from "@/extensions/markdown/editor/editor-context";
 import { TipTapEditor } from "@/extensions/markdown/editor/tip-tap-editor";
+import {
+	desktopWorkspaceApi,
+	useDesktopWorkspaceDir,
+} from "@/extensions/markdown/editor/desktop-workspace";
 import type { EmptyMarkdownDefaultBlock } from "@/extensions/markdown/editor/tiptap-markdown-bridge";
 import { renderMarkdownReviewDiffHtml } from "./render-review-diff-html";
 import "./style.css";
@@ -181,6 +185,7 @@ function MarkdownViewLoaded({
 							<Suspense fallback={<MarkdownReviewOverlayFallback />}>
 								<MarkdownReviewOverlay
 									fileId={fileRow.id}
+									sourceFilePath={fileRow.path}
 									review={externalWriteReview}
 									reviewDiff={reviewDiff}
 									reviewId={externalWriteReview.reviewId}
@@ -263,6 +268,7 @@ function MarkdownAutosaveHint({ enabled }: { readonly enabled: boolean }) {
 
 function MarkdownReviewOverlay({
 	fileId,
+	sourceFilePath,
 	review,
 	reviewDiff,
 	reviewId,
@@ -273,6 +279,7 @@ function MarkdownReviewOverlay({
 	onReject,
 }: {
 	readonly fileId: string;
+	readonly sourceFilePath: string;
 	readonly review: ExternalWriteReview;
 	readonly reviewDiff: MarkdownReviewDiff;
 	readonly reviewId: string;
@@ -290,8 +297,26 @@ function MarkdownReviewOverlay({
 		readonly review?: ExternalWriteReview;
 	}) => Promise<void>;
 }) {
+	const workspaceDirState = useDesktopWorkspaceDir();
 	const beforeBlocks = useMarkdownBlocksAtCommit(fileId, beforeCommitId);
 	const afterBlocks = useMarkdownBlocksAtCommit(fileId, afterCommitId);
+	const resolveImageSrc = useMemo(() => {
+		const workspaceApi = desktopWorkspaceApi();
+		const workspacePath = workspaceDirState.workspaceDir;
+		if (
+			!sourceFilePath ||
+			!workspacePath ||
+			!workspaceApi?.resolveMarkdownImageSrc
+		) {
+			return undefined;
+		}
+		return (src: string) =>
+			workspaceApi.resolveMarkdownImageSrc({
+				src,
+				sourceFilePath,
+				workspacePath,
+			});
+	}, [sourceFilePath, workspaceDirState.workspaceDir]);
 	const enrichedReviewDiff = useMemo<MarkdownReviewDiff>(() => {
 		const beforeSnapshotsAvailable =
 			beforeBlocks !== undefined &&
@@ -310,9 +335,15 @@ function MarkdownReviewOverlay({
 		};
 	}, [afterBlocks, beforeBlocks, reviewDiff]);
 	const diffHtml = useMemo(() => {
-		return renderMarkdownReviewDiffHtml(enrichedReviewDiff);
-	}, [enrichedReviewDiff]);
+		return renderMarkdownReviewDiffHtml(enrichedReviewDiff, {
+			resolveImageSrc,
+		});
+	}, [enrichedReviewDiff, resolveImageSrc]);
 	const rejectReview = () => void onReject?.({ fileId, reviewId, review });
+
+	if (!workspaceDirState.loaded) {
+		return <MarkdownReviewOverlayFallback />;
+	}
 
 	return (
 		<div className="markdown-review-overlay">

--- a/src/extensions/markdown/render-review-diff-html.test.ts
+++ b/src/extensions/markdown/render-review-diff-html.test.ts
@@ -89,6 +89,51 @@ describe("renderMarkdownReviewDiffHtml", () => {
 		expect(statusesForText(html, "New document")).toContain("added");
 	});
 
+	test("resolves image sources in review diffs", () => {
+		const resolveImageSrc = (src: string) => `file:///workspace/docs/${src}`;
+		const fullDocumentHtml = renderMarkdownReviewDiffHtml(
+			{
+				beforeMarkdown: "![Lix mark](./lix-mark-2.svg)\n",
+				afterMarkdown: "![Lix mark](./lix-mark-3.svg)\n",
+			},
+			{ resolveImageSrc },
+		);
+
+		expect(imageSrcsForAlt(fullDocumentHtml, "Lix mark")).toEqual([
+			"file:///workspace/docs/./lix-mark-2.svg",
+			"file:///workspace/docs/./lix-mark-3.svg",
+		]);
+		expect(fullDocumentHtml).not.toContain('src="./lix-mark');
+
+		const snapshotHtml = renderMarkdownReviewDiffHtml(
+			{
+				beforeMarkdown: "![Lix mark](./lix-mark-2.svg)\n",
+				afterMarkdown: "![Lix mark](./lix-mark-3.svg)\n",
+				beforeBlocks: [
+					{
+						id: "image_block",
+						orderKey: "40",
+						block: "![Lix mark](./lix-mark-2.svg)",
+					},
+				],
+				afterBlocks: [
+					{
+						id: "image_block",
+						orderKey: "40",
+						block: "![Lix mark](./lix-mark-3.svg)",
+					},
+				],
+			},
+			{ resolveImageSrc },
+		);
+
+		expect(imageSrcsForAlt(snapshotHtml, "Lix mark")).toEqual([
+			"file:///workspace/docs/./lix-mark-2.svg",
+			"file:///workspace/docs/./lix-mark-3.svg",
+		]);
+		expect(snapshotHtml).not.toContain('src="./lix-mark');
+	});
+
 	test("keeps unchanged list items stable inside a changed list block", () => {
 		const fixture = fixtureById("quick-facts-list");
 		const html = renderMarkdownReviewDiffHtml(fixture);
@@ -704,6 +749,15 @@ function imageTitlesForAlt(html: string, alt: string): string[] {
 		.filter((image) => image.getAttribute("alt") === alt)
 		.map((image) => image.getAttribute("title"))
 		.filter((title): title is string => title !== null)
+		.sort();
+}
+
+function imageSrcsForAlt(html: string, alt: string): string[] {
+	const root = htmlRoot(html);
+	return [...root.querySelectorAll("img")]
+		.filter((image) => image.getAttribute("alt") === alt)
+		.map((image) => image.getAttribute("src"))
+		.filter((src): src is string => src !== null)
 		.sort();
 }
 

--- a/src/extensions/markdown/render-review-diff-html.ts
+++ b/src/extensions/markdown/render-review-diff-html.ts
@@ -7,8 +7,13 @@ import {
 import { parseMarkdown } from "@/extensions/markdown/editor/markdown";
 import type { MarkdownReviewDiff } from "./review-diff";
 
+type RenderMarkdownReviewDiffHtmlOptions = {
+	readonly resolveImageSrc?: (src: string) => string;
+};
+
 export function renderMarkdownReviewDiffHtml(
 	reviewDiff: MarkdownReviewDiff,
+	options: RenderMarkdownReviewDiffHtmlOptions = {},
 ): string {
 	if (
 		reviewDiff.beforeBlocks !== undefined &&
@@ -16,8 +21,8 @@ export function renderMarkdownReviewDiffHtml(
 	) {
 		return normalizeHtmlDiffFragment(
 			renderHtmlDiff({
-				beforeHtml: renderMarkdownBlocksHtml(reviewDiff.beforeBlocks),
-				afterHtml: renderMarkdownBlocksHtml(reviewDiff.afterBlocks),
+				beforeHtml: renderMarkdownBlocksHtml(reviewDiff.beforeBlocks, options),
+				afterHtml: renderMarkdownBlocksHtml(reviewDiff.afterBlocks, options),
 				diffAttribute: "data-diff-key",
 			}),
 		);
@@ -26,8 +31,8 @@ export function renderMarkdownReviewDiffHtml(
 	const beforeAst = parseMarkdown(reviewDiff.beforeMarkdown) as any;
 	const afterAst = parseMarkdown(reviewDiff.afterMarkdown) as any;
 	ensurePairedDiffIds(beforeAst, afterAst);
-	const beforeHtml = renderMarkdownAstEditorHtml(beforeAst);
-	const afterHtml = renderMarkdownAstEditorHtml(afterAst);
+	const beforeHtml = renderMarkdownAstEditorHtml(beforeAst, options);
+	const afterHtml = renderMarkdownAstEditorHtml(afterAst, options);
 	return normalizeHtmlDiffFragment(
 		renderHtmlDiff({
 			beforeHtml,
@@ -73,12 +78,16 @@ function serializeHtmlFragmentWithoutWhitespaceText(
 
 function renderMarkdownBlocksHtml(
 	blocks: NonNullable<MarkdownReviewDiff["beforeBlocks"]>,
+	options: RenderMarkdownReviewDiffHtmlOptions,
 ): string {
-	return blocks.map(renderMarkdownBlockHtml).join("\n");
+	return blocks
+		.map((block) => renderMarkdownBlockHtml(block, options))
+		.join("\n");
 }
 
 function renderMarkdownBlockHtml(
 	block: NonNullable<MarkdownReviewDiff["beforeBlocks"]>[number],
+	options: RenderMarkdownReviewDiffHtmlOptions,
 ): string {
 	const ast = parseMarkdown(block.block) as any;
 	ensureDiffIds(ast);
@@ -97,7 +106,7 @@ function renderMarkdownBlockHtml(
 			break;
 		}
 	}
-	return renderMarkdownAstEditorHtml(ast);
+	return renderMarkdownAstEditorHtml(ast, options);
 }
 
 function ensureNestedDiffIds(ast: any, blockId: string): void {


### PR DESCRIPTION
## Summary
- Thread the desktop markdown image resolver into review diff rendering so `img` sources in review mode resolve the same way as the live editor.
- Reuse the workspace helper for both the editor and review overlay, and wait for workspace path loading before rendering review HTML.
- Add regression coverage for both full-document and snapshot-backed review diffs with relative image paths.

## Testing
- `pnpm run build:lix`
- `pnpm exec vitest run src/extensions/markdown/render-review-diff-html.test.ts`
- `pnpm run typecheck`
- `pnpm exec prettier --check ...`
- `git diff --check`