### PR TITLE
Improve branch switching and view state handling

### DIFF
--- a/e2e/branch-switcher.spec.ts
+++ b/e2e/branch-switcher.spec.ts
@@ -111,30 +111,12 @@ async function createBranchFromUi(
 	branchName: string,
 ): Promise<void> {
 	await openBranchMenu(page);
-	await page.evaluate((nextBranchName) => {
-		(window as any).__flashtypeBranchPromptCalls = [];
-		window.prompt = (message?: string, defaultValue?: string) => {
-			(window as any).__flashtypeBranchPromptCalls.push({
-				message,
-				defaultValue,
-			});
-			return nextBranchName;
-		};
-	}, branchName);
 	await page.getByRole("menuitem", { name: "Create branch" }).click();
-	await expect
-		.poll(
-			async () =>
-				await page.evaluate(
-					() => (window as any).__flashtypeBranchPromptCalls?.length ?? 0,
-				),
-		)
-		.toBe(1);
-	await expect(
-		page.evaluate(() => (window as any).__flashtypeBranchPromptCalls),
-	).resolves.toEqual([
-		{ message: "Name the new branch", defaultValue: "draft-2" },
-	]);
+	const input = page.getByRole("textbox", { name: "Branch name" });
+	await expect(input).toBeVisible();
+	await expect(input).toHaveValue("draft-2");
+	await input.fill(branchName);
+	await input.press("Enter");
 }
 
 async function switchBranchFromUi(

--- a/e2e/branch-switcher.spec.ts
+++ b/e2e/branch-switcher.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test, type Page } from "@playwright/test";
+import type { ElectronApplication } from "playwright";
+import { FsBackend, openLix } from "@lix-js/sdk";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+	closeElectronApp,
+	ensureFilesViewOpenInLeftPanel,
+	expectPathMissing,
+	fileTreeFile,
+	launchDevElectronApp,
+	registerRendererConsoleLogging,
+} from "./electron-test-utils";
+
+test("persistent workspace branch switching keeps sidebar and disk on the active branch", async ({
+	browserName: _browserName,
+}, testInfo) => {
+	const workspaceDir = testInfo.outputPath("persistent-branch-workspace");
+	const sharedPath = path.join(workspaceDir, "shared.md");
+	const draftOnlyPath = path.join(workspaceDir, "draft-only.md");
+
+	let electronApp: ElectronApplication | undefined;
+	try {
+		await mkdir(workspaceDir, { recursive: true });
+		await writeFile(sharedPath, "# Main shared\n", "utf8");
+		await writeFile(
+			path.join(workspaceDir, "main-only.md"),
+			"# Main only\n",
+			"utf8",
+		);
+		await initializeLixWorkspace(workspaceDir);
+
+		electronApp = await launchDevElectronApp(workspaceDir);
+		const page = await electronApp.firstWindow();
+		registerRendererConsoleLogging(page);
+
+		await ensureFilesViewOpenInLeftPanel(page);
+		await expect(fileTreeFile(page, "/shared.md")).toBeVisible();
+		await expect(fileTreeFile(page, "/main-only.md")).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Select branch" }),
+		).toHaveText(/main/);
+
+		await createBranchFromUi(page, "draft-ui");
+		await expect(
+			page.getByRole("button", { name: "Select branch" }),
+		).toHaveText(/draft-ui/);
+
+		await writeDraftBranchState(page);
+		await expect(fileTreeFile(page, "/draft-only.md")).toBeVisible();
+		await expect(fileTreeFile(page, "/shared.md")).toBeVisible();
+		await expectDiskText(sharedPath, "# Draft shared\n");
+		await expectDiskText(draftOnlyPath, "# Draft only\n");
+
+		await switchBranchFromUi(page, "main");
+		await expect(
+			page.getByRole("button", { name: "Select branch" }),
+		).toHaveText(/main/);
+		await expect(fileTreeFile(page, "/shared.md")).toBeVisible();
+		await expect(fileTreeFile(page, "/main-only.md")).toBeVisible();
+		await expect(fileTreeFile(page, "/draft-only.md")).toHaveCount(0);
+		await expectDiskText(sharedPath, "# Main shared\n");
+		await expectPathMissing(draftOnlyPath);
+	} finally {
+		await closeElectronApp(electronApp);
+	}
+});
+
+test("ephemeral workspace shows disabled branch UI without create or switch actions", async ({
+	browserName: _browserName,
+}, testInfo) => {
+	const workspaceDir = testInfo.outputPath("ephemeral-branch-workspace");
+
+	let electronApp: ElectronApplication | undefined;
+	try {
+		await mkdir(workspaceDir, { recursive: true });
+		await writeFile(path.join(workspaceDir, "note.md"), "# Note\n", "utf8");
+
+		electronApp = await launchDevElectronApp(workspaceDir);
+		const page = await electronApp.firstWindow();
+		registerRendererConsoleLogging(page);
+
+		await ensureFilesViewOpenInLeftPanel(page);
+		await expect(fileTreeFile(page, "/note.md")).toBeVisible();
+		await expectPathMissing(path.join(workspaceDir, ".lix"));
+
+		const branchTrigger = page.getByRole("button", { name: "Select branch" });
+		await expect(branchTrigger).toBeDisabled();
+		await expect(branchTrigger).toHaveText("No branch");
+		await expect(branchTrigger).toHaveAttribute(
+			"data-attr",
+			"branch-switcher-disabled",
+		);
+		await expect(
+			page.getByRole("menuitem", { name: "Create branch" }),
+		).toHaveCount(0);
+	} finally {
+		await closeElectronApp(electronApp);
+	}
+});
+
+async function initializeLixWorkspace(workspaceDir: string): Promise<void> {
+	const lix = await openLix({
+		backend: new FsBackend({ path: workspaceDir, syncAllFiles: true }),
+	});
+	await lix.close();
+}
+
+async function createBranchFromUi(
+	page: Page,
+	branchName: string,
+): Promise<void> {
+	await openBranchMenu(page);
+	await page.evaluate((nextBranchName) => {
+		(window as any).__flashtypeBranchPromptCalls = [];
+		window.prompt = (message?: string, defaultValue?: string) => {
+			(window as any).__flashtypeBranchPromptCalls.push({
+				message,
+				defaultValue,
+			});
+			return nextBranchName;
+		};
+	}, branchName);
+	await page.getByRole("menuitem", { name: "Create branch" }).click();
+	await expect
+		.poll(
+			async () =>
+				await page.evaluate(
+					() => (window as any).__flashtypeBranchPromptCalls?.length ?? 0,
+				),
+		)
+		.toBe(1);
+	await expect(
+		page.evaluate(() => (window as any).__flashtypeBranchPromptCalls),
+	).resolves.toEqual([
+		{ message: "Name the new branch", defaultValue: "draft-2" },
+	]);
+}
+
+async function switchBranchFromUi(
+	page: Page,
+	branchName: string,
+): Promise<void> {
+	await openBranchMenu(page);
+	await page.getByRole("menuitem", { name: branchName }).click();
+}
+
+async function openBranchMenu(page: Page): Promise<void> {
+	const trigger = page.getByRole("button", { name: "Select branch" });
+	await expect(trigger).toBeEnabled();
+	await trigger.click();
+	await expect(
+		page.getByRole("menuitem", { name: "Create branch" }),
+	).toBeVisible();
+}
+
+async function writeDraftBranchState(page: Page): Promise<void> {
+	await page.evaluate(async () => {
+		const encoder = new TextEncoder();
+		await window.flashtypeDesktop?.lix.execute({
+			sql: "UPDATE lix_file SET data = $1 WHERE path = $2",
+			params: [encoder.encode("# Draft shared\n"), "/shared.md"],
+		});
+		await window.flashtypeDesktop?.lix.execute({
+			sql: "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+			params: ["/draft-only.md", encoder.encode("# Draft only\n")],
+		});
+	});
+}
+
+async function expectDiskText(
+	filePath: string,
+	expected: string,
+): Promise<void> {
+	await expect
+		.poll(async () => await readFile(filePath, "utf8"))
+		.toBe(expected);
+}

