### PR TITLE
[codex] Reduce Lix observe overhead

### DIFF
--- a/src/lib/lix-client.ts
+++ b/src/lib/lix-client.ts
@@ -212,7 +212,9 @@ export async function openDesktopLix(): Promise<Lix> {
 				void (async () => {
 					const observeId = await ensureObserveId();
 					await desktop.lix.observeClose({ observeId });
-				})();
+				})().catch(() => {
+					// If observeStart already failed, next() reports the real error.
+				});
 			},
 		};
 	};

--- a/src/lib/lix-react.test.tsx
+++ b/src/lib/lix-react.test.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
 import { LixProvider, useQuery } from "./lix-react";
 import type { Lix, ObserveEvent } from "./lix-types";
 
 afterEach(() => {
+	cleanup();
 	vi.restoreAllMocks();
 });
 
@@ -71,3 +72,79 @@ test("useQuery applies the first observe snapshot over the initial read", async 
 		expect(screen.getByTestId("value")).toHaveTextContent("fresh");
 	});
 });
+
+test("useQuery shares one observe stream between identical subscribers", async () => {
+	let resolveNext: ((event: ObserveEvent | undefined) => void) | undefined;
+	const next = vi.fn(
+		() =>
+			new Promise<ObserveEvent | undefined>((resolve) => {
+				resolveNext = resolve;
+			}),
+	);
+	const close = vi.fn();
+	const lix = {
+		observe: vi.fn(() => ({ next, close })),
+	} as unknown as Lix;
+	const execute = vi.fn(async () => [{ value: "initial" }]);
+
+	function Probe({ testId }: { readonly testId: string }) {
+		const rows = useQuery<{ value: string }>(() => ({
+			compile: () => ({
+				sql: "SELECT value FROM shared_observe_subscription",
+				parameters: ["same"],
+			}),
+			execute,
+		}));
+		return <div data-testid={testId}>{rows[0]?.value}</div>;
+	}
+
+	let view: ReturnType<typeof render>;
+	await act(async () => {
+		view = render(
+			<LixProvider lix={lix}>
+				<Suspense fallback={<div data-testid="loading" />}>
+					<Probe testId="first" />
+					<Probe testId="second" />
+				</Suspense>
+			</LixProvider>,
+		);
+	});
+
+	await expect(screen.findByTestId("first")).resolves.toHaveTextContent(
+		"initial",
+	);
+	expect(screen.getByTestId("second")).toHaveTextContent("initial");
+	await waitFor(() => {
+		expect(lix.observe).toHaveBeenCalledTimes(1);
+	});
+	expect(execute).toHaveBeenCalledTimes(1);
+
+	await act(async () => {
+		resolveNext?.(observeEvent({ value: "fresh" }));
+	});
+
+	await waitFor(() => {
+		expect(screen.getByTestId("first")).toHaveTextContent("fresh");
+		expect(screen.getByTestId("second")).toHaveTextContent("fresh");
+	});
+
+	view!.unmount();
+	expect(close).toHaveBeenCalledTimes(1);
+});
+
+function observeEvent(row: Record<string, unknown>): ObserveEvent {
+	return {
+		sequence: 1,
+		mutationSequence: 1,
+		result: {
+			columns: Object.keys(row),
+			rows: [
+				{
+					toObject: () => row,
+				},
+			] as unknown as ObserveEvent["result"]["rows"],
+			rowsAffected: 0,
+			notices: [],
+		},
+	};
+}

--- a/src/lib/lix-react.tsx
+++ b/src/lib/lix-react.tsx
@@ -33,11 +33,23 @@ type QueryCacheEntry<TRow> = {
 	error?: unknown;
 };
 
+type QueryObserverSubscriber<TRow> = {
+	onRows(rows: TRow[]): void;
+	onError(error: unknown): void;
+};
+
+type QueryObserverEntry<TRow> = {
+	events: ReturnType<Lix["observe"]>;
+	subscribers: Set<QueryObserverSubscriber<TRow>>;
+	closed: boolean;
+};
+
 const queryCache = new Map<string, QueryCacheEntry<any>>();
 const observeQueryCache = new Map<
 	string,
 	{ sql: string; params: ReadonlyArray<unknown> }
 >();
+const observeSubscriptionCache = new Map<string, QueryObserverEntry<any>>();
 const lixInstanceIds = new WeakMap<object, number>();
 let nextLixInstanceId = 1;
 
