### PR TITLE
[codex] Open agent diff review

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,7 @@
 	"version": "0.7.0",
 	"type": "module",
 	"main": "electron/main.mjs",
-	"packageManager": "pnpm@10.13.1",
-	"pnpm": {
-		"peerDependencyRules": {
-			"allowedVersions": {
-				"@glideapps/glide-data-grid>react": "^19.0.0",
-				"@glideapps/glide-data-grid>react-dom": "^19.0.0"
-			}
-		}
-	},
+	"packageManager": "pnpm@11.7.0",
 	"scripts": {
 		"dev": "node scripts/dev.mjs",
 		"dev:renderer": "vite --host 127.0.0.1 --port 4173 --strictPort",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,20 @@ packages:
   - submodule/lix/packages/js-sdk
   - "!submodule/lix/packages/**/dist"
 
+peerDependencyRules:
+  allowedVersions:
+    "@glideapps/glide-data-grid>react": ^19.0.0
+    "@glideapps/glide-data-grid>react-dom": ^19.0.0
+
+allowBuilds:
+  "@parcel/watcher": false
+  "@posthog/cli": false
+  core-js: false
+  electron: true
+  electron-winstaller: false
+  esbuild: false
+  node-pty: true
+
 onlyBuiltDependencies:
   - electron
   - node-pty

--- a/src/extensions/files/index.test.tsx
+++ b/src/extensions/files/index.test.tsx
@@ -6,6 +6,7 @@ import { openLix } from "@/test-utils/node-lix-sdk";
 import { FilesView } from "./index";
 import type { ExtensionContext } from "../../extension-runtime/types";
 import { qb } from "@/lib/lix-kysely";
+import { ACTIVE_FILE_ID_KEY } from "@/hooks/key-value/schema";
 import {
 	appendAgentTurnCommitRange,
 	type AgentTurnCommitRange,
@@ -141,6 +142,43 @@ async function startTreeRenameByLabel(
 		});
 	});
 	return findTreeRenameInput(utils);