--- a/src/extensions/markdown/editor/tip-tap-editor.tsx
+++ b/src/extensions/markdown/editor/tip-tap-editor.tsx
@@ -402,7 +402,7 @@ function TipTapEditorLoadedContent({
 
 	// Observe markdown file rows and refresh on external changes.
 	useEffect(() => {
-		if (!activeFileId || !editor) return;
+		if (!activeFileId || !editor || !isActiveView) return;
 		const events = lix.observe(
 			`
 				SELECT
@@ -465,6 +465,7 @@ function TipTapEditorLoadedContent({
 		editor,
 		activeFileId,
 		activeBranchId,
+		isActiveView,
 		initialMarkdown,
 		defaultBlock,
 	]);

--- a/src/hooks/key-value/use-key-value.ts
+++ b/src/hooks/key-value/use-key-value.ts
@@ -63,7 +63,7 @@ type OptimisticSlot = {
 	notifyScheduled?: boolean;
 };
 
-const OPTIMISTIC_SLOTS = new Map<string, OptimisticSlot>();
+const OPTIMISTIC_SLOTS = new WeakMap<object, Map<string, OptimisticSlot>>();
 
 function notifyOptimisticListeners(slot: OptimisticSlot): void {
 	if (slot.notifyScheduled) {
@@ -79,28 +79,41 @@ function notifyOptimisticListeners(slot: OptimisticSlot): void {
 	});
 }
 
-function getOptimisticSlot(key: string): OptimisticSlot {
-	let slot = OPTIMISTIC_SLOTS.get(key);
+function getOptimisticSlots(lix: Lix): Map<string, OptimisticSlot> {
+	let slots = OPTIMISTIC_SLOTS.get(lix as object);
+	if (!slots) {
+		slots = new Map<string, OptimisticSlot>();
+		OPTIMISTIC_SLOTS.set(lix as object, slots);
+	}
+	return slots;
+}
+
+function getOptimisticSlot(lix: Lix, key: string): OptimisticSlot {
+	const slots = getOptimisticSlots(lix);
+	let slot = slots.get(key);
 	if (!slot) {
 		slot = { hasValue: false, value: undefined, listeners: new Set() };
-		OPTIMISTIC_SLOTS.set(key, slot);
+		slots.set(key, slot);
 	}
 	return slot;
 }
 
-function readOptimisticSnapshot(key: string): {
+function readOptimisticSnapshot(
+	lix: Lix,
+	key: string,
+): {
 	hasValue: boolean;
 	value: unknown;
 } {
-	const slot = OPTIMISTIC_SLOTS.get(key);
+	const slot = OPTIMISTIC_SLOTS.get(lix as object)?.get(key);
 	if (!slot) {
 		return { hasValue: false, value: undefined };
 	}
 	return { hasValue: slot.hasValue, value: slot.value };
 }
 
-function setOptimisticValue(key: string, value: unknown): void {
-	const slot = getOptimisticSlot(key);
+function setOptimisticValue(lix: Lix, key: string, value: unknown): void {
+	const slot = getOptimisticSlot(lix, key);
 	if (slot.hasValue && valuesEqual(slot.value, value)) {
 		return;
 	}
@@ -109,25 +122,30 @@ function setOptimisticValue(key: string, value: unknown): void {
 	notifyOptimisticListeners(slot);
 }
 
-function clearOptimisticValue(key: string): void {
-	const slot = OPTIMISTIC_SLOTS.get(key);
+function clearOptimisticValue(lix: Lix, key: string): void {
+	const slots = OPTIMISTIC_SLOTS.get(lix as object);
+	const slot = slots?.get(key);
 	if (!slot) return;
 	if (!slot.hasValue) return;
 	slot.hasValue = false;
 	slot.value = undefined;
 	notifyOptimisticListeners(slot);
 	if (slot.listeners.size === 0) {
-		OPTIMISTIC_SLOTS.delete(key);
+		slots?.delete(key);
 	}
 }
 
-function subscribeOptimistic(key: string, listener: () => void): () => void {
-	const slot = getOptimisticSlot(key);
+function subscribeOptimistic(
+	lix: Lix,
+	key: string,
+	listener: () => void,
+): () => void {
+	const slot = getOptimisticSlot(lix, key);
 	slot.listeners.add(listener);
 	return () => {
 		slot.listeners.delete(listener);
 		if (!slot.hasValue && slot.listeners.size === 0) {
-			OPTIMISTIC_SLOTS.delete(key);
+			OPTIMISTIC_SLOTS.get(lix as object)?.delete(key);
 		}
 	};
 }
@@ -186,7 +204,7 @@ export function useKeyValue<K extends string>(
 		hasValue: boolean;
 		value: ValueOf<K> | null;
 	}>(() => {
-		const snapshot = readOptimisticSnapshot(key as string);
+		const snapshot = readOptimisticSnapshot(lix, key as string);
 		return {
 			hasValue: snapshot.hasValue,
 			value: (snapshot.value ?? null) as ValueOf<K> | null,
@@ -194,7 +212,7 @@ export function useKeyValue<K extends string>(
 	});
 
 	useEffect(() => {
-		const snapshot = readOptimisticSnapshot(key as string);
+		const snapshot = readOptimisticSnapshot(lix, key as string);
 		const next = {
 			hasValue: snapshot.hasValue,
 			value: (snapshot.value ?? null) as ValueOf<K> | null,
@@ -204,11 +222,11 @@ export function useKeyValue<K extends string>(
 				? prev
 				: next,
 		);
-	}, [key]);
+	}, [lix, key]);
 
 	useEffect(() => {
 		const handle = () => {
-			const snapshot = readOptimisticSnapshot(key as string);
+			const snapshot = readOptimisticSnapshot(lix, key as string);
 			const next = {
 				hasValue: snapshot.hasValue,
 				value: (snapshot.value ?? null) as ValueOf<K> | null,
@@ -219,9 +237,10 @@ export function useKeyValue<K extends string>(
 					: next,
 			);
 		};
-		return subscribeOptimistic(key as string, handle);
-	}, [key]);
+		return subscribeOptimistic(lix, key as string, handle);
+	}, [lix, key]);
 
+	const latestLixRef = useRef(lix);
 	const latestKeyRef = useRef(key as string);
 	const latestQueryValueRef = useRef<ValueOf<K> | null>(null);
 	const latestOptimisticRef = useRef(optimistic);
@@ -237,7 +256,7 @@ export function useKeyValue<K extends string>(
 			const clearKey = `${latestKeyRef.current}:${JSON.stringify(latestOptimistic.value)}`;
 			if (lastOptimisticClearRef.current === clearKey) return;
 			lastOptimisticClearRef.current = clearKey;
-			clearOptimisticValue(latestKeyRef.current);
+			clearOptimisticValue(latestLixRef.current, latestKeyRef.current);
 		} else {
 			lastOptimisticClearRef.current = null;
 		}
@@ -245,7 +264,7 @@ export function useKeyValue<K extends string>(
 
 	const setValue = useCallback(
 		async (newValue: ValueOf<K>) => {
-			setOptimisticValue(key as string, newValue as ValueOf<K> | null);
+			setOptimisticValue(lix, key as string, newValue as ValueOf<K> | null);
 			await upsertValue(lix, key as string, newValue as unknown, {
 				defaultBranchId: String(defaultBranchId),
 				untracked,
@@ -269,6 +288,7 @@ export function useKeyValue<K extends string>(
 	const resolvedValue = optimistic.hasValue ? optimistic.value : value;
 
 	latestKeyRef.current = key as string;
+	latestLixRef.current = lix;
 	latestQueryValueRef.current = value;
 	latestOptimisticRef.current = optimistic;
 

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -19,6 +19,8 @@ import type { Lix } from "@/lib/lix-types";
 type DesktopMock = {
 	readonly emitNewFile: () => Promise<void>;
 	readonly onNewFile: ReturnType<typeof vi.fn>;
+	readonly setActiveFilePath: ReturnType<typeof vi.fn>;
+	readonly setOpenFilePaths: ReturnType<typeof vi.fn>;
 };
 
 type AgentHooksDesktopMock = {
@@ -456,6 +458,65 @@ describe("V2LayoutShell active file sidebar highlight", () => {
 	});
 });
 
+describe("V2LayoutShell central file views", () => {
+	test("collapses stale persisted central files to the active view", async () => {
+		const desktop = installDesktopMock();
+		const lix = await openLix({
+			keyValues: [uiStateKeyValue(multipleCentralFilesState())],
+		});
+		await writeReviewFile(lix, "file_stale", "/stale.md", "# Stale");
+		await writeReviewFile(lix, "file_active", "/active.md", "# Active");
+
+		const utils = await renderShell(lix);
+
+		await waitFor(() =>
+			expect(desktop.setOpenFilePaths).toHaveBeenCalledWith({
+				filePaths: ["active.md"],
+			}),
+		);
+		await waitFor(async () => {
+			expect(centralFilePaths(await readPersistedUiState(lix))).toEqual([
+				"/active.md",
+			]);
+		});
+
+		await unmountShell(utils);
+		await lix.close();
+	});
+
+	test("opening multiple startup files leaves only the selected file open", async () => {
+		const desktop = installDesktopMock();
+		const handledFilePaths: string[] = [];
+		const lix = await openLix({
+			keyValues: [uiStateKeyValue(noFilesViewState())],
+		});
+		await writeReviewFile(lix, "file_a", "/a.md", "# A");
+		await writeReviewFile(lix, "file_b", "/b.md", "# B");
+
+		const utils = await renderShell(lix, {
+			pendingOpenFilePaths: ["a.md", "b.md"],
+			onPendingOpenFileHandled: (filePath) => {
+				handledFilePaths.push(filePath);
+			},
+		});
+
+		await waitFor(() => expect(handledFilePaths).toEqual(["a.md", "b.md"]));
+		await waitFor(() =>
+			expect(desktop.setOpenFilePaths).toHaveBeenCalledWith({
+				filePaths: ["a.md"],
+			}),
+		);
+		await waitFor(async () => {
+			expect(centralFilePaths(await readPersistedUiState(lix))).toEqual([
+				"/a.md",
+			]);
+		});
+
+		await unmountShell(utils);
+		await lix.close();
+	});
+});
+
 describe("V2LayoutShell agent review auto-open", () => {
 	test("returns current active file context from turn-start hooks", async () => {
 		const desktop = installAgentHooksDesktopMock();
@@ -574,7 +635,11 @@ describe("V2LayoutShell agent review auto-open", () => {
 
 async function renderShell(
 	lix: Lix,
-	options: { readonly workspace?: WorkspaceContext } = {},
+	options: {
+		readonly workspace?: WorkspaceContext;
+		readonly pendingOpenFilePaths?: readonly string[];
+		readonly onPendingOpenFileHandled?: (filePath: string) => void;
+	} = {},
 ) {
 	let result: ReturnType<typeof render> | undefined;
 	await act(async () => {
@@ -585,6 +650,8 @@ async function renderShell(
 						<V2LayoutShell
 							workspace={options.workspace}
 							workspaceName="Workspace"
+							pendingOpenFilePaths={options.pendingOpenFilePaths}
+							onPendingOpenFileHandled={options.onPendingOpenFileHandled}
 						/>
 					</Suspense>
 				</KeyValueProvider>
@@ -613,6 +680,8 @@ async function unmountShell(utils: ReturnType<typeof render>): Promise<void> {
 
 function installDesktopMock(): DesktopMock {
 	let listener: (() => void | Promise<void>) | null = null;
+	const setActiveFilePath = vi.fn();
+	const setOpenFilePaths = vi.fn();
 	const onNewFile = vi.fn((nextListener: () => void | Promise<void>) => {
 		listener = nextListener;
 		return () => {
@@ -624,8 +693,8 @@ function installDesktopMock(): DesktopMock {
 	window.flashtypeDesktop = {
 		workspace: {
 			onNewFile,
-			setActiveFilePath: vi.fn(),
-			setOpenFilePaths: vi.fn(),
+			setActiveFilePath,
+			setOpenFilePaths,
 		},
 	} as unknown as Window["flashtypeDesktop"];
 	return {
@@ -636,6 +705,8 @@ function installDesktopMock(): DesktopMock {
 			await listener();
 		},
 		onNewFile,
+		setActiveFilePath,
+		setOpenFilePaths,
 	};
 }
 
@@ -785,6 +856,59 @@ function openFileState(fileId: string, filePath: string): FlashtypeUiState {
 		},
 		layout: { sizes: { left: 20, central: 50, right: 30 } },
 	};
+}
+
+function multipleCentralFilesState(): FlashtypeUiState {
+	const active = openFileState("file_active", "/active.md");
+	const staleInstance = fileExtensionInstanceForKind(
+		FILE_EXTENSION_KIND,
+		"file_stale",
+	);
+	return {
+		...active,
+		panels: {
+			...active.panels,
+			central: {
+				views: [
+					{
+						instance: staleInstance,
+						kind: FILE_EXTENSION_KIND,
+						state: {
+							fileId: "file_stale",
+							filePath: "/stale.md",
+							flashtype: { label: "stale.md" },
+						},
+					},
+					...active.panels.central.views,
+				],
+				activeInstance: fileExtensionInstanceForKind(
+					FILE_EXTENSION_KIND,
+					"file_active",
+				),
+			},
+		},
+	};
+}
+
+async function readPersistedUiState(
+	lix: Lix,
+): Promise<FlashtypeUiState | undefined> {
+	const row = await qb(lix)
+		.selectFrom("lix_key_value_by_branch")
+		.select("value")
+		.where("key", "=", "flashtype_ui_state")
+		.where("lixcol_branch_id", "=", "global")
+		.executeTakeFirst();
+	return row?.value as FlashtypeUiState | undefined;
+}
+
+function centralFilePaths(uiState: FlashtypeUiState | undefined): string[] {
+	return (
+		uiState?.panels.central.views
+			.map((entry) => entry.state?.filePath)
+			.filter((filePath): filePath is string => typeof filePath === "string") ??
+		[]
+	);
 }
 
 async function findFilePath(

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -11,6 +11,7 @@ import {
 	FILES_EXTENSION_KIND,
 	fileExtensionInstanceForKind,
 } from "@/extension-runtime/extension-instance-helpers";
+import type { WorkspaceContext } from "@/extension-runtime/types";
 import { resolveLixFileForOpen, V2LayoutShell } from "./layout-shell";
 import type { FlashtypeUiState } from "./ui-state";
 import type { Lix } from "@/lib/lix-types";
@@ -271,6 +272,63 @@ describe("resolveLixFileForOpen", () => {
 	});
 });
 
+describe("V2LayoutShell branch status", () => {
+	test("renders enabled branch UI without an explicit workspace context", async () => {
+		const lix = await openLix();
+		const utils = await renderShell(lix);
+
+		const trigger = await screen.findByRole("button", {
+			name: "Select branch",
+		});
+		expect(trigger).toBeEnabled();
+		expect(trigger).toHaveTextContent("main");
+		expect(trigger).not.toHaveAttribute(
+			"data-attr",
+			"branch-switcher-disabled",
+		);
+
+		await unmountShell(utils);
+		await lix.close();
+	});
+
+	test("renders enabled branch UI for persistent workspaces", async () => {
+		const lix = await openLix();
+		const utils = await renderShell(lix, {
+			workspace: persistentWorkspace(),
+		});
+
+		const trigger = await screen.findByRole("button", {
+			name: "Select branch",
+		});
+		expect(trigger).toBeEnabled();
+		expect(trigger).toHaveTextContent("main");
+		expect(trigger).not.toHaveAttribute(
+			"data-attr",
+			"branch-switcher-disabled",
+		);
+
+		await unmountShell(utils);
+		await lix.close();
+	});
+
+	test("renders disabled branch UI for ephemeral workspaces", async () => {
+		const lix = await openLix();
+		const utils = await renderShell(lix, {
+			workspace: ephemeralWorkspace(),
+		});
+
+		const trigger = await screen.findByRole("button", {
+			name: "Select branch",
+		});
+		expect(trigger).toBeDisabled();
+		expect(trigger).toHaveTextContent("No branch");
+		expect(trigger).toHaveAttribute("data-attr", "branch-switcher-disabled");
+
+		await unmountShell(utils);
+		await lix.close();
+	});
+});
+
 describe("V2LayoutShell native New File", () => {
 	test("routes to the active FilesView draft before creating directly", async () => {
 		const desktop = installDesktopMock();
@@ -514,14 +572,20 @@ describe("V2LayoutShell agent review auto-open", () => {
 	});
 });
 
-async function renderShell(lix: Lix) {
+async function renderShell(
+	lix: Lix,
+	options: { readonly workspace?: WorkspaceContext } = {},
+) {
 	let result: ReturnType<typeof render> | undefined;
 	await act(async () => {
 		result = render(
 			<LixProvider lix={lix}>
 				<KeyValueProvider defs={KEY_VALUE_DEFINITIONS}>
 					<Suspense fallback={<div data-testid="loading" />}>
-						<V2LayoutShell workspaceName="Workspace" />
+						<V2LayoutShell
+							workspace={options.workspace}
+							workspaceName="Workspace"
+						/>
 					</Suspense>
 				</KeyValueProvider>
 			</LixProvider>,
@@ -792,5 +856,13 @@ function ephemeralWorkspace() {
 		path: "/workspace",
 		name: "workspace",
 		openFilePaths: [],
+	} as const;
+}
+
+function persistentWorkspace() {
+	return {
+		ephemeral: false,
+		path: "/workspace",
+		name: "workspace",
 	} as const;
 }

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -209,6 +209,15 @@ const activeFilePathFromPanel = (panel: PanelState): string | null => {
 	return typeof rawPath === "string" && rawPath.length > 0 ? rawPath : null;
 };
 
+const collapsePanelToActiveView = (panel: PanelState): PanelState => {
+	const activeEntry = activeEntryFromPanel(panel);
+	if (!activeEntry) return { views: [], activeInstance: null };
+	return {
+		views: [activeEntry],
+		activeInstance: activeEntry.instance,
+	};
+};
+
 const newFileDraftHandlerKey = (
 	registration: NewFileDraftHandlerRegistration,
 ): string => `${registration.panelSide}:${registration.viewInstance}`;
@@ -686,10 +695,13 @@ function LayoutShellLoadedContent({
 	);
 
 	const initialLayoutSizes = normalizeLayoutSizes(uiState.layout?.sizes);
-	const sanitizedPersistedPanels = useMemo(
-		() => sanitizePanels(uiState.panels),
-		[uiState],
-	);
+	const sanitizedPersistedPanels = useMemo(() => {
+		const panels = sanitizePanels(uiState.panels);
+		return {
+			...panels,
+			central: collapsePanelToActiveView(panels.central),
+		};
+	}, [uiState]);
 
 	const [leftPanel, setLeftPanel] = useState<PanelState>(() =>
 		hydratePanel(sanitizedPersistedPanels.left, extensionMap, {
@@ -697,9 +709,11 @@ function LayoutShellLoadedContent({
 		}),
 	);
 	const [centralPanel, setCentralPanel] = useState<PanelState>(() =>
-		hydratePanel(sanitizedPersistedPanels.central, extensionMap, {
-			preserveUnknownKinds: true,
-		}),
+		collapsePanelToActiveView(
+			hydratePanel(sanitizedPersistedPanels.central, extensionMap, {
+				preserveUnknownKinds: true,
+			}),
+		),
 	);
 	const [rightPanel, setRightPanel] = useState<PanelState>(() =>
 		hydratePanel(sanitizedPersistedPanels.right, extensionMap, {
@@ -1047,11 +1061,7 @@ function LayoutShellLoadedContent({
 	}, [lix, replaceInstalledExtensions, clearInstalledExtensions]);
 
 	const lastPersistedRef = useRef<string>(
-		JSON.stringify({
-			focusedPanel: uiState.focusedPanel,
-			panels: sanitizedPersistedPanels,
-			layout: { sizes: initialLayoutSizes },
-		} satisfies FlashtypeUiState),
+		JSON.stringify(uiStateKV ?? DEFAULT_FLASHTYPE_UI_STATE),
 	);
 	const pendingPersistRef = useRef<string | null>(null);
 	const hydratingRef = useRef(false);
@@ -1100,10 +1110,12 @@ function LayoutShellLoadedContent({
 		setCentralPanel((prev) =>
 			prev === sanitizedPersistedPanels.central
 				? prev
-				: hydratePanel(
-						sanitizedPersistedPanels.central,
-						extensionMap,
-						hydrateOptions,
+				: collapsePanelToActiveView(
+						hydratePanel(
+							sanitizedPersistedPanels.central,
+							extensionMap,
+							hydrateOptions,
+						),
 					),
 		);
 		setRightPanel((prev) =>
@@ -1152,7 +1164,9 @@ function LayoutShellLoadedContent({
 			hydratePanel(current, extensionMap, hydrateOptions),
 		);
 		setCentralPanel((current) =>
-			hydratePanel(current, extensionMap, hydrateOptions),
+			collapsePanelToActiveView(
+				hydratePanel(current, extensionMap, hydrateOptions),
+			),
 		);
 		setRightPanel((current) =>
 			hydratePanel(current, extensionMap, hydrateOptions),
@@ -1202,8 +1216,8 @@ function LayoutShellLoadedContent({
 			reducer: (state: PanelState) => PanelState,
 			options: { focus?: boolean } = {},
 		) => {
-			const applyReducer = (prev: PanelState) =>
-				hydratePanel(
+			const applyReducer = (prev: PanelState) => {
+				const next = hydratePanel(
 					reducer(
 						hydratePanel(prev, extensionMap, {
 							preserveUnknownKinds: !hasLoadedInstalledExtensions,
@@ -1212,6 +1226,8 @@ function LayoutShellLoadedContent({
 					extensionMap,
 					{ preserveUnknownKinds: !hasLoadedInstalledExtensions },
 				);
+				return side === "central" ? collapsePanelToActiveView(next) : next;
+			};
 			if (side === "left") {
 				setLeftPanel(applyReducer);
 			} else if (side === "central") {

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -2616,7 +2616,9 @@ function LayoutShellLoadedContent({
 						</Panel>
 					</PanelGroup>
 				</div>
-				<StatusBar left={<BranchSwitcher />} />
+				<StatusBar
+					left={<BranchSwitcher disabled={workspace?.ephemeral === true} />}
+				/>
 			</div>
 			<DragOverlay>
 				{activeId && activeDragView ? (

--- a/src/shell/top-bar/branch-switcher.test.tsx
+++ b/src/shell/top-bar/branch-switcher.test.tsx
@@ -126,8 +126,6 @@ describe("BranchSwitcher", () => {
 
 	test("creates a branch from the menu and switches to it", async () => {
 		const branchName = `feature-${Math.random().toString(36).slice(2, 7)}`;
-		const promptSpy = vi.fn().mockReturnValue(` ${branchName} `);
-		vi.stubGlobal("prompt", promptSpy);
 
 		await renderWithProviders();
 		await openBranchMenu();
@@ -139,7 +137,13 @@ describe("BranchSwitcher", () => {
 			fireEvent.click(createItem);
 		});
 
-		expect(promptSpy).toHaveBeenCalledWith("Name the new branch", "draft-2");
+		const input = await screen.findByRole("textbox", { name: "Branch name" });
+		expect(input).toHaveValue("draft-2");
+		await act(async () => {
+			fireEvent.input(input, { target: { value: ` ${branchName} ` } });
+			fireEvent.keyDown(input, { key: "Enter" });
+		});
+
 		await waitFor(() => {
 			expect(
 				screen.getByRole("button", { name: "Select branch" }),
@@ -162,9 +166,6 @@ describe("BranchSwitcher", () => {
 	});
 
 	test("uses the suggested branch name when create prompt is blank", async () => {
-		const promptSpy = vi.fn().mockReturnValue("   ");
-		vi.stubGlobal("prompt", promptSpy);
-
 		await renderWithProviders();
 		await openBranchMenu();
 
@@ -175,7 +176,13 @@ describe("BranchSwitcher", () => {
 			fireEvent.click(createItem);
 		});
 
-		expect(promptSpy).toHaveBeenCalledWith("Name the new branch", "draft-2");
+		const input = await screen.findByRole("textbox", { name: "Branch name" });
+		expect(input).toHaveValue("draft-2");
+		await act(async () => {
+			fireEvent.input(input, { target: { value: "   " } });
+			fireEvent.keyDown(input, { key: "Enter" });
+		});
+
 		await waitFor(() => {
 			expect(
 				screen.getByRole("button", { name: "Select branch" }),
@@ -195,9 +202,7 @@ describe("BranchSwitcher", () => {
 		expect(active.value).toBe(created.id);
 	});
 
-	test("does not create a branch when create prompt is cancelled", async () => {
-		const promptSpy = vi.fn().mockReturnValue(null);
-		vi.stubGlobal("prompt", promptSpy);
+	test("does not create a branch when inline creation is cancelled", async () => {
 		const initialCount = await branchCount();
 
 		await renderWithProviders();
@@ -210,8 +215,15 @@ describe("BranchSwitcher", () => {
 			fireEvent.click(createItem);
 		});
 
-		expect(promptSpy).toHaveBeenCalledWith("Name the new branch", "draft-2");
+		const input = await screen.findByRole("textbox", { name: "Branch name" });
+		await act(async () => {
+			fireEvent.keyDown(input, { key: "Escape" });
+		});
+
 		expect(await branchCount()).toBe(initialCount);
+		expect(
+			screen.queryByRole("textbox", { name: "Branch name" }),
+		).not.toBeInTheDocument();
 		expect(
 			screen.getByRole("button", { name: "Select branch" }),
 		).toHaveTextContent("main");

--- a/src/shell/top-bar/branch-switcher.test.tsx
+++ b/src/shell/top-bar/branch-switcher.test.tsx
@@ -12,6 +12,18 @@ import { LixProvider } from "@/lib/lix-react";
 import { openLix, type Lix } from "@/test-utils/node-lix-sdk";
 import { BranchSwitcher } from "./branch-switcher";
 
+describe("BranchSwitcher disabled", () => {
+	test("renders a disabled control without a Lix provider", () => {
+		render(<BranchSwitcher disabled />);
+
+		const trigger = screen.getByRole("button", { name: "Select branch" });
+		expect(trigger).toBeDisabled();
+		expect(trigger).toHaveTextContent("No branch");
+		expect(trigger).toHaveAttribute("data-attr", "branch-switcher-disabled");
+		expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+	});
+});
+
 describe("BranchSwitcher", () => {
 	let lix: Lix;
 	let cleanupFns: Array<() => Promise<void>> = [];
@@ -26,6 +38,22 @@ describe("BranchSwitcher", () => {
 				</LixProvider>,
 			);
 		});
+	};
+
+	const openBranchMenu = async () => {
+		const trigger = await screen.findByRole("button", {
+			name: "Select branch",
+		});
+		await act(async () => {
+			fireEvent.pointerDown(trigger, { button: 0 });
+			fireEvent.pointerUp(trigger, { button: 0 });
+		});
+		return trigger;
+	};
+
+	const branchCount = async () => {
+		const rows = await qb(lix).selectFrom("lix_branch").select("id").execute();
+		return rows.length;
 	};
 
 	beforeEach(async () => {
@@ -94,6 +122,99 @@ describe("BranchSwitcher", () => {
 				.executeTakeFirstOrThrow();
 			expect(active.value).toBe(newBranch.id);
 		});
+	});
+
+	test("creates a branch from the menu and switches to it", async () => {
+		const branchName = `feature-${Math.random().toString(36).slice(2, 7)}`;
+		const promptSpy = vi.fn().mockReturnValue(` ${branchName} `);
+		vi.stubGlobal("prompt", promptSpy);
+
+		await renderWithProviders();
+		await openBranchMenu();
+
+		const createItem = await screen.findByRole("menuitem", {
+			name: "Create branch",
+		});
+		await act(async () => {
+			fireEvent.click(createItem);
+		});
+
+		expect(promptSpy).toHaveBeenCalledWith("Name the new branch", "draft-2");
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Select branch" }),
+			).toHaveTextContent(branchName);
+		});
+
+		const created = await qb(lix)
+			.selectFrom("lix_branch")
+			.select(["id", "name"])
+			.where("name", "=", branchName)
+			.executeTakeFirstOrThrow();
+		expect(created.name).toBe(branchName);
+
+		const active = await qb(lix)
+			.selectFrom("lix_key_value")
+			.where("key", "=", "lix_workspace_branch_id")
+			.select("value")
+			.executeTakeFirstOrThrow();
+		expect(active.value).toBe(created.id);
+	});
+
+	test("uses the suggested branch name when create prompt is blank", async () => {
+		const promptSpy = vi.fn().mockReturnValue("   ");
+		vi.stubGlobal("prompt", promptSpy);
+
+		await renderWithProviders();
+		await openBranchMenu();
+
+		const createItem = await screen.findByRole("menuitem", {
+			name: "Create branch",
+		});
+		await act(async () => {
+			fireEvent.click(createItem);
+		});
+
+		expect(promptSpy).toHaveBeenCalledWith("Name the new branch", "draft-2");
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Select branch" }),
+			).toHaveTextContent("draft-2");
+		});
+
+		const created = await qb(lix)
+			.selectFrom("lix_branch")
+			.select(["id", "name"])
+			.where("name", "=", "draft-2")
+			.executeTakeFirstOrThrow();
+		const active = await qb(lix)
+			.selectFrom("lix_key_value")
+			.where("key", "=", "lix_workspace_branch_id")
+			.select("value")
+			.executeTakeFirstOrThrow();
+		expect(active.value).toBe(created.id);
+	});
+
+	test("does not create a branch when create prompt is cancelled", async () => {
+		const promptSpy = vi.fn().mockReturnValue(null);
+		vi.stubGlobal("prompt", promptSpy);
+		const initialCount = await branchCount();
+
+		await renderWithProviders();
+		await openBranchMenu();
+
+		const createItem = await screen.findByRole("menuitem", {
+			name: "Create branch",
+		});
+		await act(async () => {
+			fireEvent.click(createItem);
+		});
+
+		expect(promptSpy).toHaveBeenCalledWith("Name the new branch", "draft-2");
+		expect(await branchCount()).toBe(initialCount);
+		expect(
+			screen.getByRole("button", { name: "Select branch" }),
+		).toHaveTextContent("main");
 	});
 
 	test("renames a branch via actions menu", async () => {

--- a/src/shell/top-bar/branch-switcher.tsx
+++ b/src/shell/top-bar/branch-switcher.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { qb, sql } from "@/lib/lix-kysely";
 import { useLix, useQuery, useQueryTakeFirstOrThrow } from "@/lib/lix-react";
 import { Button } from "@/components/ui/button";
@@ -19,6 +19,7 @@ import {
 	PenLine,
 	Plus,
 	Trash2,
+	X,
 } from "lucide-react";
 import clsx from "clsx";
 
@@ -47,7 +48,10 @@ export function BranchSwitcher({ disabled = false }: BranchSwitcherProps = {}) {
 	if (disabled) {
 		return <DisabledBranchSwitcher />;
 	}
+	return <EnabledBranchSwitcher />;
+}
 
+function EnabledBranchSwitcher() {
 	const lix = useLix();
 	const branches = useQuery<BranchRow>((lix) =>
 		qb(lix)
@@ -122,6 +126,26 @@ function BranchSwitcherContent({
 
 	const [pendingAction, setPendingAction] = useState<string | null>(null);
 	const [menuOpen, setMenuOpen] = useState(false);
+	const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+	const [createBranchName, setCreateBranchName] = useState("");
+	const createInputRef = useRef<HTMLInputElement | null>(null);
+	const createSuggestion = `draft-${branches.length + 1}`;
+
+	useEffect(() => {
+		if (!isCreateFormOpen) return;
+		const frame = window.requestAnimationFrame(() => {
+			createInputRef.current?.focus();
+			createInputRef.current?.select();
+		});
+		return () => window.cancelAnimationFrame(frame);
+	}, [isCreateFormOpen]);
+
+	const handleMenuOpenChange = useCallback((open: boolean) => {
+		setMenuOpen(open);
+		if (!open) {
+			setIsCreateFormOpen(false);
+		}
+	}, []);
 
 	const handleSwitch = useCallback(
 		async (branchId: string) => {
@@ -138,24 +162,33 @@ function BranchSwitcherContent({
 		[lix, activeBranchRow.id],
 	);
 
+	const handleStartCreateBranch = useCallback(() => {
+		setCreateBranchName(createSuggestion);
+		setIsCreateFormOpen(true);
+	}, [createSuggestion]);
+
 	const handleCreateBranch = useCallback(async () => {
 		if (!lix) return;
-		const suggestion = `draft-${branches.length + 1}`;
-		const entered = window.prompt("Name the new branch", suggestion);
-		if (entered === null) return;
-		const trimmed = entered.trim();
+		const trimmed = createBranchName.trim();
 		setPendingAction("create");
 		try {
 			const created = await lix.createBranch({
-				name: trimmed.length > 0 ? trimmed : suggestion,
+				name: trimmed.length > 0 ? trimmed : createSuggestion,
 			});
 			await lix.switchBranch({ branchId: created.id });
+			setIsCreateFormOpen(false);
+			setMenuOpen(false);
 		} catch (error) {
 			console.error("Failed to create branch", error);
 		} finally {
 			setPendingAction(null);
 		}
-	}, [lix, branches.length]);
+	}, [lix, createBranchName, createSuggestion]);
+
+	const handleCancelCreateBranch = useCallback(() => {
+		setIsCreateFormOpen(false);
+		setCreateBranchName("");
+	}, []);
 
 	const handleRenameBranch = useCallback(
 		async (branchId: string, currentName: string) => {
@@ -214,7 +247,7 @@ function BranchSwitcherContent({
 	const isBusy = pendingAction !== null;
 
 	return (
-		<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+		<DropdownMenu open={menuOpen} onOpenChange={handleMenuOpenChange}>
 			<DropdownMenuTrigger asChild>
 				<Button
 					type="button"
@@ -336,13 +369,66 @@ function BranchSwitcherContent({
 					})
 				)}
 				<DropdownMenuSeparator />
-				<DropdownMenuItem
-					onSelect={handleCreateBranch}
-					className="flex items-center gap-2 px-2 py-1.5 text-xs text-[var(--color-text-secondary)]"
-				>
-					<Plus className="h-3 w-3" />
-					<span>Create branch</span>
-				</DropdownMenuItem>
+				{isCreateFormOpen ? (
+					<div
+						className="flex items-center gap-1 px-2 py-1.5"
+						onKeyDown={(event) => {
+							event.stopPropagation();
+						}}
+					>
+						<input
+							ref={createInputRef}
+							aria-label="Branch name"
+							className="h-6 min-w-0 flex-1 rounded border border-[var(--color-border-panel)] bg-transparent px-1.5 text-xs text-[var(--color-text-primary)] outline-none focus:border-[var(--color-icon-brand)]"
+							value={createBranchName}
+							disabled={isBusy}
+							onChange={(event) => {
+								setCreateBranchName(event.currentTarget.value);
+							}}
+							onKeyDown={(event) => {
+								if (event.key === "Enter") {
+									event.preventDefault();
+									void handleCreateBranch();
+								} else if (event.key === "Escape") {
+									event.preventDefault();
+									handleCancelCreateBranch();
+								}
+							}}
+						/>
+						<button
+							type="button"
+							aria-label="Create branch"
+							data-attr="branch-create-submit"
+							className="flex h-6 w-6 items-center justify-center rounded text-[var(--color-icon-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] disabled:opacity-50"
+							disabled={isBusy}
+							onClick={() => {
+								void handleCreateBranch();
+							}}
+						>
+							<Check className="h-3.5 w-3.5" />
+						</button>
+						<button
+							type="button"
+							aria-label="Cancel branch creation"
+							className="flex h-6 w-6 items-center justify-center rounded text-[var(--color-icon-tertiary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] disabled:opacity-50"
+							disabled={isBusy}
+							onClick={handleCancelCreateBranch}
+						>
+							<X className="h-3.5 w-3.5" />
+						</button>
+					</div>
+				) : (
+					<DropdownMenuItem
+						onSelect={(event) => {
+							event.preventDefault();
+							handleStartCreateBranch();
+						}}
+						className="flex items-center gap-2 px-2 py-1.5 text-xs text-[var(--color-text-secondary)]"
+					>
+						<Plus className="h-3 w-3" />
+						<span>Create branch</span>
+					</DropdownMenuItem>
+				)}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/src/shell/top-bar/branch-switcher.tsx
+++ b/src/shell/top-bar/branch-switcher.tsx
@@ -29,6 +29,10 @@ type BranchRow = {
 	commit_id: string | null;
 };
 
+type BranchSwitcherProps = {
+	readonly disabled?: boolean;
+};
+
 /**
  * Dropdown trigger that lists available branches and switches the active one.
  *
@@ -39,7 +43,11 @@ type BranchRow = {
  * @example
  * <BranchSwitcher />
  */
-export function BranchSwitcher() {
+export function BranchSwitcher({ disabled = false }: BranchSwitcherProps = {}) {
+	if (disabled) {
+		return <DisabledBranchSwitcher />;
+	}
+
 	const lix = useLix();
 	const branches = useQuery<BranchRow>((lix) =>
 		qb(lix)
@@ -53,6 +61,23 @@ export function BranchSwitcher() {
 	);
 
 	return <BranchSwitcherWithActiveBranch lix={lix} branches={branches} />;
+}
+
+function DisabledBranchSwitcher() {
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="sm"
+			className="inline-flex h-5.5 items-center gap-1 rounded-md px-1.5 font-normal text-[var(--color-icon-tertiary)]"
+			aria-label="Select branch"
+			data-attr="branch-switcher-disabled"
+			disabled
+		>
+			<GitBranch className="size-3" />
+			<span className="text-[11.5px]">No branch</span>
+		</Button>
+	);
 }
 
 function BranchSwitcherWithActiveBranch({


### PR DESCRIPTION
## Summary

- Replace prompt-based branch creation with an inline branch form in the switcher.
- Disable branch switching for ephemeral workspaces and show a clear no-branch state.
- Collapse stale central file views and scope optimistic key-value state per Lix instance.