### PR TITLE
[codex] Fix markdown link clicks

### DIFF
--- a/src/extensions/markdown/editor/create-editor.test.ts
+++ b/src/extensions/markdown/editor/create-editor.test.ts
@@ -146,6 +146,90 @@ async function createEditorFromFile(args: {
 	return editor;
 }
 
+test("clicking a rendered markdown link opens it externally", async () => {
+	const lix = await openLix();
+	const originalDesktop = window.flashtypeDesktop;
+	const openedUrls: string[] = [];
+	window.flashtypeDesktop = {
+		app: {
+			openExternal: async ({ url }: { url: string }) => {
+				openedUrls.push(url);
+				return { status: "opened" };
+			},
+		},
+	} as unknown as Window["flashtypeDesktop"];
+	const editor = createEditor({
+		lix,
+		initialMarkdown: "Read the [docs](https://example.com/docs).",
+		persistState: false,
+	});
+	const editorDom = editor.view.dom;
+	document.body.appendChild(editorDom);
+
+	try {
+		const link = editor.view.dom.querySelector("a");
+		expect(link).toBeInstanceOf(HTMLAnchorElement);
+
+		const clickEvent = new MouseEvent("click", {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+		});
+		clickEvent.preventDefault();
+		link?.dispatchEvent(clickEvent);
+
+		expect(clickEvent.defaultPrevented).toBe(true);
+		expect(openedUrls).toEqual(["https://example.com/docs"]);
+	} finally {
+		editor.destroy();
+		editorDom.remove();
+		window.flashtypeDesktop = originalDesktop;
+	}
+});
+
+test("clicking a relative or fragment markdown link does not open externally", async () => {
+	const lix = await openLix();
+	const originalDesktop = window.flashtypeDesktop;
+	const openedUrls: string[] = [];
+	window.flashtypeDesktop = {
+		app: {
+			openExternal: async ({ url }: { url: string }) => {
+				openedUrls.push(url);
+				return { status: "opened" };
+			},
+		},
+	} as unknown as Window["flashtypeDesktop"];
+	const editor = createEditor({
+		lix,
+		initialMarkdown:
+			"Read the [guide](./guide.md) or jump to [intro](#intro).",
+		persistState: false,
+	});
+	const editorDom = editor.view.dom;
+	document.body.appendChild(editorDom);
+
+	try {
+		const links = Array.from(editor.view.dom.querySelectorAll("a"));
+		expect(links).toHaveLength(2);
+
+		for (const link of links) {
+			const clickEvent = new MouseEvent("click", {
+				bubbles: true,
+				cancelable: true,
+				button: 0,
+			});
+			link.dispatchEvent(clickEvent);
+			expect(clickEvent.defaultPrevented).toBe(false);
+		}
+
+		expect(openedUrls).toEqual([]);
+	} finally {
+		editor.destroy();
+		editorDom.remove();
+		window.flashtypeDesktop = originalDesktop;
+	}
+});
+
 // TipTap + Lix persistence paste tests (no React)
 test("paste at start inserts before existing content (TipTap + Lix)", async () => {
 	const lix = await openLix({

--- a/src/extensions/markdown/editor/create-editor.ts
+++ b/src/extensions/markdown/editor/create-editor.ts
@@ -62,6 +62,49 @@ function isSelectionNavigationKey(event: KeyboardEvent): boolean {
 	);
 }
 
+function externalLinkUrlFromClick(event: MouseEvent): string | null {
+	if (event.button !== 0) {
+		return null;
+	}
+	const target =
+		event.target instanceof Element
+			? event.target.closest("a[href]")
+			: null;
+	if (!(target instanceof HTMLAnchorElement)) {
+		return null;
+	}
+	const href = target.getAttribute("href")?.trim();
+	if (!href) {
+		return null;
+	}
+	const protocolMatch = href.match(/^([a-zA-Z][a-zA-Z\d+.-]*):/);
+	const protocol = protocolMatch?.[1]?.toLowerCase();
+	if (protocol === "http" || protocol === "https" || protocol === "mailto") {
+		return target.href;
+	}
+	return null;
+}
+
+function openExternalLink(url: string): void {
+	const openExternal = window.flashtypeDesktop?.app?.openExternal;
+	if (openExternal) {
+		void openExternal({ url });
+		return;
+	}
+	window.open(url, "_blank", "noopener,noreferrer");
+}
+
+function handleExternalLinkClick(event: MouseEvent): void {
+	const url = externalLinkUrlFromClick(event);
+	if (!url) {
+		return;
+	}
+	event.preventDefault();
+	event.stopPropagation();
+	event.stopImmediatePropagation();
+	openExternalLink(url);
+}
+
 function ensureTopLevelIds(children: any[]): void {
 	const seen = new Set<string>();
 	for (const node of children) {
@@ -110,6 +153,7 @@ export function createEditor(args: CreateEditorArgs): Editor {
 	let destroyed = false;
 	let editorInstance: Editor | null = null;
 	let currentEditor: Editor | null = null;
+	let cleanupExternalLinkClick: (() => void) | null = null;
 	let lastPersistedMarkdown = normalizePersistedMarkdown(
 		initialMarkdown ?? serializeAst(ast as any),
 	);
@@ -207,6 +251,8 @@ export function createEditor(args: CreateEditorArgs): Editor {
 			scheduleRun();
 		},
 		onDestroy: () => {
+			cleanupExternalLinkClick?.();
+			cleanupExternalLinkClick = null;
 			persistQueued = false;
 			if (persistStateTimer) {
 				clearTimeout(persistStateTimer);
@@ -249,6 +295,15 @@ export function createEditor(args: CreateEditorArgs): Editor {
 			},
 		},
 	});
+	const editorDom = editorInstance.view.dom;
+	editorDom.addEventListener("click", handleExternalLinkClick, {
+		capture: true,
+	});
+	cleanupExternalLinkClick = () => {
+		editorDom.removeEventListener("click", handleExternalLinkClick, {
+			capture: true,
+		});
+	};
 	currentEditor = editorInstance;
 	return editorInstance;
 }


### PR DESCRIPTION
## What changed
- Opens rendered markdown links through the desktop external-browser API from a capture-phase listener on the editor DOM.
- Keeps non-left-click interactions ignored and cleans up the listener when the editor is destroyed.
- Adds regression coverage for a rendered markdown link click, including the case where the click has already been default-prevented by editor internals.

## Why
Markdown links rendered inside the TipTap/ProseMirror contenteditable surface received pointer clicks, but the editor stopped the event before the old browser-opening path could run. Users could see links, but clicking them did not open the browser.

## Demo
MP4 demo uploaded to GitHub: https://github.com/opral/flashtype/releases/download/pr-241-link-click-demo/link-click-fix-demo.mp4

The video shows a real Electron pointer click. The banner is displayed after the Electron main process observes `shell.openExternal(\"https://example.com/flashtype-link-demo\")`.

## Validation
- `./node_modules/.bin/vitest run src/extensions/markdown/editor/create-editor.test.ts`
- `./node_modules/.bin/tsc -p . --pretty false`
- Electron pointer-click smoke script with `shell.openExternal` patched in the main process, confirming it received `https://example.com/flashtype-link-demo`.

## Notes
- `./node_modules/.bin/oxlint --tsconfig ./tsconfig.json --ignore-path .gitignore --ignore-pattern \"submodule/**\" --format stylish .` still reports existing unrelated lint issues in `src/extensions/files/index.test.tsx`, `src/extensions/files/file-tree.tsx`, and existing warnings in fuzz tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor event handling and navigation only; no auth, persistence, or data-model changes.
> 
> **Overview**
> Fixes **markdown links that did not open** when clicked inside the TipTap editor by handling **left-clicks on rendered anchors** in a **capture-phase** listener on the editor DOM, before ProseMirror can swallow the event.
> 
> **http**, **https**, and **mailto** links are opened via `flashtypeDesktop.app.openExternal` when available, with a `window.open` fallback. **Relative** and **fragment** hrefs are left alone. The listener is **removed on editor destroy**. New tests cover external opens (including when `preventDefault` was already called) and non-external links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f2f1df92b27900f6975b6c3dcbd3289d33bd48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->