+}
+
+async function writeActiveFileId(
+	lix: Awaited<ReturnType<typeof openLix>>,
+	fileId: string,
+): Promise<void> {
+	await qb(lix)
+		.insertInto("lix_key_value_by_branch")
+		.values({
+			key: ACTIVE_FILE_ID_KEY,
+			value: fileId,
+			lixcol_branch_id: "global",
+			lixcol_global: true,
+			lixcol_untracked: true,
+		})
+		.onConflict((oc) =>
+			oc.columns(["key", "lixcol_branch_id"]).doUpdateSet({ value: fileId }),
+		)
+		.execute();
+}
+
+async function clearActiveFileId(
+	lix: Awaited<ReturnType<typeof openLix>>,
+): Promise<void> {
+	await qb(lix)
+		.insertInto("lix_key_value_by_branch")
+		.values({
+			key: ACTIVE_FILE_ID_KEY,
+			value: null,
+			lixcol_branch_id: "global",
+			lixcol_global: true,
+			lixcol_untracked: true,
+		})
+		.onConflict((oc) =>
+			oc.columns(["key", "lixcol_branch_id"]).doUpdateSet({ value: null }),
+		)
+		.execute();
 }
 
 describe("FilesView", () => {
@@ -281,6 +319,109 @@ describe("FilesView", () => {
 			window.flashtypeDesktop = originalDesktop;
 			await lix.close();
 		}
+	});
+
+	test("updates the selected row when the active file changes outside the tree", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values([
+				{ id: "file_one", path: "/one.md", data: new Uint8Array() },
+				{ id: "file_two", path: "/two.md", data: new Uint8Array() },
+			])
+			.execute();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView context={createViewContext(lix)} />
+					</Suspense>
+				</LixProvider>,
+			);
+		});
+		await waitForFilesViewReady(utils!);
+		const one = await findTreeItemByLabel(utils!, "one.md");
+		const two = await findTreeItemByLabel(utils!, "two.md");
+
+		await act(async () => {
+			await writeActiveFileId(lix, "file_two");
+		});
+		await waitFor(() => {
+			expect(two).toHaveAttribute("data-item-selected", "true");
+			expect(one).not.toHaveAttribute("data-item-selected", "true");
+		});
+
+		await act(async () => {
+			await clearActiveFileId(lix);
+		});
+		await waitFor(() => {
+			expect(two).not.toHaveAttribute("data-item-selected", "true");
+			expect(one).not.toHaveAttribute("data-item-selected", "true");
+		});
+
+		utils!.unmount();
+		await lix.close();
+	});
+
+	test("does not overwrite an intentional tree selection on entry refresh", async () => {
+		const lix = await openLix();
+		await qb(lix)
+			.insertInto("lix_file")
+			.values([
+				{ id: "file_one", path: "/one.md", data: new Uint8Array() },
+				{ id: "file_two", path: "/two.md", data: new Uint8Array() },
+			])
+			.execute();
+
+		let utils: ReturnType<typeof render>;
+		await act(async () => {
+			utils = render(
+				<LixProvider lix={lix}>
+					<Suspense fallback={null}>
+						<FilesView context={createViewContext(lix)} />
+					</Suspense>
+				</LixProvider>,
+			);
+		});
+		await waitForFilesViewReady(utils!);
+
+		await act(async () => {
+			await writeActiveFileId(lix, "file_two");
+		});
+		const one = await findTreeItemByLabel(utils!, "one.md");
+		const two = await findTreeItemByLabel(utils!, "two.md");
+		await waitFor(() => {
+			expect(two).toHaveAttribute("data-item-selected", "true");
+		});
+
+		await act(async () => {
+			fireEvent.click(one);
+		});
+		await waitFor(() => {
+			expect(one).toHaveAttribute("data-item-selected", "true");
+			expect(two).not.toHaveAttribute("data-item-selected", "true");
+		});
+
+		await act(async () => {
+			await qb(lix)
+				.insertInto("lix_file")
+				.values({
+					id: "file_three",
+					path: "/three.md",
+					data: new Uint8Array(),
+				})
+				.execute();
+		});
+		await findTreeItemByLabel(utils!, "three.md");
+		await waitFor(() => {
+			expect(one).toHaveAttribute("data-item-selected", "true");
+			expect(two).not.toHaveAttribute("data-item-selected", "true");
+		});
+
+		utils!.unmount();
+		await lix.close();
 	});
 
 	test("focuses the inline draft without forcing the left panel", async () => {

--- a/src/extensions/files/index.tsx
+++ b/src/extensions/files/index.tsx
@@ -20,6 +20,7 @@ import {
 } from "./file-tree";
 import { createReactExtensionDefinition } from "../../extension-runtime/react-extension";
 import { qb } from "@/lib/lix-kysely";
+import { ACTIVE_FILE_ID_KEY } from "@/hooks/key-value/schema";
 import { FILES_EXTENSION_KIND } from "../../extension-runtime/extension-instance-helpers";
 import type { FilesystemEntryRow } from "@/queries";
 import type { Lix } from "@/lib/lix-types";
@@ -48,16 +49,81 @@ export function FilesView({ context }: FilesViewProps) {
 	const entries = useQuery<FilesystemEntryRow>((lix) =>
 		selectFilesystemEntries(lix),
 	);
-	return <FilesViewContent context={context} lix={lix} entries={entries} />;
+	return (
+		<FilesViewAgentTurnRangeLoader
+			context={context}
+			lix={lix}
+			entries={entries}
+		/>
+	);
 }
 
-function FilesViewContent({
+function FilesViewAgentTurnRangeLoader({
 	context,
 	lix,
 	entries,
 }: FilesViewProps & {
 	readonly lix: Lix;
 	readonly entries: FilesystemEntryRow[];
+}) {
+	const rangeRow = useQueryTakeFirst<{ value: unknown }>((lix) =>
+		qb(lix)
+			.selectFrom("lix_key_value_by_branch")
+			.select("value")
+			.where("key", "=", AGENT_TURN_COMMIT_RANGE_KEY)
+			.where("lixcol_branch_id", "=", "global")
+			.limit(1),
+	);
+	return (
+		<FilesViewActiveFileLoader
+			context={context}
+			lix={lix}
+			entries={entries}
+			agentTurnCommitRangeValue={rangeRow?.value}
+		/>
+	);
+}
+
+function FilesViewActiveFileLoader({
+	context,
+	lix,
+	entries,
+	agentTurnCommitRangeValue,
+}: FilesViewProps & {
+	readonly lix: Lix;
+	readonly entries: FilesystemEntryRow[];
+	readonly agentTurnCommitRangeValue: unknown;
+}) {
+	const activeFile = useQueryTakeFirst<{ value: unknown }>((lix) =>
+		qb(lix)
+			.selectFrom("lix_key_value_by_branch")
+			.select("value")
+			.where("key", "=", ACTIVE_FILE_ID_KEY)
+			.where("lixcol_branch_id", "=", "global")
+			.limit(1),
+	);
+	return (
+		<FilesViewContent
+			context={context}
+			lix={lix}
+			entries={entries}
+			activeFileValue={activeFile?.value}
+			agentTurnCommitRangeValue={agentTurnCommitRangeValue}
+		/>
+	);
+}
+
+function FilesViewContent({
+	context,
+	lix,
+	entries,
+	activeFileValue,
+	agentTurnCommitRangeValue,
+}: FilesViewProps & {
+	readonly lix: Lix;
+	readonly entries: FilesystemEntryRow[];
+	readonly activeFileValue: unknown;
+	readonly agentTurnCommitRangeValue: unknown;
 }) {
 	const ownerIdRef = useRef(
 		`files-view:${context?.viewInstance ?? Math.random().toString(36).slice(2)}`,
@@ -88,7 +154,13 @@ function FilesViewContent({
 		() => buildFilesystemTree(combinedEntries),
 		[combinedEntries],
 	);
-	const pendingReviewPaths = usePendingExternalWriteReviewPaths(lix, nodes);
+	const activeFileId =
+		typeof activeFileValue === "string" ? activeFileValue : null;
+	const pendingReviewPaths = usePendingExternalWriteReviewPaths(
+		lix,
+		nodes,
+		agentTurnCommitRangeValue,
+	);
 	const creatingRef = useRef(false);
 	const renamingRef = useRef(false);
 	const [pendingPaths, setPendingPaths] = useState<string[]>([]);
@@ -103,6 +175,10 @@ function FilesViewContent({
 	const [selectedKind, setSelectedKind] = useState<"file" | "directory" | null>(
 		null,
 	);
+	const lastSyncedActiveFileRef = useRef<{
+		fileId: string | null;
+		path: string | null;
+	}>({ fileId: null, path: null });
 	const [isDraggingOver, setIsDraggingOver] = useState(false);
 	const dragCounterRef = useRef(0);
 	const entryPathSet = useMemo(() => {
@@ -119,6 +195,35 @@ function FilesViewContent({
 				.map((entry) => entry.path),
 		);
 	}, [combinedEntries]);
+	useEffect(() => {
+		if (!activeFileId) {
+			if (activeFileValue === null) {
+				lastSyncedActiveFileRef.current = { fileId: null, path: null };
+				setSelectedPath(null);
+				setSelectedFileId(null);
+				setSelectedKind(null);
+			}
+			return;
+		}
+		const activeEntry = combinedEntries.find(
+			(entry) => entry.kind === "file" && entry.id === activeFileId,
+		);
+		if (!activeEntry) return;
+		const lastSynced = lastSyncedActiveFileRef.current;
+		if (
+			lastSynced.fileId === activeFileId &&
+			lastSynced.path === activeEntry.path
+		) {
+			return;
+		}
+		lastSyncedActiveFileRef.current = {
+			fileId: activeFileId,
+			path: activeEntry.path,
+		};
+		setSelectedPath(activeEntry.path);
+		setSelectedFileId(activeEntry.id);
+		setSelectedKind("file");
+	}, [activeFileId, activeFileValue, combinedEntries]);
 	const existingFilePaths = useMemo(() => {
 		const combined = new Set(entryPathSet);
 		for (const path of pendingPaths) {
@@ -820,19 +925,14 @@ function FilesViewContent({
 function usePendingExternalWriteReviewPaths(
 	lix: Lix,
 	nodes: readonly FilesystemTreeNode[],
+	agentTurnCommitRangeValue: unknown,
 ): ReadonlySet<string> {
-	const rangeRow = useQueryTakeFirst<{ value: unknown }>((lix) =>
-		qb(lix)
-			.selectFrom("lix_key_value_by_branch")
-			.select("value")
-			.where("key", "=", AGENT_TURN_COMMIT_RANGE_KEY)
-			.where("lixcol_branch_id", "=", "global")
-			.limit(1),
-	);
 	const ranges = useMemo(
 		() =>
-			isAgentTurnCommitRangeStore(rangeRow?.value) ? rangeRow.value.ranges : [],
-		[rangeRow?.value],
+			isAgentTurnCommitRangeStore(agentTurnCommitRangeValue)
+				? agentTurnCommitRangeValue.ranges
+				: [],
+		[agentTurnCommitRangeValue],
 	);
 	const reviewableFiles = useMemo(
 		() => collectReviewableTreeFiles(nodes),

--- a/src/extensions/markdown/index.tsx
+++ b/src/extensions/markdown/index.tsx
@@ -57,6 +57,7 @@ type MarkdownViewProps = {
 };
 
 type HistoricalMarkdownBlockRow = {
+	readonly commit_id: string;
 	readonly snapshot_content: unknown;
 };
 
@@ -298,47 +299,37 @@ function MarkdownReviewOverlay({
 	}) => Promise<void>;
 }) {
 	const workspaceDirState = useDesktopWorkspaceDir();
-	const beforeBlocks = useMarkdownBlocksAtCommit(fileId, beforeCommitId);
-	const afterBlocks = useMarkdownBlocksAtCommit(fileId, afterCommitId);
-	const resolveImageSrc = useMemo(() => {
-		const workspaceApi = desktopWorkspaceApi();
-		const workspacePath = workspaceDirState.workspaceDir;
-		if (
-			!sourceFilePath ||
-			!workspacePath ||
-			!workspaceApi?.resolveMarkdownImageSrc
-		) {
-			return undefined;
-		}
-		return (src: string) =>
-			workspaceApi.resolveMarkdownImageSrc({
-				src,
-				sourceFilePath,
-				workspacePath,
-			});
-	}, [sourceFilePath, workspaceDirState.workspaceDir]);
-	const enrichedReviewDiff = useMemo<MarkdownReviewDiff>(() => {
-		const beforeSnapshotsAvailable =
-			beforeBlocks !== undefined &&
-			(beforeBlocks.length > 0 ||
-				reviewDiff.beforeMarkdown.trim().length === 0);
-		const afterSnapshotsAvailable =
-			afterBlocks !== undefined &&
-			(afterBlocks.length > 0 || reviewDiff.afterMarkdown.trim().length === 0);
-		if (!beforeSnapshotsAvailable || !afterSnapshotsAvailable) {
-			return reviewDiff;
-		}
-		return {
-			...reviewDiff,
-			beforeBlocks: beforeBlocks ?? [],
-			afterBlocks: afterBlocks ?? [],
-		};
-	}, [afterBlocks, beforeBlocks, reviewDiff]);
-	const diffHtml = useMemo(() => {
-		return renderMarkdownReviewDiffHtml(enrichedReviewDiff, {
-			resolveImageSrc,
-		});
-	}, [enrichedReviewDiff, resolveImageSrc]);
+	const { beforeBlocks, afterBlocks } = useMarkdownBlocksAtCommits(
+		fileId,
+		beforeCommitId,
+		afterCommitId,
+	);
+	const workspaceApi = desktopWorkspaceApi();
+	const workspacePath = workspaceDirState.workspaceDir;
+	const resolveImageSrc =
+		sourceFilePath && workspacePath && workspaceApi?.resolveMarkdownImageSrc
+			? (src: string) =>
+					workspaceApi.resolveMarkdownImageSrc({
+						src,
+						sourceFilePath,
+						workspacePath,
+					})
+			: undefined;
+	const beforeSnapshotsAvailable =
+		beforeBlocks.length > 0 || reviewDiff.beforeMarkdown.trim().length === 0;
+	const afterSnapshotsAvailable =
+		afterBlocks.length > 0 || reviewDiff.afterMarkdown.trim().length === 0;
+	const enrichedReviewDiff: MarkdownReviewDiff =
+		beforeSnapshotsAvailable && afterSnapshotsAvailable
+			? {
+					...reviewDiff,
+					beforeBlocks,
+					afterBlocks,
+				}
+			: reviewDiff;
+	const diffHtml = renderMarkdownReviewDiffHtml(enrichedReviewDiff, {
+		resolveImageSrc,
+	});
 	const rejectReview = () => void onReject?.({ fileId, reviewId, review });
 
 	if (!workspaceDirState.loaded) {
@@ -377,56 +368,64 @@ function MarkdownReviewOverlayFallback() {
 	);
 }
 
-function useMarkdownBlocksAtCommit(
+function useMarkdownBlocksAtCommits(
 	fileId: string,
-	commitId: string | undefined,
-): MarkdownBlockSnapshot[] | undefined {
+	beforeCommitId: string,
+	afterCommitId: string,
+): {
+	readonly beforeBlocks: MarkdownBlockSnapshot[];
+	readonly afterBlocks: MarkdownBlockSnapshot[];
+} {
 	const rows = useQuery<HistoricalMarkdownBlockRow>(
 		(lix) =>
-			commitId
-				? historicalMarkdownBlocksQuery(lix, commitId, fileId)
-				: emptyMarkdownBlocksQuery(),
+			historicalMarkdownBlocksQuery(lix, beforeCommitId, afterCommitId, fileId),
 		{ subscribe: false },
 	);
-	return useMemo(() => {
-		if (!commitId) return undefined;
-		return rows
-			.map((row) => parseHistoricalMarkdownBlock(row.snapshot_content))
-			.filter((block): block is MarkdownBlockSnapshot => block !== null)
-			.sort(
-				(left, right) =>
-					left.orderKey.localeCompare(right.orderKey) ||
-					left.id.localeCompare(right.id),
-			);
-	}, [commitId, rows]);
+	const beforeBlocks: MarkdownBlockSnapshot[] = [];
+	const afterBlocks: MarkdownBlockSnapshot[] = [];
+	for (const row of rows) {
+		const block = parseHistoricalMarkdownBlock(row.snapshot_content);
+		if (!block) continue;
+		if (row.commit_id === beforeCommitId) {
+			beforeBlocks.push(block);
+		}
+		if (row.commit_id === afterCommitId) {
+			afterBlocks.push(block);
+		}
+	}
+	beforeBlocks.sort(compareMarkdownBlocks);
+	afterBlocks.sort(compareMarkdownBlocks);
+	return { beforeBlocks, afterBlocks };
 }
 
 function historicalMarkdownBlocksQuery(
 	lix: ReturnType<typeof useLix>,
-	commitId: string,
+	beforeCommitId: string,
+	afterCommitId: string,
 	fileId: string,
 ) {
 	const sql = `
 		WITH ranked AS (
 			SELECT
+				start_commit_id AS commit_id,
 				entity_pk,
 				snapshot_content,
 				depth,
 				ROW_NUMBER() OVER (
-					PARTITION BY entity_pk
+					PARTITION BY start_commit_id, entity_pk
 					ORDER BY depth ASC
 				) AS rn
 			FROM lix_state_history
-			WHERE start_commit_id = ?
+			WHERE start_commit_id IN (?, ?)
 				AND file_id = ?
 				AND schema_key = 'markdown_block'
 		)
-		SELECT snapshot_content
+		SELECT commit_id, snapshot_content
 		FROM ranked
 		WHERE rn = 1
 			AND snapshot_content IS NOT NULL
 	`;
-	const parameters = [commitId, fileId] as const;
+	const parameters = [beforeCommitId, afterCommitId, fileId] as const;
 	return {
 		compile: () => ({ sql, parameters }),
 		execute: async () => {
@@ -438,11 +437,14 @@ function historicalMarkdownBlocksQuery(
 	};
 }
 
-function emptyMarkdownBlocksQuery() {
-	return {
-		compile: () => ({ sql: "SELECT 1 WHERE 0", parameters: [] }),
-		execute: async () => [] as HistoricalMarkdownBlockRow[],
-	};
+function compareMarkdownBlocks(
+	left: MarkdownBlockSnapshot,
+	right: MarkdownBlockSnapshot,
+): number {
+	return (
+		left.orderKey.localeCompare(right.orderKey) ||
+		left.id.localeCompare(right.id)
+	);
 }
 
 function parseHistoricalMarkdownBlock(

--- a/src/hooks/key-value/schema.ts
+++ b/src/hooks/key-value/schema.ts
@@ -11,10 +11,12 @@ export type KeyDef<V> = {
 	defaultValue?: V | null;
 };
 
+export const ACTIVE_FILE_ID_KEY = "flashtype_active_file_id" as const;
+
 // Flashtype keys + per-key defaults
 export const KEY_VALUE_DEFINITIONS = {
 	// Cross-branch UI state, not change-controlled
-	flashtype_active_file_id: {
+	[ACTIVE_FILE_ID_KEY]: {
 		defaultBranchId: "global",
 		untracked: true,
 	} as KeyDef<string | null>,

--- a/src/shell/external-write-review-history.test.ts
+++ b/src/shell/external-write-review-history.test.ts
@@ -8,6 +8,7 @@ import type { ExternalWriteReview } from "@/extension-runtime/external-write-rev
 import {
 	getExternalWriteReview,
 	getExternalWriteReviewData,
+	getFirstPendingExternalWriteReviewFile,
 	useExternalWriteReview,
 } from "./external-write-review-history";
 import {
@@ -63,6 +64,173 @@ describe("getExternalWriteReview", () => {
 			expect(review?.beforeCommitId).toBe(beforeCommitId);
 			expect(review?.afterCommitId).toBe(afterCommitId);
 			await expectReviewData(lix, review, "turn before", "turn after");
+		} finally {
+			await lix.close();
+		}
+	});
+
+	test("finds the first file with a pending review for an agent range", async () => {
+		const lix = await openLix();
+		try {
+			await writeFile(lix, "changed-file", "/docs/changed.md", "before");
+			const beforeCommitId = await activeCommitId(lix);
+			await writeFile(lix, "changed-file", "/docs/changed.md", "after");
+			const afterCommitId = await activeCommitId(lix);
+
+			const file = await getFirstPendingExternalWriteReviewFile(
+				lix,
+				agentRange({
+					id: "range-first-review-file",
+					beforeCommitId,
+					afterCommitId,
+				}),
+			);
+
+			expect(file).toEqual({
+				fileId: "changed-file",
+				path: "/docs/changed.md",
+			});
+		} finally {
+			await lix.close();
+		}
+	});
+
+	test("returns no first pending review file for a no-op range", async () => {
+		const lix = await openLix();
+		try {
+			await writeFile(lix, "noop-first-file", "/docs/noop-first.md", "before");
+			const commitId = await activeCommitId(lix);
+			await writeFile(lix, "noop-first-file", "/docs/noop-first.md", "after");
+
+			const file = await getFirstPendingExternalWriteReviewFile(
+				lix,
+				agentRange({
+					id: "range-noop-first-file",
+					beforeCommitId: commitId,
+					afterCommitId: commitId,
+				}),
+			);
+
+			expect(file).toBeNull();
+		} finally {
+			await lix.close();
+		}
+	});
+
+	test("skips cleared files when finding the first pending review file", async () => {
+		const lix = await openLix();
+		try {
+			await writeFile(lix, "cleared-first-file", "/docs/a-cleared.md", "a0");
+			await writeFile(lix, "open-first-file", "/docs/b-open.md", "b0");
+			const beforeCommitId = await activeCommitId(lix);
+			await writeFile(lix, "cleared-first-file", "/docs/a-cleared.md", "a1");
+			await writeFile(lix, "open-first-file", "/docs/b-open.md", "b1");
+			const afterCommitId = await activeCommitId(lix);
+
+			const file = await getFirstPendingExternalWriteReviewFile(lix, {
+				...agentRange({
+					id: "range-cleared-first-file",
+					beforeCommitId,
+					afterCommitId,
+				}),
+				clearedFileIds: ["cleared-first-file"],
+			});
+
+			expect(file).toEqual({
+				fileId: "open-first-file",
+				path: "/docs/b-open.md",
+			});
+		} finally {
+			await lix.close();
+		}
+	});
+
+	test("uses deterministic path order when multiple files changed", async () => {
+		const lix = await openLix();
+		try {
+			await writeFile(lix, "z-file", "/docs/z-later.md", "z0");
+			await writeFile(lix, "a-file", "/docs/a-first.md", "a0");
+			const beforeCommitId = await activeCommitId(lix);
+			await writeFile(lix, "z-file", "/docs/z-later.md", "z1");
+			await writeFile(lix, "a-file", "/docs/a-first.md", "a1");
+			const afterCommitId = await activeCommitId(lix);
+
+			const file = await getFirstPendingExternalWriteReviewFile(
+				lix,
+				agentRange({
+					id: "range-multiple-first-file",
+					beforeCommitId,
+					afterCommitId,
+				}),
+			);
+
+			expect(file).toEqual({
+				fileId: "a-file",
+				path: "/docs/a-first.md",
+			});
+		} finally {
+			await lix.close();
+		}
+	});
+
+	test("skips files whose aggregate review cancels out", async () => {
+		const lix = await openLix();
+		try {
+			await writeFile(lix, "a-file", "/docs/a-first.md", "a0");
+			await writeFile(lix, "b-file", "/docs/b-next.md", "b0");
+			const firstBeforeCommitId = await activeCommitId(lix);
+			await writeFile(lix, "a-file", "/docs/a-first.md", "a1");
+			const firstAfterCommitId = await activeCommitId(lix);
+			const firstRange = agentRange({
+				id: "range-aggregate-first",
+				beforeCommitId: firstBeforeCommitId,
+				afterCommitId: firstAfterCommitId,
+			});
+			const secondRange = agentRange({
+				id: "range-aggregate-second",
+				beforeCommitId: firstAfterCommitId,
+				afterCommitId: firstAfterCommitId,
+			});
+			await writeFile(lix, "a-file", "/docs/a-first.md", "a0");
+			await writeFile(lix, "b-file", "/docs/b-next.md", "b1");
+			const secondAfterCommitId = await activeCommitId(lix);
+			const range = {
+				...secondRange,
+				afterCommitId: secondAfterCommitId,
+			};
+
+			const file = await getFirstPendingExternalWriteReviewFile(lix, range, [
+				firstRange,
+				range,
+			]);
+
+			expect(file).toEqual({
+				fileId: "b-file",
+				path: "/docs/b-next.md",
+			});
+		} finally {
+			await lix.close();
+		}
+	});
+
+	test("returns no first pending review file when no file is reviewable", async () => {
+		const lix = await openLix();
+		try {
+			await writeFile(lix, "same-file", "/docs/same.md", "same");
+			const beforeCommitId = await activeCommitId(lix);
+			await writeFile(lix, "same-file", "/docs/same.md", "same");
+			const afterCommitId = await activeCommitId(lix);
+
+			const file = await getFirstPendingExternalWriteReviewFile(
+				lix,
+				agentRange({
+					id: "range-no-reviewable-file",
+					beforeCommitId,
+					afterCommitId,
+				}),
+			);
+
+			expect(file).toBeNull();
 		} finally {
 			await lix.close();
 		}

--- a/src/shell/external-write-review-history.ts
+++ b/src/shell/external-write-review-history.ts
@@ -59,6 +59,49 @@ export async function getPendingExternalWriteReviewPaths(
 	return pendingPaths;
 }
 
+export async function getFirstPendingExternalWriteReviewFile(
+	lix: Lix,
+	range: AgentTurnCommitRange,
+	ranges: readonly AgentTurnCommitRange[] = [range],
+): Promise<ExternalWriteReviewFile | null> {
+	if (range.beforeCommitId === range.afterCommitId) {
+		return null;
+	}
+	const files = await qb(lix)
+		.selectFrom("lix_file")
+		.select(["id", "path"])
+		.orderBy("path", "asc")
+		.execute();
+	for (const file of files) {
+		const fileId = file.id as string;
+		if (range.clearedFileIds?.includes(fileId)) continue;
+		const path = file.path as string;
+		const rangeReview = await getAgentTurnExternalWriteReview(
+			lix,
+			fileId,
+			path,
+			[range],
+		);
+		if (!rangeReview) continue;
+		const review =
+			ranges.length === 1 && ranges[0]?.id === range.id
+				? rangeReview
+				: await getAgentTurnExternalWriteReview(lix, fileId, path, ranges);
+		if (review) {
+			return { fileId, path };
+		}
+	}
+	return null;
+}
+
+export async function getPendingExternalWriteReviewForFile(
+	lix: Lix,
+	file: ExternalWriteReviewFile,
+	ranges: readonly AgentTurnCommitRange[],
+): Promise<ExternalWriteReview | null> {
+	return getAgentTurnExternalWriteReview(lix, file.fileId, file.path, ranges);
+}
+
 export function useExternalWriteReview(args: {
 	readonly fileId?: string | null;
 	readonly path?: string | null;

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -1,22 +1,50 @@
 import { Suspense, act } from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { LixProvider } from "@/lib/lix-react";
 import { KeyValueProvider } from "@/hooks/key-value/use-key-value";
-import { KEY_VALUE_DEFINITIONS } from "@/hooks/key-value/schema";
+import {
+	ACTIVE_FILE_ID_KEY,
+	KEY_VALUE_DEFINITIONS,
+} from "@/hooks/key-value/schema";
 import { openLix } from "@/test-utils/node-lix-sdk";
 import { qb } from "@/lib/lix-kysely";
 import { FILES_EXTENSION_KIND } from "@/extension-runtime/extension-instance-helpers";
 import { resolveLixFileForOpen, V2LayoutShell } from "./layout-shell";
 import type { FlashtypeUiState } from "./ui-state";
 import type { Lix } from "@/lib/lix-types";
+import { appendAgentTurnCommitRange } from "./agent-turn-review-range";
 
 type DesktopMock = {
 	readonly emitNewFile: () => Promise<void>;
 	readonly onNewFile: ReturnType<typeof vi.fn>;
 };
 
+type AgentHooksDesktopMock = {
+	readonly emitTurnEvent: (event: AgentHookTestEvent) => Promise<void>;
+	readonly onTurnEvent: ReturnType<typeof vi.fn>;
+	readonly setActiveFilePath: ReturnType<typeof vi.fn>;
+	readonly setOpenFilePaths: ReturnType<typeof vi.fn>;
+};
+
+type AgentHookTestEvent = {
+	readonly id: string;
+	readonly instanceId?: string;
+	readonly agent: "claude" | "codex";
+	readonly phase: "turn-start" | "turn-stop";
+	readonly sessionId?: string;
+	readonly turnId?: string;
+	readonly createdAt: number;
+};
+
 const originalDesktop = window.flashtypeDesktop;
+const encoder = new TextEncoder();
 
 function queryFileTreeHosts(container: HTMLElement): NodeListOf<HTMLElement> {
 	return container.querySelectorAll<HTMLElement>("file-tree-container");
@@ -63,6 +91,9 @@ function getFileTreeHostForShadowElement(
 
 afterEach(() => {
 	cleanup();
+	for (const portal of document.querySelectorAll("[data-base-ui-portal]")) {
+		portal.remove();
+	}
 	window.flashtypeDesktop = originalDesktop;
 });
 
@@ -336,14 +367,190 @@ describe("V2LayoutShell native New File", () => {
 	});
 });
 
-async function renderShell(lix: Lix) {
+describe("V2LayoutShell agent reviews", () => {
+	test("opens the changed file diff when an agent turn changes an unopened file", async () => {
+		const desktop = installAgentHooksDesktopMock();
+		const lix = await openLix({
+			keyValues: [uiStateKeyValue(noFilesViewState())],
+		});
+		vi.spyOn(lix, "syncDiskToLix").mockResolvedValue(undefined);
+		await writeFile(lix, "agent-review-file", "/agent-review.md", "# Before");
+
+		const utils = await renderShell(lix);
+		await screen.findByTestId("central-panel-empty-state");
+		await waitFor(() => expect(desktop.onTurnEvent).toHaveBeenCalled());
+
+		await act(async () => {
+			await desktop.emitTurnEvent(agentTurnEvent("turn-start"));
+		});
+		await act(async () => {
+			await writeFile(lix, "agent-review-file", "/agent-review.md", "# After");
+		});
+		await act(async () => {
+			await desktop.emitTurnEvent(agentTurnEvent("turn-stop"));
+		});
+
+		const keepButton = await screen.findByRole("button", { name: /keep/i });
+		expect(keepButton).toHaveAttribute("data-attr", "diff-accept");
+		expect(screen.getByRole("button", { name: /undo/i })).toHaveAttribute(
+			"data-attr",
+			"diff-reject",
+		);
+		await act(async () => {
+			fireEvent.click(keepButton);
+		});
+		await screen.findByTestId("central-panel-empty-state");
+		await waitFor(() =>
+			expect(desktop.setActiveFilePath).toHaveBeenLastCalledWith({
+				filePath: null,
+			}),
+		);
+		await waitFor(async () => {
+			expect(await readActiveFileId(lix)).toBeNull();
+		});
+
+		utils.unmount();
+		await lix.close();
+	});
+
+	test("switches from an already open document to the changed file diff", async () => {
+		const desktop = installAgentHooksDesktopMock();
+		const lix = await openLix();
+		vi.spyOn(lix, "syncDiskToLix").mockResolvedValue(undefined);
+		await writeFile(lix, "open-document-file", "/open.md", "# Open");
+		await writeFile(lix, "agent-review-file", "/agent-review.md", "# Before");
+
+		const utils = await renderShell(lix, { pendingOpenFilePaths: ["open.md"] });
+		await screen.findByTestId("tiptap-editor");
+		await waitFor(() =>
+			expect(desktop.setActiveFilePath).toHaveBeenCalledWith({
+				filePath: "/open.md",
+			}),
+		);
+		await waitFor(() => expect(desktop.onTurnEvent).toHaveBeenCalled());
+
+		await act(async () => {
+			await desktop.emitTurnEvent(agentTurnEvent("turn-start"));
+		});
+		await act(async () => {
+			await writeFile(lix, "agent-review-file", "/agent-review.md", "# After");
+		});
+		await act(async () => {
+			await desktop.emitTurnEvent(agentTurnEvent("turn-stop"));
+		});
+
+		const keepButton = await screen.findByRole("button", { name: /keep/i });
+		expect(keepButton).toHaveAttribute("data-attr", "diff-accept");
+		expect(screen.getByRole("button", { name: /undo/i })).toHaveAttribute(
+			"data-attr",
+			"diff-reject",
+		);
+		await waitFor(() =>
+			expect(desktop.setActiveFilePath).toHaveBeenLastCalledWith({
+				filePath: "/agent-review.md",
+			}),
+		);
+		await waitFor(async () => {
+			expect(await readActiveFileId(lix)).toBe("agent-review-file");
+		});
+		await act(async () => {
+			fireEvent.click(keepButton);
+		});
+		await waitFor(() =>
+			expect(desktop.setActiveFilePath).toHaveBeenLastCalledWith({
+				filePath: "/open.md",
+			}),
+		);
+		await waitFor(async () => {
+			expect(await readActiveFileId(lix)).toBe("open-document-file");
+		});
+		await waitFor(() => {
+			const lastCall = desktop.setOpenFilePaths.mock.calls.at(-1)?.[0] as
+				| { filePaths?: string[] }
+				| undefined;
+			expect([...(lastCall?.filePaths ?? [])].sort()).toEqual([
+				"agent-review.md",
+				"open.md",
+			]);
+		});
+
+		utils.unmount();
+		await lix.close();
+	});
+
+	test("does not open a file when a new range clears the aggregate review", async () => {
+		const desktop = installAgentHooksDesktopMock();
+		const lix = await openLix();
+		vi.spyOn(lix, "syncDiskToLix").mockResolvedValue(undefined);
+		try {
+			await writeFile(lix, "open-document-file", "/open.md", "# Open");
+			await writeFile(lix, "agent-review-file", "/agent-review.md", "# Before");
+			const beforeCommitId = await activeCommitId(lix);
+			await writeFile(lix, "agent-review-file", "/agent-review.md", "# After");
+			const middleCommitId = await activeCommitId(lix);
+			await appendAgentTurnCommitRange(lix, {
+				id: "seeded-range",
+				agent: "codex",
+				beforeCommitId,
+				afterCommitId: middleCommitId,
+				startedAt: 1,
+				completedAt: 2,
+			});
+
+			const utils = await renderShell(lix, {
+				pendingOpenFilePaths: ["open.md"],
+			});
+			await screen.findByTestId("tiptap-editor");
+			await waitFor(() =>
+				expect(desktop.setActiveFilePath).toHaveBeenLastCalledWith({
+					filePath: "/open.md",
+				}),
+			);
+			await waitFor(() => expect(desktop.onTurnEvent).toHaveBeenCalled());
+
+			await act(async () => {
+				await desktop.emitTurnEvent(agentTurnEvent("turn-start"));
+			});
+			await act(async () => {
+				await writeFile(
+					lix,
+					"agent-review-file",
+					"/agent-review.md",
+					"# Before",
+				);
+			});
+			await act(async () => {
+				await desktop.emitTurnEvent(agentTurnEvent("turn-stop"));
+			});
+
+			await waitFor(async () => {
+				expect(await readActiveFileId(lix)).toBe("open-document-file");
+			});
+			expect(
+				screen.queryByRole("group", { name: "External write review actions" }),
+			).toBeNull();
+			expect(desktop.setActiveFilePath).toHaveBeenLastCalledWith({
+				filePath: "/open.md",
+			});
+
+			utils.unmount();
+		} finally {
+			await lix.close();
+		}
+	});
+});
+
+async function renderShell(
+	lix: Lix,
+	props: Partial<Parameters<typeof V2LayoutShell>[0]> = {},
+) {
 	let result: ReturnType<typeof render> | undefined;
 	await act(async () => {
 		result = render(
 			<LixProvider lix={lix}>
 				<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
 					<Suspense fallback={<div data-testid="loading" />}>
-						<V2LayoutShell workspaceName="Workspace" />
+						<V2LayoutShell workspaceName="Workspace" {...props} />
 					</Suspense>
 				</KeyValueProvider>
 			</LixProvider>,
@@ -360,6 +567,42 @@ async function expectNewFileCreatedAndOpened(lix: Lix) {
 	await act(async () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
+}
+
+async function writeFile(
+	lix: Lix,
+	id: string,
+	path: string,
+	text: string,
+): Promise<void> {
+	await qb(lix)
+		.insertInto("lix_file")
+		.values({ id, path, data: encoder.encode(text) })
+		.onConflict((oc) =>
+			oc.column("id").doUpdateSet({ path, data: encoder.encode(text) }),
+		)
+		.execute();
+}
+
+async function activeCommitId(lix: Lix): Promise<string> {
+	const result = await lix.execute(
+		"SELECT lix_active_branch_commit_id() AS commit_id",
+	);
+	const commitId = result.rows[0]?.get("commit_id");
+	if (typeof commitId !== "string") {
+		throw new Error("Missing active commit id");
+	}
+	return commitId;
+}
+
+async function readActiveFileId(lix: Lix): Promise<unknown> {
+	const row = await qb(lix)
+		.selectFrom("lix_key_value_by_branch")
+		.select("value")
+		.where("key", "=", ACTIVE_FILE_ID_KEY)
+		.where("lixcol_branch_id", "=", "global")
+		.executeTakeFirst();
+	return row?.value;
 }
 
 function installDesktopMock(): DesktopMock {
@@ -387,6 +630,54 @@ function installDesktopMock(): DesktopMock {
 			await listener();
 		},
 		onNewFile,
+	};
+}
+
+function installAgentHooksDesktopMock(): AgentHooksDesktopMock {
+	let listener: ((event: unknown) => void | Promise<void>) | null = null;
+	const setActiveFilePath = vi.fn();
+	const setOpenFilePaths = vi.fn();
+	const onTurnEvent = vi.fn(
+		(nextListener: (event: unknown) => void | Promise<void>) => {
+			listener = nextListener;
+			return () => {
+				if (listener === nextListener) {
+					listener = null;
+				}
+			};
+		},
+	);
+	window.flashtypeDesktop = {
+		workspace: {
+			setActiveFilePath,
+			setOpenFilePaths,
+		},
+		agentHooks: {
+			onTurnEvent,
+		},
+	} as unknown as Window["flashtypeDesktop"];
+	return {
+		emitTurnEvent: async (event) => {
+			if (!listener) {
+				throw new Error("agent turn listener was not registered");
+			}
+			await listener(event);
+		},
+		onTurnEvent,
+		setActiveFilePath,
+		setOpenFilePaths,
+	};
+}
+
+function agentTurnEvent(phase: "turn-start" | "turn-stop"): AgentHookTestEvent {
+	return {
+		id: `agent-review-${phase}`,
+		instanceId: "agent-review-instance",
+		agent: "codex",
+		phase,
+		sessionId: "agent-review-session",
+		turnId: "agent-review-turn",
+		createdAt: phase === "turn-start" ? 1 : 2,
 	};
 }
 

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -21,9 +21,10 @@ import {
 	useSensor,
 	useSensors,
 } from "@dnd-kit/core";
-import { useLix } from "@/lib/lix-react";
+import { useLix, useQueryTakeFirst } from "@/lib/lix-react";
 import type { Lix } from "@/lib/lix-types";
 import { useKeyValue } from "@/hooks/key-value/use-key-value";
+import { ACTIVE_FILE_ID_KEY } from "@/hooks/key-value/schema";
 import { SidePanel } from "./side-panel";
 import { CentralPanel } from "./central-panel";
 import { TopBar } from "./top-bar";
@@ -90,11 +91,18 @@ import {
 } from "./panel-utils";
 import { buildAgentLaunchArgsWithActiveFile } from "./agent-launch";
 import {
+	AGENT_TURN_COMMIT_RANGE_KEY,
 	clearAgentTurnCommitRangeFile,
 	appendAgentTurnCommitRange,
+	isAgentTurnCommitRangeStore,
+	readAgentTurnCommitRanges,
 	type AgentTurnCommitRange,
 } from "./agent-turn-review-range";
-import { getFileDataAtCommit } from "./external-write-review-history";
+import {
+	getFileDataAtCommit,
+	getFirstPendingExternalWriteReviewFile,
+	getPendingExternalWriteReviewForFile,
+} from "./external-write-review-history";
 
 type NewFileDraftHandlerRegistration = {
 	readonly panelSide: PanelSide;
@@ -119,6 +127,17 @@ type ActiveAgentTurn = {
 	readonly key: string;
 	readonly event: AgentHookTurnEvent;
 	readonly beforeCommitIdPromise: Promise<string | null>;
+};
+
+type ResolvedFileViewOpenResult = {
+	readonly kind: ExtensionKind;
+	readonly instance: string;
+};
+
+type AgentDiffReturnTarget = {
+	readonly openedInstance: string;
+	readonly previousActiveFileId: string | null;
+	readonly previousActiveInstance: string | null;
 };
 
 const stripLaunchArgs = (view: ExtensionInstance): ExtensionInstance => {
@@ -625,9 +644,7 @@ function LayoutShellActiveFileLoader(
 		readonly setUiStateKV: (newValue: FlashtypeUiState) => Promise<void>;
 	},
 ) {
-	const [activeFileId, setActiveFileId] = useKeyValue(
-		"flashtype_active_file_id",
-	);
+	const [activeFileId, setActiveFileId] = useKeyValue(ACTIVE_FILE_ID_KEY);
 	return (
 		<LayoutShellLoadedContent
 			{...props}
@@ -717,6 +734,12 @@ function LayoutShellLoadedContent({
 	const openDiffReviewByFileIdRef = useRef(
 		new Map<string, ExternalWriteReview>(),
 	);
+	const agentDiffReturnTargetsRef = useRef(
+		new Map<string, AgentDiffReturnTarget>(),
+	);
+	const agentDiffReturnTargetsByFileIdRef = useRef(
+		new Map<string, AgentDiffReturnTarget>(),
+	);
 	const resolveDiffReviewTelemetryRef = useRef<
 		| ((
 				review: ExternalWriteReview,
@@ -725,6 +748,11 @@ function LayoutShellLoadedContent({
 		| null
 	>(null);
 	const activeAgentTurnsRef = useRef(new Map<string, ActiveAgentTurn>());
+	const openFirstAgentDiffForRangeRef = useRef<
+		((range: AgentTurnCommitRange) => Promise<void>) | null
+	>(null);
+	const autoOpenedAgentRangeIdsRef = useRef(new Set<string>());
+	const hasSeededAutoOpenedAgentRangesRef = useRef(false);
 	const workspaceIdRef = useRef<string | undefined>(undefined);
 	const panelStatesRef = useRef({
 		left: leftPanel,
@@ -756,6 +784,22 @@ function LayoutShellLoadedContent({
 	useEffect(() => {
 		workspaceIdRef.current = undefined;
 	}, [lix]);
+
+	const agentTurnCommitRangeRow = useQueryTakeFirst<{ value: unknown }>((lix) =>
+		qb(lix)
+			.selectFrom("lix_key_value_by_branch")
+			.select("value")
+			.where("key", "=", AGENT_TURN_COMMIT_RANGE_KEY)
+			.where("lixcol_branch_id", "=", "global")
+			.limit(1),
+	);
+	const agentTurnCommitRanges = useMemo(
+		() =>
+			isAgentTurnCommitRangeStore(agentTurnCommitRangeRow?.value)
+				? agentTurnCommitRangeRow.value.ranges
+				: [],
+		[agentTurnCommitRangeRow?.value],
+	);
 
 	useEffect(() => {
 		panelStatesRef.current = {
@@ -893,6 +937,15 @@ function LayoutShellLoadedContent({
 						completedAt: Date.now(),
 					};
 					await appendAgentTurnCommitRange(lix, range);
+					autoOpenedAgentRangeIdsRef.current.add(range.id);
+					try {
+						await openFirstAgentDiffForRangeRef.current?.(range);
+					} catch (error: unknown) {
+						console.warn(
+							"[agent-turn-review] failed to open changed file review",
+							error,
+						);
+					}
 				}
 			} catch (error: unknown) {
 				activeAgentTurnsRef.current.delete(key);
@@ -1366,10 +1419,11 @@ function LayoutShellLoadedContent({
 			trackTelemetry?: boolean;
 			trackDocumentOpenAttempt?: boolean;
 			trackDocumentViewed?: boolean;
-		}) => {
+		}): ResolvedFileViewOpenResult => {
 			const handler =
 				findFileHandlerExtension(extensionMap.values(), filePath) ?? undefined;
 			const kind = handler?.kind ?? FILE_EXTENSION_KIND;
+			const instance = fileExtensionInstanceForKind(kind, fileId);
 			if (trackDocumentOpenAttempt) {
 				captureWorkspaceTelemetry("document_open_attempted", {
 					...documentOpenAttemptTelemetryProperties({ filePath, handler }),
@@ -1389,7 +1443,7 @@ function LayoutShellLoadedContent({
 			handleOpenView({
 				panel,
 				kind,
-				instance: fileExtensionInstanceForKind(kind, fileId),
+				instance,
 				state: {
 					...buildFileExtensionProps({ fileId, filePath }),
 					...(state ?? {}),
@@ -1398,9 +1452,83 @@ function LayoutShellLoadedContent({
 				focus,
 				pending,
 			});
+			return { kind, instance };
 		},
 		[handleOpenView, extensionMap, captureWorkspaceTelemetry],
 	);
+
+	const openFirstAgentDiffForRange = useCallback(
+		async (range: AgentTurnCommitRange) => {
+			const storedRanges = await readAgentTurnCommitRanges(lix);
+			const ranges = storedRanges.some((candidate) => candidate.id === range.id)
+				? storedRanges
+				: [...storedRanges, range];
+			const file = await getFirstPendingExternalWriteReviewFile(
+				lix,
+				range,
+				ranges,
+			);
+			if (!file) return;
+			const review = await getPendingExternalWriteReviewForFile(
+				lix,
+				file,
+				ranges,
+			);
+			if (!review) return;
+			const currentCentralPanel = panelStatesRef.current.central;
+			const previousActiveInstance =
+				currentCentralPanel.activeInstance ??
+				currentCentralPanel.views[0]?.instance ??
+				null;
+			const previousActiveEntry = previousActiveInstance
+				? (currentCentralPanel.views.find(
+						(entry) => entry.instance === previousActiveInstance,
+					) ?? null)
+				: null;
+			const previousActiveFileId =
+				activeMarkdownFileIdFromExtensionInstance(previousActiveEntry);
+			const openedView = openResolvedFileView({
+				panel: "central",
+				fileId: file.fileId,
+				filePath: file.path,
+				focus: true,
+				trackDocumentOpenAttempt: true,
+				trackDocumentViewed: true,
+			});
+			const target =
+				agentDiffReturnTargetsByFileIdRef.current.get(file.fileId) ??
+				({
+					openedInstance: openedView.instance,
+					previousActiveFileId,
+					previousActiveInstance,
+				} satisfies AgentDiffReturnTarget);
+			agentDiffReturnTargetsByFileIdRef.current.set(file.fileId, target);
+			agentDiffReturnTargetsRef.current.set(review.reviewId, target);
+			void setActiveFileId(file.fileId);
+		},
+		[lix, openResolvedFileView, setActiveFileId],
+	);
+	openFirstAgentDiffForRangeRef.current = openFirstAgentDiffForRange;
+
+	useEffect(() => {
+		if (!hasSeededAutoOpenedAgentRangesRef.current) {
+			for (const range of agentTurnCommitRanges) {
+				autoOpenedAgentRangeIdsRef.current.add(range.id);
+			}
+			hasSeededAutoOpenedAgentRangesRef.current = true;
+			return;
+		}
+		for (const range of agentTurnCommitRanges) {
+			if (autoOpenedAgentRangeIdsRef.current.has(range.id)) continue;
+			autoOpenedAgentRangeIdsRef.current.add(range.id);
+			void openFirstAgentDiffForRange(range).catch((error: unknown) => {
+				console.warn(
+					"[agent-turn-review] failed to open changed file review",
+					error,
+				);
+			});
+		}
+	}, [agentTurnCommitRanges, openFirstAgentDiffForRange]);
 
 	const handleOpenFile = useCallback(
 		async ({
@@ -1544,6 +1672,57 @@ function LayoutShellLoadedContent({
 		[],
 	);
 
+	const restoreAgentDiffReturnTarget = useCallback(
+		(review: ExternalWriteReview) => {
+			const target = agentDiffReturnTargetsRef.current.get(review.reviewId);
+			if (!target) return;
+			for (const [
+				reviewId,
+				storedTarget,
+			] of agentDiffReturnTargetsRef.current) {
+				if (storedTarget === target) {
+					agentDiffReturnTargetsRef.current.delete(reviewId);
+				}
+			}
+			agentDiffReturnTargetsByFileIdRef.current.delete(review.fileId);
+			setPanelState(
+				"central",
+				(current) => {
+					const views =
+						target.previousActiveInstance === null
+							? current.views.filter(
+									(entry) => entry.instance !== target.openedInstance,
+								)
+							: current.views;
+					const previousViewExists =
+						target.previousActiveInstance !== null &&
+						views.some(
+							(entry) => entry.instance === target.previousActiveInstance,
+						);
+					const activeInstance = previousViewExists
+						? target.previousActiveInstance
+						: null;
+					return { views, activeInstance };
+				},
+				{ focus: true },
+			);
+			void setActiveFileId(target.previousActiveFileId);
+		},
+		[setActiveFileId, setPanelState],
+	);
+
+	const resolveExternalWriteReview = useCallback(
+		(
+			review: ExternalWriteReview,
+			outcome: "accepted" | "abandoned" | "rejected",
+		) => {
+			const resolved = resolveDiffReviewTelemetry(review, outcome);
+			restoreAgentDiffReturnTarget(review);
+			return resolved;
+		},
+		[resolveDiffReviewTelemetry, restoreAgentDiffReturnTarget],
+	);
+
 	const isExternalWriteReviewCurrent = useCallback(
 		async (review: ExternalWriteReview): Promise<boolean> => {
 			const [current, afterData] = await Promise.all([
@@ -1583,13 +1762,13 @@ function LayoutShellLoadedContent({
 			const outcome = (await isExternalWriteReviewCurrent(review))
 				? "accepted"
 				: "abandoned";
-			resolveDiffReviewTelemetry(review, outcome);
+			resolveExternalWriteReview(review, outcome);
 		},
 		[
 			lix,
 			getExternalWriteReviewForFile,
 			isExternalWriteReviewCurrent,
-			resolveDiffReviewTelemetry,
+			resolveExternalWriteReview,
 		],
 	);
 
@@ -1610,7 +1789,7 @@ function LayoutShellLoadedContent({
 					reviewId: review.reviewId,
 					agentTurnRangeIds: review.agentTurnRangeIds,
 				});
-				resolveDiffReviewTelemetry(review, "abandoned");
+				resolveExternalWriteReview(review, "abandoned");
 				return;
 			}
 			const beforeData = await getFileDataAtCommit(
@@ -1624,7 +1803,7 @@ function LayoutShellLoadedContent({
 					reviewId: review.reviewId,
 					agentTurnRangeIds: review.agentTurnRangeIds,
 				});
-				resolveDiffReviewTelemetry(review, "abandoned");
+				resolveExternalWriteReview(review, "abandoned");
 				return;
 			}
 			const { fileId } = args;
@@ -1639,16 +1818,16 @@ function LayoutShellLoadedContent({
 				agentTurnRangeIds: review.agentTurnRangeIds,
 			});
 			if (Number(result.numUpdatedRows) > 0) {
-				resolveDiffReviewTelemetry(review, "rejected");
+				resolveExternalWriteReview(review, "rejected");
 			} else {
-				resolveDiffReviewTelemetry(review, "abandoned");
+				resolveExternalWriteReview(review, "abandoned");
 			}
 		},
 		[
 			lix,
 			getExternalWriteReviewForFile,
 			isExternalWriteReviewCurrent,
-			resolveDiffReviewTelemetry,
+			resolveExternalWriteReview,
 		],
 	);
 
@@ -1706,13 +1885,13 @@ function LayoutShellLoadedContent({
 						review &&
 						!diffResolvedReviewIdsRef.current.has(review.reviewId)
 					) {
-						resolveDiffReviewTelemetry(review, "abandoned");
+						resolveExternalWriteReview(review, "abandoned");
 					}
 					break;
 				}
 			}
 		},
-		[setPanelState, resolveDiffReviewTelemetry],
+		[setPanelState, resolveExternalWriteReview],
 	);
 
 	const handleCloseFileViews = useCallback(
@@ -1750,11 +1929,11 @@ function LayoutShellLoadedContent({
 					removedReview &&
 					!diffResolvedReviewIdsRef.current.has(removedReview.reviewId)
 				) {
-					resolveDiffReviewTelemetry(removedReview, "abandoned");
+					resolveExternalWriteReview(removedReview, "abandoned");
 				}
 			}
 		},
-		[setPanelState, resolveDiffReviewTelemetry],
+		[setPanelState, resolveExternalWriteReview],
 	);
 
 	const activeCentralEntry = useMemo(() => {
@@ -2051,7 +2230,6 @@ function LayoutShellLoadedContent({
 		activeMarkdownFileIdFromExtensionInstance(activeCentralEntry);
 
 	useEffect(() => {
-		if (!activeCentralFileId) return;
 		if (activeFileId === activeCentralFileId) return;
 		void setActiveFileId(activeCentralFileId);
 	}, [activeCentralFileId, activeFileId, setActiveFileId]);


### PR DESCRIPTION
## Summary

- Automatically opens the first reviewable changed file when an agent turn records changes, so users see the diff even if that file was not already open.
- Chooses files deterministically by path and skips no-op, cleared, byte-identical, and aggregate-cancelled reviews.
- Restores the previous active file after Keep/Undo, including the case where another document was active before the agent diff opened.
- Keeps the file tree selection in sync for agent-opened files without stomping deliberate user selections.

## Root Cause

Agent changes were only recorded as pending review ranges. If the changed file was not already the active/open document, the editor never navigated to the pending diff, so users could miss agent writes.

## Validation

- `./node_modules/.bin/vitest run src/shell/external-write-review-history.test.ts src/shell/layout-shell.test.tsx src/extensions/files/index.test.tsx`
- `./node_modules/.bin/tsc -p . --pretty false`
- `./node_modules/.bin/prettier --check src/extensions/files/file-tree.tsx src/extensions/files/index.tsx src/extensions/files/index.test.tsx src/shell/external-write-review-history.ts src/shell/external-write-review-history.test.ts src/shell/layout-shell.tsx src/shell/layout-shell.test.tsx src/extensions/markdown/index.tsx src/hooks/key-value/schema.ts`
- `git diff --check`

## Demo Video

Recorded locally and intentionally not committed:

`/tmp/flashtype-pr-assets/open-agent-diff-review.webm`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central-panel navigation, active-file key-value sync, and external-write review resolution on agent turns; behavior is covered by new layout-shell and review-history tests but touches core editing flow.
> 
> **Overview**
> When an agent turn finishes, the shell **automatically opens the first reviewable changed file** in the central panel (by path order), skipping no-op ranges, cleared files, byte-identical changes, and aggregate-cancelled reviews. **Keep/Undo** on that diff restores the prior central tab and `flashtype_active_file_id`, including when another document was already open.
> 
> The **Files** view subscribes to `ACTIVE_FILE_ID_KEY` so tree selection follows agent-opened files, with guards so a deliberate click is not overwritten when the file list refreshes. Review history adds **`getFirstPendingExternalWriteReviewFile`** / **`getPendingExternalWriteReviewForFile`**; markdown review overlays fetch before/after block snapshots in **one** history query.
> 
> Tooling: **pnpm 11.7.0**, peer/build rules moved to `pnpm-workspace.yaml`, and `ACTIVE_FILE_ID_KEY` exported from the key-value schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6bce28fc970c223302c7780805b3ae4988cfa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->