### PR TITLE
[codex] Add agent funnel telemetry

### DIFF
--- a/electron/types.d.ts
+++ b/electron/types.d.ts
@@ -308,12 +308,14 @@ export type DesktopAppApi = {
 
 export type DesktopTelemetryEventName =
 	| "agent_opened"
+	| "agent_start_failed"
 	| "app_opened"
 	| "diff_opened"
 	| "diff_resolved"
 	| "document_open_attempted"
 	| "document_modified"
 	| "document_viewed"
+	| "prompt_submitted"
 	| "workspace_recovery_lifecycle"
 	| "workspace_extension_profiled"
 	| "workspace_profiled";

--- a/src/extensions/terminal/index.test.tsx
+++ b/src/extensions/terminal/index.test.tsx
@@ -9,6 +9,10 @@ const xtermMock = vi.hoisted(() => ({
 		dispose: ReturnType<typeof vi.fn>;
 	}>,
 }));
+const telemetryMock = vi.hoisted(() => ({
+	captureTelemetry: vi.fn(),
+	captureTelemetryException: vi.fn(),
+}));
 
 vi.mock("@xterm/xterm", () => {
 	class MockTerminal {
@@ -35,6 +39,8 @@ vi.mock("@xterm/addon-fit", () => {
 	return { FitAddon: MockFitAddon };
 });
 
+vi.mock("@/lib/telemetry", () => telemetryMock);
+
 import { TerminalView } from "./index";
 
 const originalDesktop = window.flashtypeDesktop;
@@ -43,6 +49,8 @@ const originalResizeObserver = window.ResizeObserver;
 describe("TerminalView", () => {
 	beforeEach(() => {
 		xtermMock.instances.length = 0;
+		telemetryMock.captureTelemetry.mockClear();
+		telemetryMock.captureTelemetryException.mockClear();
 		window.ResizeObserver = class {
 			observe = vi.fn();
 			disconnect = vi.fn();
@@ -93,6 +101,18 @@ describe("TerminalView", () => {
 			screen.getByText(/Flashtype needs Claude Code 2\.1\.78 or newer/u),
 		).toBeInTheDocument();
 		expect(xtermMock.instances[0]?.writeln).not.toHaveBeenCalled();
+		expect(telemetryMock.captureTelemetry).toHaveBeenCalledWith(
+			"agent_start_failed",
+			{
+				agent: "claude",
+				reason: "unsupported",
+				required_version: "2.1.78",
+				detected_version: "2.1.77",
+				surface: "terminal",
+				retry_count: 0,
+			},
+		);
+		expect(telemetryMock.captureTelemetryException).not.toHaveBeenCalled();
 
 		fireEvent.click(screen.getByRole("button", { name: /retry/i }));
 
@@ -104,7 +124,200 @@ describe("TerminalView", () => {
 			}),
 		);
 	});
+
+	test.each([
+		["missing", "Claude Code not found"],
+		["unparseable", "Could not read Claude Code version"],
+		["timeout", "Claude Code version check timed out"],
+		["failed", "Claude Code version check failed"],
+	] as const)(
+		"captures agent version startup telemetry for %s errors",
+		async (reason, title) => {
+			const terminalApi = createTerminalApi();
+			terminalApi.create = vi.fn().mockResolvedValueOnce({
+				status: "agentVersionError",
+				agent: "claude",
+				requiredVersion: "2.1.78",
+				reason,
+			});
+			window.flashtypeDesktop = createDesktop(terminalApi);
+
+			render(
+				<TerminalView
+					launchConfig={{
+						initialCommand: "claude-flashtype",
+						pathWrapper: {
+							executableName: "claude-flashtype",
+							command: "claude --settings '{}'",
+						},
+					}}
+				/>,
+			);
+
+			expect(await screen.findByText(title)).toBeInTheDocument();
+			expect(telemetryMock.captureTelemetry).toHaveBeenCalledWith(
+				"agent_start_failed",
+				{
+					agent: "claude",
+					reason,
+					required_version: "2.1.78",
+					detected_version: undefined,
+					surface: "terminal",
+					retry_count: 0,
+				},
+			);
+			expect(telemetryMock.captureTelemetryException).not.toHaveBeenCalled();
+		},
+	);
+
+	test("captures retry count on later startup failures", async () => {
+		const terminalApi = createTerminalApi();
+		terminalApi.create = vi
+			.fn()
+			.mockResolvedValueOnce({
+				status: "agentVersionError",
+				agent: "codex",
+				requiredVersion: "0.134.0",
+				detectedVersion: "0.133.0",
+				reason: "unsupported",
+			})
+			.mockResolvedValueOnce({
+				status: "agentVersionError",
+				agent: "codex",
+				requiredVersion: "0.134.0",
+				detectedVersion: "0.133.0",
+				reason: "unsupported",
+			});
+		window.flashtypeDesktop = createDesktop(terminalApi);
+
+		render(
+			<TerminalView
+				launchConfig={{
+					initialCommand: "codex-flashtype",
+					pathWrapper: {
+						executableName: "codex-flashtype",
+						command: "codex --dangerously-bypass-hook-trust",
+					},
+				}}
+			/>,
+		);
+
+		expect(
+			await screen.findByText("Codex update required"),
+		).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+		await waitFor(() => expect(terminalApi.create).toHaveBeenCalledTimes(2));
+		await waitFor(() =>
+			expect(telemetryMock.captureTelemetry).toHaveBeenLastCalledWith(
+				"agent_start_failed",
+				{
+					agent: "codex",
+					reason: "unsupported",
+					required_version: "0.134.0",
+					detected_version: "0.133.0",
+					surface: "terminal",
+					retry_count: 1,
+				},
+			),
+		);
+	});
+
+	test("captures unexpected agent startup errors as telemetry and exceptions", async () => {
+		const terminalApi = createTerminalApi();
+		const error = new Error("pty failed");
+		terminalApi.create = vi.fn().mockRejectedValueOnce(error);
+		window.flashtypeDesktop = createDesktop(terminalApi);
+
+		render(
+			<TerminalView
+				launchConfig={{
+					initialCommand: "codex-flashtype",
+					pathWrapper: {
+						executableName: "codex-flashtype",
+						command: "codex --dangerously-bypass-hook-trust",
+					},
+				}}
+			/>,
+		);
+
+		expect(
+			await screen.findByText("Failed to start terminal"),
+		).toBeInTheDocument();
+		expect(telemetryMock.captureTelemetry).toHaveBeenCalledWith(
+			"agent_start_failed",
+			{
+				agent: "codex",
+				reason: "unexpected",
+				surface: "terminal",
+				retry_count: 0,
+			},
+		);
+		expect(telemetryMock.captureTelemetryException).toHaveBeenCalledWith(
+			error,
+			{
+				agent: "codex",
+				reason: "unexpected",
+				surface: "terminal",
+				retry_count: 0,
+			},
+		);
+	});
+
+	test("captures initial command write failures as agent startup telemetry", async () => {
+		const terminalApi = createTerminalApi();
+		const error = new Error("write failed");
+		terminalApi.create = vi.fn().mockResolvedValueOnce({
+			status: "ok",
+			id: "terminal-1",
+		});
+		terminalApi.write = vi.fn().mockRejectedValueOnce(error);
+		window.flashtypeDesktop = createDesktop(terminalApi);
+
+		render(
+			<TerminalView
+				launchConfig={{
+					initialCommand: "claude-flashtype",
+					pathWrapper: {
+						executableName: "claude-flashtype",
+						command: "claude --settings '{}'",
+					},
+				}}
+			/>,
+		);
+
+		expect(
+			await screen.findByText("Failed to start terminal"),
+		).toBeInTheDocument();
+		expect(telemetryMock.captureTelemetry).toHaveBeenCalledWith(
+			"agent_start_failed",
+			{
+				agent: "claude",
+				reason: "unexpected",
+				surface: "terminal",
+				retry_count: 0,
+			},
+		);
+		expect(telemetryMock.captureTelemetryException).toHaveBeenCalledWith(
+			error,
+			{
+				agent: "claude",
+				reason: "unexpected",
+				surface: "terminal",
+				retry_count: 0,
+			},
+		);
+	});
 });
+
+function createDesktop(terminalApi: DesktopTerminalApi) {
+	return {
+		lix: {
+			workspaceDir: vi.fn().mockResolvedValue("/workspace"),
+		},
+		terminal: terminalApi,
+	} as unknown as Window["flashtypeDesktop"];
+}
 
 function createTerminalApi(): DesktopTerminalApi {
 	return {

--- a/src/extensions/terminal/index.tsx
+++ b/src/extensions/terminal/index.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Button } from "@/components/ui/button";
+import { captureTelemetry, captureTelemetryException } from "@/lib/telemetry";
 import { createReactExtensionDefinition } from "../../extension-runtime/react-extension";
 import { TERMINAL_EXTENSION_KIND } from "../../extension-runtime/extension-instance-helpers";
 import {
@@ -57,6 +58,7 @@ type AgentVersionErrorResult = Extract<
 type TerminalStartupError =
 	| { kind: "agentVersion"; error: AgentVersionErrorResult }
 	| { kind: "unexpected"; error: unknown };
+type AgentTelemetryName = AgentVersionErrorResult["agent"];
 
 export function TerminalView({
 	launchConfig,
@@ -84,6 +86,7 @@ export function TerminalView({
 		let disposed = false;
 		let cleanedUp = false;
 		let terminalId: string | null = null;
+		const attemptLaunchConfig = launchConfigRef.current;
 
 		setStartupError(null);
 		const terminal = new Terminal({
@@ -156,6 +159,10 @@ export function TerminalView({
 
 		const showStartupError = (error: TerminalStartupError) => {
 			if (disposed) return;
+			captureAgentStartFailure(error, {
+				launchConfig: attemptLaunchConfig,
+				retryCount: retryKey,
+			});
 			setStartupError(error);
 			cleanupLocalTerminal();
 		};
@@ -170,7 +177,7 @@ export function TerminalView({
 					cwd,
 					cols: terminal.cols,
 					rows: terminal.rows,
-					pathWrapper: launchConfigRef.current.pathWrapper,
+					pathWrapper: attemptLaunchConfig.pathWrapper,
 				});
 				if (created.status === "agentVersionError") {
 					showStartupError({ kind: "agentVersion", error: created });
@@ -182,11 +189,11 @@ export function TerminalView({
 				}
 				terminalId = created.id;
 				handleResize();
-				const command = launchConfigRef.current.initialCommand;
-				launchConfigRef.current = {};
+				const command = attemptLaunchConfig.initialCommand;
 				if (command) {
 					await terminalApi.write({ id: created.id, data: `${command}\r` });
 				}
+				launchConfigRef.current = {};
 			} catch (error) {
 				showStartupError({ kind: "unexpected", error });
 			}
@@ -225,6 +232,59 @@ export function TerminalView({
 			<div ref={containerRef} className="h-full w-full p-2" />
 		</div>
 	);
+}
+
+function captureAgentStartFailure(
+	error: TerminalStartupError,
+	options: {
+		readonly launchConfig: TerminalLaunchConfig;
+		readonly retryCount: number;
+	},
+) {
+	const properties = agentStartFailureTelemetryProperties(error, options);
+	if (!properties) return;
+	captureTelemetry("agent_start_failed", properties);
+	if (error.kind === "unexpected") {
+		captureTelemetryException(error.error, properties);
+	}
+}
+
+function agentStartFailureTelemetryProperties(
+	error: TerminalStartupError,
+	options: {
+		readonly launchConfig: TerminalLaunchConfig;
+		readonly retryCount: number;
+	},
+) {
+	const common = {
+		surface: "terminal",
+		retry_count: options.retryCount,
+	} as const;
+	if (error.kind === "agentVersion") {
+		return {
+			...common,
+			agent: error.error.agent,
+			reason: error.error.reason,
+			required_version: error.error.requiredVersion,
+			detected_version: error.error.detectedVersion,
+		};
+	}
+	const agent = readAgentTelemetryName(options.launchConfig);
+	if (!agent) return null;
+	return {
+		...common,
+		agent,
+		reason: "unexpected",
+	};
+}
+
+function readAgentTelemetryName(
+	launchConfig: TerminalLaunchConfig,
+): AgentTelemetryName | null {
+	const executableName = launchConfig.pathWrapper?.executableName;
+	if (executableName === "claude-flashtype") return "claude";
+	if (executableName === "codex-flashtype") return "codex";
+	return null;
 }
 
 function TerminalStartupErrorView({

--- a/src/shell/layout-shell.test.tsx
+++ b/src/shell/layout-shell.test.tsx
@@ -26,6 +26,19 @@ import { resolveLixFileForOpen, V2LayoutShell } from "./layout-shell";
 import type { FlashtypeUiState } from "./ui-state";
 import type { Lix } from "@/lib/lix-types";
 
+const telemetryMock = vi.hoisted(() => ({
+	captureTelemetry: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/telemetry")>("@/lib/telemetry");
+	return {
+		...actual,
+		captureTelemetry: telemetryMock.captureTelemetry,
+	};
+});
+
 type DesktopMock = {
 	readonly emitCloseFile: () => Promise<void>;
 	readonly emitNewFile: () => Promise<void>;
@@ -113,6 +126,7 @@ function getFileTreeHostForShadowElement(
 afterEach(() => {
 	cleanup();
 	window.flashtypeDesktop = originalDesktop;
+	telemetryMock.captureTelemetry.mockClear();
 });
 
 describe("resolveLixFileForOpen", () => {
@@ -911,6 +925,72 @@ describe("V2LayoutShell checkpoint editor revisions", () => {
 });
 
 describe("V2LayoutShell agent review auto-open", () => {
+	test("captures prompt submitted telemetry from turn-start hooks", async () => {
+		const desktop = installAgentHooksDesktopMock();
+		const lix = await openLix();
+		vi.spyOn(lix, "syncDiskToLix").mockResolvedValue();
+
+		const utils = await renderShell(lix);
+		await waitFor(() => expect(desktop.onTurnEvent).toHaveBeenCalled());
+		telemetryMock.captureTelemetry.mockClear();
+
+		await act(async () => {
+			await desktop.emitTurnEvent(agentTurnEvent("turn-start"));
+		});
+
+		await waitFor(() =>
+			expect(telemetryMock.captureTelemetry).toHaveBeenCalledWith(
+				"prompt_submitted",
+				expect.objectContaining({
+					agent: "codex",
+					surface: "terminal",
+					source: "agent_hook",
+					attempt_number: 1,
+				}),
+			),
+		);
+
+		await unmountShell(utils);
+		await lix.close();
+	});
+
+	test("increments prompt submitted attempt numbers per agent session", async () => {
+		const desktop = installAgentHooksDesktopMock();
+		const lix = await openLix();
+		vi.spyOn(lix, "syncDiskToLix").mockResolvedValue();
+
+		const utils = await renderShell(lix);
+		await waitFor(() => expect(desktop.onTurnEvent).toHaveBeenCalled());
+		telemetryMock.captureTelemetry.mockClear();
+
+		await act(async () => {
+			await desktop.emitTurnEvent(agentTurnEvent("turn-start"));
+			await desktop.emitTurnEvent({
+				...agentTurnEvent("turn-start"),
+				id: "event-turn-start-2",
+				turnId: "test-turn-2",
+				createdAt: 2,
+			});
+		});
+
+		await waitFor(() =>
+			expect(telemetryMock.captureTelemetry).toHaveBeenCalledTimes(2),
+		);
+		expect(telemetryMock.captureTelemetry).toHaveBeenNthCalledWith(
+			1,
+			"prompt_submitted",
+			expect.objectContaining({ attempt_number: 1 }),
+		);
+		expect(telemetryMock.captureTelemetry).toHaveBeenNthCalledWith(
+			2,
+			"prompt_submitted",
+			expect.objectContaining({ attempt_number: 2 }),
+		);
+
+		await unmountShell(utils);
+		await lix.close();
+	});
+
 	test("returns current active file context from turn-start hooks", async () => {
 		const desktop = installAgentHooksDesktopMock();
 		const lix = await openLix({

--- a/src/shell/layout-shell.tsx
+++ b/src/shell/layout-shell.tsx
@@ -712,6 +712,24 @@ function agentTurnKey(event: AgentHookTurnEvent): string {
 	].join(":");
 }
 
+function agentPromptAttemptKey(event: AgentHookTurnEvent): string {
+	return [
+		event.instanceId ?? "unknown-instance",
+		event.agent,
+		event.sessionId ?? event.cwd ?? "unknown-session",
+	].join(":");
+}
+
+function incrementAgentPromptAttemptNumber(
+	attempts: Map<string, number>,
+	event: AgentHookTurnEvent,
+): number {
+	const key = agentPromptAttemptKey(event);
+	const nextAttemptNumber = (attempts.get(key) ?? 0) + 1;
+	attempts.set(key, nextAttemptNumber);
+	return nextAttemptNumber;
+}
+
 type LixFileForOpen = {
 	readonly id: string;
 	readonly path: string;
@@ -1192,6 +1210,7 @@ function LayoutShellLoadedContent({
 		| null
 	>(null);
 	const activeAgentTurnsRef = useRef(new Map<string, ActiveAgentTurn>());
+	const agentPromptAttemptNumbersRef = useRef(new Map<string, number>());
 	const autoOpenFirstAgentReviewFileRef = useRef(
 		async (_range: AgentTurnCommitRange) => {},
 	);
@@ -1314,6 +1333,16 @@ function LayoutShellLoadedContent({
 		async (event: AgentHookTurnEvent): Promise<AgentHookTurnEventResult> => {
 			const key = agentTurnKey(event);
 			if (event.phase === "turn-start") {
+				const attemptNumber = incrementAgentPromptAttemptNumber(
+					agentPromptAttemptNumbersRef.current,
+					event,
+				);
+				captureWorkspaceTelemetry("prompt_submitted", {
+					agent: event.agent,
+					surface: "terminal",
+					source: "agent_hook",
+					attempt_number: attemptNumber,
+				});
 				const additionalContext = buildFlashtypeActiveFilePrompt(
 					activeFilePathFromPanel(panelStatesRef.current.central),
 				);
@@ -1384,7 +1413,7 @@ function LayoutShellLoadedContent({
 				throw error;
 			}
 		},
-		[lix],
+		[lix, captureWorkspaceTelemetry],
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- Add typed `agent_start_failed` and `prompt_submitted` telemetry events.
- Emit `agent_start_failed` for handled agent version startup failures and unexpected terminal startup failures, including initial command write failures.
- Emit `prompt_submitted` from agent `turn-start` hooks with safe funnel properties: `agent`, `surface`, `source`, and `attempt_number`.

## Why
The onboarding funnel had a blind spot between `agent_opened` and `diff_opened`, making it impossible to distinguish users who never submitted a prompt from users whose submitted prompt produced no visible diff. Agent startup failures also rendered an error card without structured telemetry.

## Validation
- `pnpm vitest run src/extensions/terminal/index.test.tsx src/lib/telemetry.test.ts electron/telemetry.test.mjs`
- `pnpm vitest run src/shell/layout-shell.test.tsx -t "prompt submitted"`
- `pnpm prettier --check electron/types.d.ts src/shell/layout-shell.tsx src/shell/layout-shell.test.tsx src/extensions/terminal/index.tsx src/extensions/terminal/index.test.tsx`

## Known issue
- `pnpm run typecheck` still fails on existing unrelated Lix SDK type drift around missing `ExecuteOptions` exports in `src/lib/lix-types.ts` and `src/test-utils/node-lix-sdk.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes with no changes to auth, persistence, or agent execution behavior beyond firing telemetry on existing error paths and hook handlers.
> 
> **Overview**
> Adds typed **`agent_start_failed`** and **`prompt_submitted`** desktop telemetry events to close gaps between **`agent_opened`** and **`diff_opened`**.
> 
> **Terminal startup:** **`TerminalView`** now emits **`agent_start_failed`** when agent terminals fail to start—version check outcomes (missing, unsupported, timeout, etc.), unexpected PTY/create errors, and initial command write failures. Payloads include **`agent`**, **`reason`**, **`surface: terminal`**, **`retry_count`**, and version fields when applicable; unexpected failures also call **`captureTelemetryException`**.
> 
> **Prompt funnel:** On agent **`turn-start`** hooks, the layout shell records **`prompt_submitted`** with **`agent`**, **`surface: terminal`**, **`source: agent_hook`**, and a per-session **`attempt_number`** keyed by instance, agent, and session.
> 
> Tests mock telemetry in terminal and layout-shell suites to assert event names and properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f3e03040508a4d0306391e4a52170fe7a6f68bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->