@@ -81,35 +93,20 @@ export function useQuery<TRow>(
 
 	useEffect(() => {
 		if (!subscribe) return;
-		let closed = false;
-		const events = lix.observe(observeQuery.sql, observeQuery.params);
-
-		void (async () => {
-			try {
-				while (!closed) {
-					const event = await events.next();
-					if (closed || event === undefined) break;
-					const nextRows = queryResultToRows<TRow>(event.result);
-					cacheQueryRows(cacheKey, nextRows);
-					if (rowsEqual(rowsRef.current, nextRows)) {
-						continue;
-					}
-					rowsRef.current = nextRows;
-					setRows(nextRows);
+		return subscribeToQueryObserver<TRow>(cacheKey, lix, observeQuery, {
+			onRows(nextRows) {
+				if (rowsEqual(rowsRef.current, nextRows)) {
+					return;
 				}
-			} catch (error) {
-				if (closed) return;
-				queryCache.delete(cacheKey);
+				rowsRef.current = nextRows;
+				setRows(nextRows);
+			},
+			onError(error) {
 				setRows(() => {
 					throw error instanceof Error ? error : new Error(String(error));
 				});
-			}
-		})();
-
-		return () => {
-			closed = true;
-			events.close();
-		};
+			},
+		});
 	}, [cacheKey, subscribe, lix, observeQuery]);
 
 	if (entry.error !== undefined) {
@@ -122,6 +119,84 @@ export function useQuery<TRow>(
 	return subscribe
 		? (cachedRows ?? rowsRef.current ?? initialRows)
 		: initialRows;
+}
+
+function subscribeToQueryObserver<TRow>(
+	cacheKey: string,
+	lix: Lix,
+	observeQuery: { sql: string; params: ReadonlyArray<unknown> },
+	subscriber: QueryObserverSubscriber<TRow>,
+): () => void {
+	const entry = getQueryObserverEntry<TRow>(cacheKey, lix, observeQuery);
+	entry.subscribers.add(subscriber);
+	return () => {
+		entry.subscribers.delete(subscriber);
+		if (entry.subscribers.size > 0) {
+			return;
+		}
+		closeQueryObserverEntry(cacheKey, entry);
+	};
+}
+
+function getQueryObserverEntry<TRow>(
+	cacheKey: string,
+	lix: Lix,
+	observeQuery: { sql: string; params: ReadonlyArray<unknown> },
+): QueryObserverEntry<TRow> {
+	const cached = observeSubscriptionCache.get(cacheKey) as
+		| QueryObserverEntry<TRow>
+		| undefined;
+	if (cached && !cached.closed) {
+		return cached;
+	}
+
+	const entry: QueryObserverEntry<TRow> = {
+		events: lix.observe(observeQuery.sql, observeQuery.params),
+		subscribers: new Set(),
+		closed: false,
+	};
+	observeSubscriptionCache.set(cacheKey, entry);
+	void runQueryObserver(cacheKey, entry);
+	return entry;
+}
+
+async function runQueryObserver<TRow>(
+	cacheKey: string,
+	entry: QueryObserverEntry<TRow>,
+): Promise<void> {
+	try {
+		while (!entry.closed) {
+			const event = await entry.events.next();
+			if (entry.closed || event === undefined) break;
+			const nextRows = queryResultToRows<TRow>(event.result);
+			cacheQueryRows(cacheKey, nextRows);
+			for (const subscriber of Array.from(entry.subscribers)) {
+				subscriber.onRows(nextRows);
+			}
+		}
+	} catch (error) {
+		if (entry.closed) return;
+		queryCache.delete(cacheKey);
+		for (const subscriber of Array.from(entry.subscribers)) {
+			subscriber.onError(error);
+		}
+	} finally {
+		if (!entry.closed) {
+			closeQueryObserverEntry(cacheKey, entry);
+		}
+	}
+}
+
+function closeQueryObserverEntry<TRow>(
+	cacheKey: string,
+	entry: QueryObserverEntry<TRow>,
+): void {
+	if (entry.closed) {
+		return;
+	}
+	entry.closed = true;
+	observeSubscriptionCache.delete(cacheKey);
+	entry.events.close();
 }
 
 export const useQueryTakeFirst = <TResult,>(


### PR DESCRIPTION
## What changed

- Shares one `useQuery` observe stream between identical React subscribers.
- Guards `observe.close()` against a rejected `observeStart` promise so close cleanup cannot create an unhandled rejection.
- Updates the `submodule/lix` pointer to the shared observe runtime change in opral/lix#566.

## Why

Opening Flashtype could create many active Lix observers, and the previous native Lix implementation created one `lix-observe-events` OS thread per subscription. The Lix change removes that per-observe thread cost, and the React pooling change reduces duplicate identical observe subscriptions in the app layer.

## Measured impact

After opening a markdown file in Flashtype with this change:

- Active observes: 9
- `lix-observe-events` threads: 0
- `lix-observe-runtime` threads: 1
- Electron idle CPU in the sampled state: 0.0%

## Validation

- `vitest run src/lib/lix-react.test.tsx`
- `tsc -p . --noEmit`
- `oxlint`
- `prettier --check`
- `git diff --check`
- `git -C submodule/lix diff --check`

Also validated earlier while developing the Lix submodule change:

- `pnpm -C submodule/lix/packages/js-sdk exec vitest run src/open-lix.test.ts`
- `cargo check --manifest-path submodule/lix/Cargo.toml --package lix_js_sdk`
- `cargo fmt --manifest-path submodule/lix/Cargo.toml --package lix_js_sdk --check`
- `pnpm -C submodule/lix/packages/js-sdk run build:native`
