### PR TITLE
[codex] Add close file menu item

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -496,6 +496,24 @@ function requestNewFileFromApplicationMenu() {
 	window.webContents.send("workspace:newFile");
 }
 
+function requestCloseFileFromApplicationMenu() {
+	if (!canOpenWorkspaceWindows()) {
+		return;
+	}
+	const window = getWorkspaceWindowForFileAction();
+	if (!window || window.webContents.isDestroyed()) {
+		return;
+	}
+	if (!isHeadless) {
+		if (window.isMinimized()) {
+			window.restore();
+		}
+		window.show();
+		window.focus();
+	}
+	window.webContents.send("workspace:closeFile");
+}
+
 async function toggleTrackChangesFromApplicationMenu(trackChanges) {
 	const window = getWorkspaceWindowForFileAction();
 	if (!window || window.isDestroyed() || !getWorkspace(window)) {
@@ -1135,6 +1153,7 @@ function registerAppIpc() {
 		}
 		applyDockWindowChrome(window);
 		updateDockMenu();
+		installApplicationMenu();
 	});
 	ipcMain.handle("workspace:setOpenFilePaths", (event, payload) => {
 		const window = BrowserWindow.fromWebContents(event.sender);
@@ -1810,6 +1829,9 @@ function buildFileMenu() {
 	const trackingWorkspace = trackingWindow
 		? getWorkspace(trackingWindow)
 		: null;
+	const hasActiveDocument = trackingWindow
+		? activeFilePathsByWindowId.has(trackingWindow.id)
+		: false;
 	return {
 		label: "File",
 		submenu: [
@@ -1835,6 +1857,14 @@ function buildFileMenu() {
 				enabled: Boolean(getWorkspaceWindowForFileAction()),
 				click: () => {
 					requestNewFileFromApplicationMenu();
+				},
+			},
+			{
+				id: "close-file",
+				label: "Close File",
+				enabled: hasActiveDocument,
+				click: () => {
+					requestCloseFileFromApplicationMenu();
 				},
 			},
 			{

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -47,6 +47,13 @@ const workspace = {
 			ipcRenderer.off("workspace:newFile", wrapped);
 		};
 	},
+	onCloseFile: (listener) => {
+		const wrapped = () => listener();
+		ipcRenderer.on("workspace:closeFile", wrapped);
+		return () => {
+			ipcRenderer.off("workspace:closeFile", wrapped);
+		};
+	},
 	open: (payload) => ipcRenderer.invoke("workspace:open", payload),
 	openInNewWindow: (payload) =>
 		ipcRenderer.invoke("workspace:openInNewWindow", payload),

--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -227,6 +227,8 @@ export type DesktopWorkspaceApi = {
 	profile(): Promise<DesktopWorkspaceProfile | null>;
 	/** Fired when the native menu asks the workspace UI to start a new file. */
 	onNewFile(listener: () => void): () => void;
+	/** Fired when the native menu asks the workspace UI to close the active file. */
+	onCloseFile(listener: () => void): () => void;
 	/**
 	 * Opens a workspace. With a path (e.g. from a dropped folder) it adopts it
 	 * directly; without one it shows the native directory picker. Resolves to

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -17,7 +17,9 @@ import type { FlashtypeUiState } from "./ui-state";
 import type { Lix } from "@/lib/lix-types";
 
 type DesktopMock = {
+	readonly emitCloseFile: () => Promise<void>;
 	readonly emitNewFile: () => Promise<void>;
+	readonly onCloseFile: ReturnType<typeof vi.fn>;
 	readonly onNewFile: ReturnType<typeof vi.fn>;
 	readonly setActiveFilePath: ReturnType<typeof vi.fn>;
 	readonly setOpenFilePaths: ReturnType<typeof vi.fn>;
@@ -430,6 +432,37 @@ describe("V2LayoutShell native New File", () => {
 	});
 });
 
+describe("V2LayoutShell native Close File", () => {
+	test("closes the active central document", async () => {
+		const desktop = installDesktopMock();
+		const lix = await openLix({
+			keyValues: [uiStateKeyValue(openFileState("file_active", "/active.md"))],
+		});
+		await qb(lix)
+			.insertInto("lix_file")
+			.values({
+				id: "file_active",
+				path: "/active.md",
+				data: new TextEncoder().encode("# Active"),
+			})
+			.execute();
+
+		const utils = await renderShell(lix);
+		await screen.findByTestId("tiptap-editor");
+		await waitFor(() => expect(desktop.onCloseFile).toHaveBeenCalled());
+
+		await act(async () => {
+			await desktop.emitCloseFile();
+		});
+
+		await screen.findByTestId("central-panel-empty-state");
+		expect(screen.queryByTestId("tiptap-editor")).toBeNull();
+
+		utils.unmount();
+		await lix.close();
+	});
+});
+
 describe("V2LayoutShell active file sidebar highlight", () => {
 	test("highlights the active central file in the Files view", async () => {
 		const lix = await openLix({
@@ -679,31 +712,50 @@ async function unmountShell(utils: ReturnType<typeof render>): Promise<void> {
 }
 
 function installDesktopMock(): DesktopMock {
-	let listener: (() => void | Promise<void>) | null = null;
+	let newFileListener: (() => void | Promise<void>) | null = null;
+	let closeFileListener: (() => void | Promise<void>) | null = null;
 	const setActiveFilePath = vi.fn();
 	const setOpenFilePaths = vi.fn();
 	const onNewFile = vi.fn((nextListener: () => void | Promise<void>) => {
-		listener = nextListener;
+		newFileListener = nextListener;
 		return () => {
-			if (listener === nextListener) {
-				listener = null;
+			if (newFileListener === nextListener) {
+				newFileListener = null;
 			}
 		};
 	});
+	const onCloseFile = vi.fn(
+		(nextListener: () => void | Promise<void>) => {
+			closeFileListener = nextListener;
+			return () => {
+				if (closeFileListener === nextListener) {
+					closeFileListener = null;
+				}
+			};
+		},
+	);
 	window.flashtypeDesktop = {
 		workspace: {
+			onCloseFile,
 			onNewFile,
 			setActiveFilePath,
 			setOpenFilePaths,
 		},
 	} as unknown as Window["flashtypeDesktop"];
 	return {
+		emitCloseFile: async () => {
+			if (!closeFileListener) {
+				throw new Error("native Close File listener was not registered");
+			}
+			await closeFileListener();
+		},
 		emitNewFile: async () => {
-			if (!listener) {
+			if (!newFileListener) {
 				throw new Error("native New File listener was not registered");
 			}
-			await listener();
+			await newFileListener();
 		},
+		onCloseFile,
 		onNewFile,
 		setActiveFilePath,
 		setOpenFilePaths,

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -2156,6 +2156,24 @@ function LayoutShellLoadedContent({
 		};
 	}, [handleNativeNewFile]);
 
+	const handleNativeCloseFile = useCallback(() => {
+		if (!activeCentralEntry?.instance) return;
+		if (typeof activeCentralEntry.state?.filePath !== "string") return;
+		handleCloseView({
+			panel: "central",
+			instance: activeCentralEntry.instance,
+			focus: true,
+		});
+	}, [activeCentralEntry, handleCloseView]);
+
+	useEffect(() => {
+		const unsubscribe =
+			window.flashtypeDesktop?.workspace.onCloseFile?.(handleNativeCloseFile);
+		return () => {
+			unsubscribe?.();
+		};
+	}, [handleNativeCloseFile]);
+
 	const activeCentralFileId =
 		activeMarkdownFileIdFromExtensionInstance(activeCentralEntry);
 


### PR DESCRIPTION
## Summary
- Add a native File > Close File menu item.
- Send a workspace close-file event from Electron to the renderer.
- Close the active central file tab from the shell when that native command fires.

## Validation
- ./node_modules/.bin/vitest run src/shell/layout-shell.test.tsx
- ./node_modules/.bin/vitest run src/extensions/files/index.test.tsx
- ./node_modules/.bin/tsc -p . --pretty false
- node --check electron/main.mjs && node --check electron/preload.mjs
- git diff --check HEAD~1..HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop menu and renderer tab-close wiring only; reuses existing close-view logic with no auth or persistence changes beyond menu refresh.
> 
> **Overview**
> Adds a native **File > Close File** action on desktop, wired the same way as **New File**: the main process focuses the target workspace window and sends `workspace:closeFile` to the renderer.
> 
> The menu item is **enabled only when that window has an active document** (tracked via `activeFilePathsByWindowId`), and the app menu is **refreshed when the active file path changes** so the control stays in sync. Preload and desktop types expose **`onCloseFile`** for the shell.
> 
> **`V2LayoutShell`** subscribes to that event and closes the **active central** tab through the existing `handleCloseView` path. A layout-shell test covers the native close flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53439354b70871de78562eb6f272d073a03d1a6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->